### PR TITLE
V0.90.0: Cache revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -117,7 +117,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "tokio",
@@ -180,7 +180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock",
- "cfg-if 1.0.0",
+ "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
@@ -215,7 +215,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if 1.0.0",
+ "cfg-if",
  "event-listener",
  "futures-lite",
  "rustix",
@@ -242,7 +242,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "atomic-waker",
- "cfg-if 1.0.0",
+ "cfg-if",
  "futures-core",
  "futures-io",
  "rustix",
@@ -345,7 +345,7 @@ checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -468,10 +468,10 @@ dependencies = [
  "base64 0.13.1",
  "bitvec",
  "hex",
- "indexmap 2.2.6",
+ "indexmap",
  "js-sys",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -607,12 +607,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -735,14 +729,8 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
-
-[[package]]
-name = "crc64fast"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bb92ecea20291efcf0009e2713d64b7e327dedb8ce780545250f24075429e2"
 
 [[package]]
 name = "crossbeam-channel"
@@ -844,7 +832,7 @@ dependencies = [
  "futures-util",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -932,7 +920,7 @@ version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -995,10 +983,10 @@ dependencies = [
  "ashpd",
  "async-channel",
  "async-lock",
+ "base64 0.22.1",
  "bson",
  "chrono",
  "duplicate",
- "fasthash",
  "futures",
  "gettext-rs",
  "gio 0.20.7",
@@ -1018,10 +1006,10 @@ dependencies = [
  "musicbrainz_rs",
  "once_cell",
  "pipewire",
- "polodb_core",
  "regex",
  "reqwest 0.12.5",
  "ringbuffer",
+ "rusqlite",
  "rustc-hash 2.0.0",
  "rustls",
  "serde",
@@ -1073,26 +1061,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fasthash"
-version = "0.4.0"
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032213946b4eaae09117ec63f020322b78ca7a31d8aa2cf64df3032e1579690f"
-dependencies = [
- "cfg-if 0.1.10",
- "fasthash-sys",
- "num-traits",
- "seahash 3.0.7",
- "xoroshiro128",
-]
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fasthash-sys"
-version = "0.3.2"
+name = "fallible-streaming-iterator"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6de941abfe2e715cdd34009d90546f850597eb69ca628ddfbf616e53dda28f8"
-dependencies = [
- "gcc",
-]
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1163,6 +1141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,12 +1175,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1326,12 +1304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "gdk-pixbuf"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1376,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1558,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7"
 dependencies = [
  "heck",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1571,7 +1543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715601f8f02e71baef9c1f94a657a9a77c192aea6097cf9ae7e5e177cd8cde68"
 dependencies = [
  "heck",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1706,7 +1678,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "188211f546ce5801f6d0245c37b6249143a2cb4fa040e54829ca1e76796e9f09"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1743,7 +1715,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1762,7 +1734,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1775,24 +1747,9 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crunchy",
  "num-traits",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -1800,6 +1757,24 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "heck"
@@ -2239,17 +2214,6 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
@@ -2437,7 +2401,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-targets 0.52.6",
 ]
 
@@ -2509,6 +2473,16 @@ dependencies = [
  "bindgen",
  "cc",
  "system-deps 6.2.2",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2592,15 +2566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,7 +2610,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rayon",
 ]
 
@@ -2654,15 +2619,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -2809,7 +2765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
 ]
 
@@ -2820,7 +2776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
@@ -2934,27 +2890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,7 +2940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3148,7 +3083,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3203,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3213,7 +3148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3343,42 +3278,13 @@ version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix",
  "tracing",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "polodb_core"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714bc48cfa44e6713512efabffe69887e564e5d88b0fdc83d27c0c1d3137e857"
-dependencies = [
- "bson",
- "byteorder",
- "crc64fast",
- "getrandom",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
- "js-sys",
- "libc",
- "lz4_flex",
- "memmap2",
- "num_enum",
- "regex",
- "serde",
- "serde-wasm-bindgen",
- "smallvec",
- "thiserror",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -3422,16 +3328,6 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3516,26 +3412,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3545,23 +3428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3584,7 +3452,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if 1.0.0",
+ "cfg-if",
  "interpolate_name",
  "itertools 0.12.1",
  "libc",
@@ -3598,7 +3466,7 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "simd_helpers",
  "system-deps 6.2.2",
@@ -3653,15 +3521,6 @@ name = "rctree"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e03e7866abec1101869ffa8e2c8355c4c2419d0214ece0cc3e428e5b94dea6e9"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -3797,7 +3656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
@@ -3810,6 +3669,21 @@ name = "ringbuffer"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.6.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "time",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3926,12 +3800,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f57ca1d128a43733fd71d583e837b1f22239a37ebea09cde11d8d9a9080f47"
-
-[[package]]
-name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
@@ -3994,17 +3862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,7 +3887,7 @@ version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -4084,7 +3941,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -4205,8 +4062,8 @@ dependencies = [
  "crossbeam-channel",
  "getrandom",
  "parking_lot",
- "rand 0.8.5",
- "seahash 4.1.0",
+ "rand",
+ "seahash",
  "thiserror",
  "tracing",
  "wg",
@@ -4361,7 +4218,7 @@ version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
@@ -4539,22 +4396,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4567,7 +4413,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4656,16 +4502,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 0.1.10",
- "static_assertions",
-]
 
 [[package]]
 name = "typenum"
@@ -4765,12 +4601,10 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
- "atomic",
  "getrandom",
- "rand 0.8.5",
+ "rand",
  "serde",
  "uuid-macro-internal",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4834,7 +4668,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -4859,7 +4693,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5147,7 +4981,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -5157,7 +4991,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -5201,15 +5035,6 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
-]
-
-[[package]]
-name = "xoroshiro128"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eeda34baec49c4f1eb2c04d59b761582fd6330010f9330ca696ca1a355dfcd"
-dependencies = [
- "rand 0.4.6",
 ]
 
 [[package]]
@@ -5281,7 +5106,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "sha1",
@@ -5331,7 +5156,7 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -5344,7 +5169,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3ad52bf7d51ef2a7b1bf9bbac6a2ebb8c77c7df297d3246963573d931bd5fd"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -5501,7 +5326,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -5514,7 +5339,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fb722e4d5e0d88a4c370c17abf3e2323c549d9580b4c2d775f475a45b34307"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,8 @@ dependencies = [
  "musicbrainz_rs",
  "once_cell",
  "pipewire",
+ "r2d2",
+ "r2d2_sqlite",
  "regex",
  "reqwest 0.12.5",
  "ringbuffer",
@@ -3405,6 +3407,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee025287c0188d75ae2563bcb91c9b0d1843cfc56e4bd3ab867597971b5cc256"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ idna = "1.0.0"     # CVE-2024-12242
 [dependencies]
 async-channel = "2.3.1"
 chrono = "0.4.38"
-fasthash = "0.4.0"
 futures = "0.3.30"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 image = "0.25.1"
@@ -21,7 +20,6 @@ once_cell = "1.19.0"
 time = { version = "0.3.36", features = ["formatting"] }
 stretto = { version = "0.8", features = ["sync"] }
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }
-polodb_core = "4.4.2"
 bson = "2.11.0"
 serde = "1.0.207"
 serde_json = "1.0.124"
@@ -43,9 +41,11 @@ libc = "0.2.169"
 spectrum-analyzer = "=0.5.2"
 ashpd = "0.10.2"
 tokio = { version = "1", features = ["rt-multi-thread"] }
-pipewire = {version = "0.8.0", features = ["v0_3_44"]}
+pipewire = {version = "0.8.0", features = ["v0_3_44"] }
 duplicate = "2.0.0"
 ringbuffer = "0.15.0"
+rusqlite = { version = "0.33.0", features = ["time"] }
+base64 = "0.22.1"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ duplicate = "2.0.0"
 ringbuffer = "0.15.0"
 rusqlite = { version = "0.33.0", features = ["time"] }
 base64 = "0.22.1"
+r2d2_sqlite = "0.26.0"
+r2d2 = "0.8.10"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -8,19 +8,15 @@
 //   MusicBrainz IDs.
 // - Artist avatars are named with hashes of their names. Artist names can be substrings
 //   of artist tags instead of the full tags.
-// - Text data is stored as BSON in PoloDB as most of the time we'll be querying
-//   from Last.fm.
+// - Text data is stored as BSON blobs in SQLite.
 extern crate bson;
-extern crate fasthash;
-extern crate polodb_core;
 extern crate stretto;
+use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use async_channel::{Receiver, Sender};
-use fasthash::murmur2;
 use gio::prelude::*;
 use glib::clone;
 use gtk::{gdk::Texture, gio, glib};
 use once_cell::sync::Lazy;
-use polodb_core::{IndexModel, IndexOptions};
 use rustc_hash::FxHashSet;
 use std::{
     cell::OnceCell,
@@ -41,7 +37,10 @@ use crate::{
     utils::{resize_convert_image, settings_manager},
 };
 
-use super::CacheState;
+use super::{
+    CacheState,
+    sqlite::LocalMetaDb
+};
 
 // In-memory image cache. Declared here to ease usage between threads as Stretto
 // is already internally-mutable.
@@ -68,7 +67,7 @@ pub struct Cache {
     avatar_path: PathBuf,
     // Embedded document database for caching responses from metadata providers.
     // Think MongoDB x SQLite x Rust.
-    doc_cache: Arc<RwLock<polodb_core::Database>>,
+    doc_cache: Arc<LocalMetaDb>,
     mpd_client: OnceCell<Rc<MpdWrapper>>,
     fg_sender: Sender<ProviderMessage>, // For receiving notifications from other threads
     bg_sender: Sender<ProviderMessage>,
@@ -113,17 +112,14 @@ impl Cache {
         create_dir_all(&avatar_path).expect("ERROR: cannot create albumart cache folder");
 
         let mut doc_path = app_cache_path.clone();
+        doc_path.push("metadata.sqlite");
 
         let providers = init_meta_provider_chain();
 
-        doc_path.push("metadata.polodb");
         let cache = Self {
             albumart_path,
             avatar_path,
-            doc_cache: Arc::new(RwLock::new(
-                polodb_core::Database::open_file(doc_path)
-                    .expect("ERROR: cannot create a metadata database"),
-            )),
+            doc_cache: Arc::new(LocalMetaDb::new(doc_path).expect("Failed to connect to the local metadata cache")),
             meta_providers: Arc::new(RwLock::new(providers)),
             mpd_client: OnceCell::new(),
             fg_sender: fg_sender.clone(),
@@ -168,7 +164,7 @@ impl Cache {
 
                 while let Some(request) = receiver.next().await {
                     match request {
-                        ProviderMessage::AlbumMeta(folder_uri, key) => {
+                        ProviderMessage::AlbumMeta(mut key) => {
                             let _ = gio::spawn_blocking(clone!(
                                 #[strong]
                                 fg_sender,
@@ -178,36 +174,28 @@ impl Cache {
                                 providers,
                                 move || {
                                     // Check whether there is one already
+                                    let folder_uri = key.uri.to_owned();
                                     let existing = doc_cache
-                                        .read()
-                                        .unwrap()
-                                        .collection::<models::AlbumMeta>("album")
-                                        .find_one(key.clone());
+                                        .find_album_meta(&key);
                                     if let Ok(None) = existing {
-                                        let res = providers.read().unwrap().get_album_meta(key.clone(), None);
+                                        let res = providers.read().unwrap().get_album_meta(&mut key, None);
                                         if let Some(album) = res {
-                                            let _ = doc_cache
-                                                .write()
-                                                .unwrap()
-                                                .collection::<models::AlbumMeta>("album")
-                                                .insert_one(album);
-                                            let _ = fg_sender.send_blocking(ProviderMessage::AlbumMeta(folder_uri, key));
+                                            doc_cache.write_album_meta(&key, &album)
+                                                .expect("Unable to store downloaded album meta");
+                                            let _ = fg_sender.send_blocking(ProviderMessage::AlbumMetaAvailable(folder_uri));
                                         }
                                         else {
                                             // Push an empty AlbumMeta to block further calls for this album.
                                             println!("No album meta could be found for {}. Pushing empty document...", &folder_uri);
-                                            let _ = doc_cache
-                                                .write()
-                                                .unwrap()
-                                                .collection::<models::AlbumMeta>("album")
-                                                .insert_one(models::AlbumMeta::from_key(&key));
+                                            doc_cache.write_album_meta(&key, &models::AlbumMeta::from_key(&key))
+                                                .expect("Unable to store placeholder album meta");
                                         }
                                         sleep_after_request();
                                     }
                                 }
                             )).await;
                         },
-                        ProviderMessage::ArtistMeta(key, path, thumbnail_path) => {
+                        ProviderMessage::ArtistMeta(mut key, path, thumbnail_path) => {
                             let _ = gio::spawn_blocking(clone!(
                                 #[strong]
                                 fg_sender,
@@ -217,15 +205,11 @@ impl Cache {
                                 providers,
                                 move || {
                                     // Check whether there is one already
-                                    let existing = doc_cache
-                                        .read()
-                                        .unwrap()
-                                        .collection::<models::ArtistMeta>("artist")
-                                        .find_one(key.clone());
+                                    let existing = doc_cache.find_artist_meta(&key);
                                     if let Ok(None) = existing {
                                         // Guaranteed to have this field so just unwrap it
-                                        let name = key.get("name").unwrap().as_str().unwrap().to_owned();
-                                        let res = providers.read().unwrap().get_artist_meta(key.clone(), None);
+                                        let name = key.name.to_owned();
+                                        let res = providers.read().unwrap().get_artist_meta(&mut key, None);
                                         if let Some(artist) = res {
                                             // Try to download artist avatar too
                                             let res = get_best_image(&artist.image);
@@ -243,35 +227,31 @@ impl Cache {
                                             else {
                                                 println!("[Cache] Failed to download artist avatar: {:?}", res.err());
                                             }
-                                            let _ = doc_cache.write().unwrap().collection::<models::ArtistMeta>("artist").insert_one(artist);
+                                            doc_cache.write_artist_meta(&key, &artist)
+                                                .expect("Unable to write downloaded artist meta");
                                             let _ = fg_sender.send_blocking(ProviderMessage::ArtistMetaAvailable(name));
                                         }
 
                                         else {
                                             // Push an empty ArtistMeta to block further calls for this album.
                                             println!("No artist meta could be found for {:?}. Pushing empty document...", &key);
-                                            let _ = doc_cache.write().unwrap().collection::<models::ArtistMeta>("artist").insert_one(
-                                                models::ArtistMeta::from_key(&key)
-                                            );
+                                            doc_cache.write_artist_meta(&key, &models::ArtistMeta::from_key(&key)).expect("Unable to write downloaded artist meta");
                                         }
                                         sleep_after_request();
                                     }
                                 }
                             )).await;
                         },
-                        ProviderMessage::AlbumArt(folder_uri, bson_key, path, thumbnail_path) => {
+                        ProviderMessage::AlbumArt(key, path, thumbnail_path) => {
                             let _ = gio::spawn_blocking(clone!(
                                 #[strong]
                                 fg_sender,
                                 #[strong]
                                 doc_cache,
                                 move || {
-                                    if let Ok(Some(meta)) = doc_cache
-                                        .read()
-                                        .unwrap()
-                                        .collection::<models::AlbumMeta>("album")
-                                        .find_one(bson_key.clone()) {
-                                            let res = get_best_image(&meta.image);
+                                    if let Ok(Some(meta)) = doc_cache.find_album_meta(&key)
+                                    {
+                                        let res = get_best_image(&meta.image);
                                             if res.is_ok() {
                                                 let (hires, thumbnail) = resize_convert_image(res.unwrap());
                                                 if !path.exists() || !thumbnail_path.exists() {
@@ -279,14 +259,14 @@ impl Cache {
                                                         hires.save(&path),
                                                         thumbnail.save(&thumbnail_path)
                                                     ) {
-                                                        let _ = fg_sender.send_blocking(ProviderMessage::AlbumArt(folder_uri, bson_key, path, thumbnail_path));
+                                                        let _ = fg_sender.send_blocking(ProviderMessage::AlbumArtAvailable(key.uri));
                                                     }
                                                 }
                                             }
                                             sleep_after_request();
                                         }
                                     else {
-                                        println!("Cannot download album art: no local album meta could be found for {folder_uri}");
+                                        println!("Cannot download album art: no local album meta could be found for {}", key.uri);
                                     }
                                 }
                             )).await;
@@ -316,21 +296,20 @@ impl Cache {
                     ProviderMessage::AlbumArtAvailable(folder_uri) => {
                         this.on_album_art_downloaded(&folder_uri)
                     }
-                    ProviderMessage::AlbumArtNotAvailable(folder_uri, key) => {
+                    ProviderMessage::AlbumArtNotAvailable(key) => {
+                        let folder_uri = &key.uri;
                         println!(
                             "MPD does not have album art for {}, fetching remotely...",
-                            &folder_uri
+                            folder_uri
                         );
                         // Fill out metadata before attempting to fetch album art from external sources.
                         let _ = this.bg_sender.send_blocking(ProviderMessage::AlbumMeta(
-                            folder_uri.clone(),
                             key.clone(),
                         ));
                         let path = self.get_path_for(&MetadataType::AlbumArt(&folder_uri, false));
                         let thumbnail_path =
                             self.get_path_for(&MetadataType::AlbumArt(&folder_uri, true));
                         let _ = this.bg_sender.send_blocking(ProviderMessage::AlbumArt(
-                            folder_uri,
                             key,
                             path,
                             thumbnail_path,
@@ -376,18 +355,18 @@ impl Cache {
             // Returns the full-resolution path.
             // Do not include filename in URI.
             MetadataType::AlbumArt(folder_uri, thumbnail) => {
-                let hashed = murmur2::hash64(&folder_uri).to_string();
+                let encoded = URL_SAFE.encode(folder_uri);
 
                 let mut path = self.albumart_path.clone();
                 if *thumbnail {
-                    path.push(hashed + "_thumb.png");
+                    path.push(encoded + "_thumb.png");
                 } else {
-                    path.push(hashed + ".png");
+                    path.push(encoded + ".png");
                 }
                 path
             }
             MetadataType::ArtistAvatar(name, thumbnail) => {
-                let hashed = murmur2::hash64(&name).to_string();
+                let hashed = URL_SAFE.encode(name);
 
                 let mut path = self.avatar_path.clone();
                 if *thumbnail {
@@ -433,55 +412,53 @@ impl Cache {
             self.on_album_art_downloaded(&folder_uri);
             return;
         }
-        if let Ok(bson_key) = self.get_album_key(album) {
-            let thumbnail_path = self.get_path_for(&MetadataType::AlbumArt(&folder_uri, true));
-            let path = self.get_path_for(&MetadataType::AlbumArt(&folder_uri, false));
-            let bg_sender = self.bg_sender.clone();
-            let fg_sender = self.fg_sender.clone();
-            let settings = settings_manager().child("client");
-            // First, try to load from disk. Do this using the threadpool to avoid blocking UI.
-            let path_to_use = if thumbnail { &thumbnail_path } else { &path };
-            if path_to_use.exists() {
-                let path_to_use = path_to_use.to_owned();
-                let folder_uri = folder_uri.to_owned();
-                gio::spawn_blocking(move || {
-                    if let Ok(tex) = Texture::from_filename(path_to_use) {
-                        IMAGE_CACHE.insert(
-                            stretto_key,
-                            tex.clone(),
-                            if thumbnail { 1 } else { 16 },
-                        );
-                        IMAGE_CACHE.wait().unwrap();
-                        let _ =
-                            fg_sender.send_blocking(ProviderMessage::AlbumArtAvailable(folder_uri));
-                    }
-                });
-            }
-            // That failed, so try downloading it
-            else if settings.boolean("mpd-download-album-art") {
-                self.mpd_client().queue_background(
-                    BackgroundTask::DownloadAlbumArt(
-                        folder_uri.to_string(),
-                        bson_key,
-                        path,
-                        thumbnail_path,
-                    ),
-                    false,
-                );
-            } else {
-                // Hop straight to remote providers. For this we'll need to have album metas ready,
-                // so schedule that first.
-                let _ = bg_sender.send_blocking(ProviderMessage::AlbumMeta(
-                    folder_uri.clone(),
-                    bson_key.clone(),
-                ));
-                let _ = bg_sender.send_blocking(ProviderMessage::AlbumArt(
-                    folder_uri.to_owned(),
-                    bson_key,
+        // Not in memory => try loading from disk
+        let thumbnail_path = self.get_path_for(&MetadataType::AlbumArt(&folder_uri, true));
+        let path = self.get_path_for(&MetadataType::AlbumArt(&folder_uri, false));
+        let bg_sender = self.bg_sender.clone();
+        let fg_sender = self.fg_sender.clone();
+        let settings = settings_manager().child("client");
+        // First, try to load from disk. Do this using the threadpool to avoid blocking UI.
+        let path_to_use = if thumbnail { &thumbnail_path } else { &path };
+        if path_to_use.exists() {
+            let path_to_use = path_to_use.to_owned();
+            let folder_uri = folder_uri.to_owned();
+            gio::spawn_blocking(move || {
+                if let Ok(tex) = Texture::from_filename(path_to_use) {
+                    IMAGE_CACHE.insert(
+                        stretto_key,
+                        tex.clone(),
+                        if thumbnail { 1 } else { 16 },
+                    );
+                    IMAGE_CACHE.wait().unwrap();
+                    let _ =
+                        fg_sender.send_blocking(ProviderMessage::AlbumArtAvailable(folder_uri));
+                }
+            });
+        }
+        // Not on disk either. Try downloading it.
+        else if settings.boolean("mpd-download-album-art") {
+            self.mpd_client().queue_background(
+                BackgroundTask::DownloadAlbumArt(
+                    album.clone(),
                     path,
                     thumbnail_path,
-                ));
-            }
+                ),
+                false,
+            );
+        }
+        // Not allowed to load from MPD. Check external providers
+        else {
+            // For this we'll need to have album metas ready,
+            // so schedule that first.
+            let _ = bg_sender.send_blocking(ProviderMessage::AlbumMeta(
+                album.clone(),
+            ));
+            let _ = bg_sender.send_blocking(ProviderMessage::AlbumArt(
+                album.clone(),
+                path,
+                thumbnail_path,
+            ));
         }
     }
 
@@ -503,137 +480,65 @@ impl Cache {
         }
     }
 
-    fn get_album_key(&self, album: &AlbumInfo) -> Result<bson::Document, &str> {
-        // AlbumInfo has to have either this (preferred)
-        let mbid: Option<&str> = album.mbid.as_deref();
-        // Or BOTH of these
-        let title: Option<&str> = Some(album.title.as_ref());
-        let artist: Option<&str> = album.get_artist_tag();
-        if let Some(id) = mbid {
-            Ok(bson::doc! {
-                "mbid": id.to_string()
-            })
-        } else if title.is_some() && artist.is_some() {
-            Ok(bson::doc! {
-                "name": title.unwrap().to_string(),
-                "artist": artist.unwrap().to_string()
-            })
-        } else {
-            Err("If no mbid is available, both album name and artist must be specified")
-        }
-    }
-
     pub fn load_cached_album_meta(&self, album: &AlbumInfo) -> Option<models::AlbumMeta> {
         // Check whether we have this album cached
-        if let Ok(key) = self.get_album_key(album) {
-            println!("Key is valid");
-            let result = self
-                .doc_cache
-                .read()
-                .unwrap()
-                .collection::<models::AlbumMeta>("album")
-                .find_one(key);
-            if let Ok(res) = result {
-                if let Some(info) = res {
-                    println!("Album info cache hit!");
-                    return Some(info);
-                }
-                println!("Album info cache miss");
-                return None;
+        let result = self.doc_cache.find_album_meta(album);
+        if let Ok(res) = result {
+            if let Some(info) = res {
+                println!("Album info cache hit!");
+                return Some(info);
             }
-            println!("{:?}", result.err());
+            println!("Album info cache miss");
             return None;
         }
-        println!("No key!");
-        None
+        println!("{:?}", result.err());
+        return None;
     }
 
     pub fn ensure_cached_album_meta(&self, album: &AlbumInfo) {
-        // Needed for signalling
-        let folder_uri: &str = &album.uri;
         // Check whether we have this album cached
-        if let Ok(key) = self.get_album_key(album) {
-            let result = self
-                .doc_cache
-                .read()
-                .unwrap()
-                .collection::<models::AlbumMeta>("album")
-                .find_one(key.clone());
-            if let Ok(response) = result {
-                if response.is_none() {
-                    self.bg_sender
-                        .send_blocking(ProviderMessage::AlbumMeta(folder_uri.to_owned(), key))
-                        .expect("[Cache] Unable to schedule album meta fetch task");
-                }
-            } else {
-                println!("{:?}", result.err());
+        let result = self.doc_cache.find_album_meta(album);
+        if let Ok(response) = result {
+            if response.is_none() {
+                self.bg_sender
+                    .send_blocking(ProviderMessage::AlbumMeta(album.clone()))
+                    .expect("[Cache] Unable to schedule album meta fetch task");
             }
-        }
-    }
-
-    fn get_artist_key(&self, artist: &ArtistInfo) -> Result<bson::Document, &str> {
-        // Optional
-        let mbid: Option<&str> = artist.mbid.as_deref();
-        // Mandatory (used for signaling)
-        let name: &str = &artist.name;
-        if let Some(id) = mbid {
-            Ok(bson::doc! {
-                "mbid": id.to_string(),
-                "name": name.to_string()
-            })
         } else {
-            Ok(bson::doc! {
-                "name": name.to_string()
-            })
+            println!("{:?}", result.err());
         }
     }
 
     pub fn load_cached_artist_meta(&self, artist: &ArtistInfo) -> Option<ArtistMeta> {
-        if let Ok(key) = self.get_artist_key(artist) {
-            let result = self
-                .doc_cache
-                .read()
-                .unwrap()
-                .collection::<ArtistMeta>("artist")
-                .find_one(key);
-            if let Ok(res) = result {
-                if let Some(info) = res {
-                    println!("Artist info cache hit!");
-                    return Some(info);
-                }
-                println!("Artist info cache miss");
-                return None;
+        let result = self.doc_cache.find_artist_meta(artist);
+        if let Ok(res) = result {
+            if let Some(info) = res {
+                println!("Artist info cache hit!");
+                return Some(info);
             }
-            println!("{:?}", result.err());
+            println!("Artist info cache miss");
             return None;
         }
-        println!("No key!");
-        None
+        println!("{:?}", result.err());
+        return None;
     }
 
     pub fn ensure_cached_artist_meta(&self, artist: &ArtistInfo) {
         // Check whether we have this artist cached
-        if let Ok(key) = self.get_artist_key(artist) {
-            let result = self
-                .doc_cache
-                .read()
-                .unwrap()
-                .collection::<ArtistMeta>("artist")
-                .find_one(key.clone());
-            if let Ok(response) = result {
-                if response.is_none() {
-                    let path = self.get_path_for(&MetadataType::ArtistAvatar(&artist.name, false));
-                    let thumbnail_path =
-                        self.get_path_for(&MetadataType::ArtistAvatar(&artist.name, true));
-                    let _ = self.bg_sender.send_blocking(ProviderMessage::ArtistMeta(
-                        key,
-                        path,
-                        thumbnail_path,
-                    ));
-                }
-            } else {
-                println!("{:?}", result.err());
+        let result = self.doc_cache.find_artist_meta(artist);
+        if let Ok(response) = result {
+            if response.is_none() {
+                let path = self.get_path_for(&MetadataType::ArtistAvatar(&artist.name, false));
+                let thumbnail_path =
+                    self.get_path_for(&MetadataType::ArtistAvatar(&artist.name, true));
+                let _ = self.bg_sender.send_blocking(ProviderMessage::ArtistMeta(
+                    artist.clone(),
+                    path,
+                    thumbnail_path,
+                ));
             }
+        } else {
+            println!("{:?}", result.err());
         }
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,5 +1,6 @@
 mod controller;
 mod state;
+mod sqlite;
 
 pub use state::CacheState;
 pub mod placeholders;

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -1,0 +1,284 @@
+extern crate bson;
+use std::io::Cursor;
+
+use rusqlite::{params, Connection, Error as SQLiteError, Result, Row};
+use time::OffsetDateTime;
+
+use crate::{common::{AlbumInfo, ArtistInfo}, meta_providers::models::{AlbumMeta, ArtistMeta}};
+
+#[derive(Debug)]
+pub enum Error {
+    BytesToDocError,
+    DocToMetaError,
+    MetaToDocError,
+    DocToBytesError,
+    DBError(SQLiteError),
+    InsufficientKey
+}
+
+pub struct AlbumMetaRow {
+    folder_uri: String,
+    mbid: Option<String>,
+    title: String,
+    artist: Option<String>,
+    last_modified: OffsetDateTime,
+    data: Vec<u8>, // BSON
+}
+
+impl TryInto<AlbumMeta> for AlbumMetaRow {
+    type Error = Error;
+    fn try_into(self) -> Result<AlbumMeta, Self::Error> {
+        let mut reader = Cursor::new(self.data);
+        bson::from_document(
+            bson::Document::from_reader(&mut reader).map_err(|_| Error::BytesToDocError)?,
+        )
+            .map_err(|_| Error::DocToMetaError)
+    }
+}
+
+impl TryFrom<&Row<'_>> for AlbumMetaRow {
+    type Error = SQLiteError;
+    fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            folder_uri: row.get(0)?,
+            mbid: row.get(1)?,
+            title: row.get(2)?,
+            artist: row.get(3)?,
+            last_modified: row.get(4)?,
+            data: row.get(5)?
+        })
+    }
+}
+
+impl AlbumMetaRow {
+    pub fn new(
+        folder_uri: String,
+        mbid: Option<String>,
+        title: String,
+        artist: Option<String>,
+        last_modified: OffsetDateTime,
+        meta: &AlbumMeta,
+    ) -> Result<Self, Error> {
+        let res = Self {
+            folder_uri,
+            mbid,
+            title,
+            artist,
+            last_modified,
+            data: bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?)
+                .map_err(|_| Error::DocToBytesError)?,
+        };
+        Ok(res)
+    }
+}
+
+pub struct ArtistMetaRow {
+    name: String,
+    mbid: Option<String>,
+    last_modified: OffsetDateTime,
+    data: Vec<u8>, // BSON
+}
+
+impl TryInto<ArtistMeta> for ArtistMetaRow {
+    type Error = Error;
+    fn try_into(self) -> Result<ArtistMeta, Self::Error> {
+        let mut reader = Cursor::new(self.data);
+        bson::from_document(
+            bson::Document::from_reader(&mut reader).map_err(|_| Error::BytesToDocError)?,
+        )
+            .map_err(|_| Error::DocToMetaError)
+    }
+}
+
+impl ArtistMetaRow {
+    pub fn new(
+        name: String,
+        mbid: Option<String>,
+        last_modified: OffsetDateTime,
+        meta: &ArtistMeta,
+    ) -> Result<Self, Error> {
+        let res = Self {
+            name,
+            mbid,
+            last_modified,
+            data: bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?)
+                .map_err(|_| Error::DocToBytesError)?,
+        };
+        Ok(res)
+    }
+}
+
+impl TryFrom<&Row<'_>> for ArtistMetaRow {
+    type Error = SQLiteError;
+    fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            name: row.get(0)?,
+            mbid: row.get(1)?,
+            last_modified: row.get(2)?,
+            data: row.get(3)?
+        })
+    }
+}
+
+
+pub struct LocalMetaDb {
+    conn: Connection
+}
+
+impl LocalMetaDb {
+    /// Connect to the local metadata database, or create an empty one if one
+    /// does not exist yet.
+    pub fn new(path: &str) -> Result<Self, SQLiteError> {
+        let conn = Connection::open(path)?;
+        // Init schema & indices
+        conn.execute_batch(
+            "begin;
+create table if not exists `albums` (
+    `folder_uri` VARCHAR not null unique,
+    `mbid` VARCHAR null unique,
+    `title` VARCHAR not null,
+    `artist` VARCHAR null,
+    `last_modified` DATETIME not null,
+    `data` BLOB not null,
+    primary key (`folder_uri`)
+);
+create unique index if not exists `album_mbid` on `albums` (
+    `mbid`
+);
+create unique index if not exists `album_name` on `albums` (
+    `folder_uri`,
+    `title`
+);
+
+create table if not exists `artists` (
+    `name` VARCHAR not null unique,
+    `mbid` VARCHAR null unique,
+    `last_modified` DATETIME not null,
+    `data` BLOB not null,
+    primary key (`name`)
+);
+create unique index if not exists `artist_mbid` on `artists` (
+    `mbid`
+);
+create unique index if not exists `artist_name` on `artists` (
+    `folder_uri`,
+    `title`,
+);
+end;
+",
+        )?;
+
+        Ok(Self {conn})
+    }
+
+    pub fn find_album_meta(&self, album: &AlbumInfo) -> Result<Option<AlbumMeta>, Error> {
+        let query: Result<AlbumMetaRow, SQLiteError>;
+        if let Some(mbid) = album.mbid.as_deref() {
+            query = self
+                .conn.prepare("select * from albums where mbid = ?1")
+                     .unwrap().query_row(params![mbid], |r| { AlbumMetaRow::try_from(r) });
+        }
+        else if let (title, Some(artist)) = (&album.title, album.get_artist_tag()) {
+            query = self
+                .conn.prepare("select * from albums where title = ?1 and artist = ?2")
+                     .unwrap().query_row(params![title, artist], |r| { AlbumMetaRow::try_from(r) });
+        }
+        else { return Ok(None); }
+        match query {
+            Ok(row) => {
+                let res = row.try_into()?;
+                return Ok(Some(res));
+            }
+            Err(SQLiteError::QueryReturnedNoRows) => {
+                println!("Couldn't find anything for {:?} in local DB", album);
+                return Ok(None);
+            }
+            Err(e) => {return Err(Error::DBError(e));}
+        }
+    }
+
+    pub fn find_artist_meta(&self, artist: &ArtistInfo) -> Result<Option<ArtistMeta>, Error> {
+        let query: Result<ArtistMetaRow, SQLiteError>;
+        if let Some(mbid) = artist.mbid.as_deref() {
+            query = self
+                .conn.prepare("select * from artists where mbid = ?1")
+                     .unwrap().query_row(params![mbid], |r| { ArtistMetaRow::try_from(r) });
+        }
+        else {
+            query = self
+                .conn.prepare("select * from artists where name = ?1")
+                     .unwrap().query_row(params![&artist.name], |r| { ArtistMetaRow::try_from(r) });
+        }
+        match query {
+            Ok(row) => {
+                let res = row.try_into()?;
+                return Ok(Some(res));
+            }
+            Err(SQLiteError::QueryReturnedNoRows) => {
+                println!("Couldn't find anything for {:?} in local DB", artist);
+                return Ok(None);
+            }
+            Err(e) => {return Err(Error::DBError(e));}
+        }
+    }
+
+    pub fn write_album_meta(&mut self, album: &AlbumInfo, meta: &AlbumMeta) -> Result<(), Error> {
+        let tx = self.conn.transaction().map_err(|e| Error::DBError(e))?;
+        if let Some(mbid) = album.mbid.as_deref() {
+            tx.execute(
+                "delete from albums where mbid = ?1",
+                params![mbid]
+            );
+        }
+        else if let (title, Some(artist)) = (&album.title, album.get_artist_tag()) {
+            tx.execute(
+                "delete from albums where title = ?1 and artist = ?2",
+                params![title, artist]
+            );
+        }
+        else {
+            tx.rollback();
+            return Err(Error::InsufficientKey);
+        }
+        tx.execute(
+            "insert into albums (folder_uri, mbid, title, artist, last_modified, data) values (?1,?2,?3,?4,?5,?6)",
+            params![
+                &album.uri,
+                &album.mbid,
+                &album.title,
+                &album.get_artist_tag(),
+                OffsetDateTime::now_utc(),
+                bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?).map_err(|_| Error::DocToBytesError)?
+            ]
+        );
+        tx.commit();
+        Ok(())
+    }
+
+    pub fn write_artist_meta(&mut self, artist: &ArtistInfo, meta: &ArtistMeta) -> Result<(), Error>  {
+        let tx = self.conn.transaction().map_err(|e| Error::DBError(e))?;
+        if let Some(mbid) = artist.mbid.as_deref() {
+            tx.execute(
+                "delete from artists where mbid = ?1",
+                params![mbid]
+            );
+        }
+        else {
+            tx.execute(
+                "delete from albums where name = ?1",
+                params![&artist.name]
+            );
+        }
+        tx.execute(
+            "insert into artists (name, mbid, last_modified, data) values (?1,?2,?3,?4)",
+            params![
+                &artist.name,
+                &artist.mbid,
+                OffsetDateTime::now_utc(),
+                bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?).map_err(|_| Error::DocToBytesError)?
+            ]
+        );
+        tx.commit();
+        Ok(())
+    }
+}

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::{
     common::{Album, AlbumInfo, Artist, ArtistInfo, INode, Song, SongInfo},
-    meta_providers::Metadata,
+    meta_providers::ProviderMessage,
     player::PlaybackFlow,
     utils,
 };
@@ -115,7 +115,7 @@ mod background {
 
     pub fn download_album_art(
         client: &mut mpd::Client,
-        sender_to_cache: &Sender<Metadata>,
+        sender_to_cache: &Sender<ProviderMessage>,
         uri: String,
         key: bson::Document,
         path: PathBuf,
@@ -130,14 +130,14 @@ mod background {
 
                     if let (Ok(_), Ok(_)) = (hires.save(path), thumb.save(thumbnail_path)) {
                         sender_to_cache
-                            .send_blocking(Metadata::AlbumArt(uri, false))
+                            .send_blocking(ProviderMessage::AlbumArtAvailable(uri))
                             .expect("Cannot notify main cache of album art download result.");
                     }
                 }
             } else {
                 // Fetch from local sources instead.
                 sender_to_cache
-                    .send_blocking(Metadata::AlbumArtNotAvailable(uri, key))
+                    .send_blocking(ProviderMessage::AlbumArtNotAvailable(uri, key))
                     .expect("Album art not available from MPD, but cannot notify cache of this.");
             }
         } else {
@@ -362,14 +362,14 @@ pub struct MpdWrapper {
     bg_channel: Channel, // For waking up the child client
     bg_sender: RefCell<Option<Sender<BackgroundTask>>>, // For sending tasks to background thread
     bg_sender_high: RefCell<Option<Sender<BackgroundTask>>>, // For sending high-priority tasks to background thread
-    meta_sender: Sender<Metadata>, // For sending album arts to cache controller
+    meta_sender: Sender<ProviderMessage>, // For sending album arts to cache controller
     // Stored here so we can use them to get queue diffs.
     // It will be updated every time get_status() is called.
     queue_version: Cell<u32>,
 }
 
 impl MpdWrapper {
-    pub fn new(meta_sender: Sender<Metadata>) -> Rc<Self> {
+    pub fn new(meta_sender: Sender<ProviderMessage>) -> Rc<Self> {
         // Set up channels for communication with client object
         let (sender, receiver): (Sender<AsyncClientMessage>, Receiver<AsyncClientMessage>) =
             async_channel::unbounded();

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use time::{Date, Month};
 
-use crate::{cache::Cache, meta_providers::Metadata, utils::strip_filename_linux};
+use crate::{cache::Cache, meta_providers::MetadataType, utils::strip_filename_linux};
 
 use super::{artists_to_string, parse_mb_artist_tag, AlbumInfo, ArtistInfo};
 
@@ -380,8 +380,8 @@ impl Song {
         }
 
         // Album art, if available
-        let thumbnail_path = cache.get_path_for(&Metadata::AlbumArt(
-            strip_filename_linux(self.get_uri()).to_owned(),
+        let thumbnail_path = cache.get_path_for(&MetadataType::AlbumArt(
+            strip_filename_linux(self.get_uri()),
             true,
         ));
         if thumbnail_path.exists() {

--- a/src/gtk/library/album-content-view.ui
+++ b/src/gtk/library/album-content-view.ui
@@ -62,160 +62,177 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkBox" id="infobox_text">
-                            <property name="orientation">1</property>
-                            <property name="spacing">6</property>
-                            <property name="hexpand">true</property>
+                          <object class="GtkStack" id="infobox_spinner">
                             <child>
-                              <object class="GtkLabel" id="title">
-                                <property name="halign">start</property>
-                                <property name="wrap">true</property>
-                                <property name="justify">left</property>
-                                <property name="label">Untitled Album</property>
-                                <style>
-                                  <class name="title-2"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkImage">
-                                    <property name="icon-name">music-artist-symbolic</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="artist">
-                                    <property name="wrap">true</property>
-                                    <property name="label">Unknown Artist</property>
-                                  </object>
-                                </child>
-                                <style>
-                                  <class name="accent"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <style>
-                                  <class name="spacer"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="spacing">12</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="label" translatable="true">Originally released</property>
-                                        <style>
-                                          <class name="caption-heading"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="release_date">
-                                        <property name="label">-</property>
-                                        <style>
-                                          <class name="caption"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="label" translatable="true">Tracks</property>
-                                        <style>
-                                          <class name="caption-heading"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="track_count">
-                                        <property name="label">-</property>
-                                        <style>
-                                          <class name="caption"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="label" translatable="true">Runtime</property>
-                                        <style>
-                                          <class name="caption-heading"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="runtime">
-                                        <property name="label">-</property>
-                                        <style>
-                                          <class name="caption"/>
-                                        </style>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkScrolledWindow" id="wiki_box">
-                                <property name="hscrollbar-policy">never</property>
-                                <property name="vexpand">true</property>
+                              <object class="GtkStackPage">
+                                <property name="name">spinner</property>
                                 <property name="child">
-                                  <object class="GtkBox">
+                                  <object class="AdwSpinner"/>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkStackPage">
+                                <property name="name">content</property>
+                                <property name="child">
+                                  <object class="GtkBox" id="infobox_text">
                                     <property name="orientation">1</property>
-                                    <property name="valign">start</property>
+                                    <property name="spacing">6</property>
+                                    <property name="hexpand">true</property>
                                     <child>
-                                      <object class="GtkLabel" id="wiki_text">
+                                      <object class="GtkLabel" id="title">
                                         <property name="halign">start</property>
-                                        <property name="margin-end">12</property>
                                         <property name="wrap">true</property>
-                                        <property name="justify">fill</property>
+                                        <property name="justify">left</property>
+                                        <property name="label">Untitled Album</property>
                                         <style>
-                                          <class name="caption"/>
+                                          <class name="title-2"/>
                                         </style>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkLinkButton" id="wiki_link">
-                                        <style>
-                                          <class name="padding-0"/>
-                                        </style>
-                                        <property name="halign">start</property>
+                                      <object class="GtkBox">
+                                        <property name="spacing">6</property>
                                         <child>
-                                          <object class="GtkLabel">
-                                            <style>
-                                              <class name="caption"/>
-                                            </style>
-                                            <property name="label" translatable="true">Read more</property>
+                                          <object class="GtkImage">
+                                            <property name="icon-name">music-artist-symbolic</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="artist">
+                                            <property name="wrap">true</property>
+                                            <property name="label">Unknown Artist</property>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="accent"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator">
+                                        <style>
+                                          <class name="spacer"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="spacing">12</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="orientation">1</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="label" translatable="true">Originally released</property>
+                                                <style>
+                                                  <class name="caption-heading"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="release_date">
+                                                <property name="label">-</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="orientation">1</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="label" translatable="true">Tracks</property>
+                                                <style>
+                                                  <class name="caption-heading"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="track_count">
+                                                <property name="label">-</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="orientation">1</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="label" translatable="true">Runtime</property>
+                                                <style>
+                                                  <class name="caption-heading"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="runtime">
+                                                <property name="label">-</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                </style>
+                                              </object>
+                                            </child>
                                           </object>
                                         </child>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkLabel" id="wiki_attrib">
-                                        <property name="wrap">true</property>
-                                        <property name="halign">start</property>
-                                        <style>
-                                          <class name="caption"/>
-                                          <class name="dim-label"/>
-                                        </style>
+                                      <object class="GtkScrolledWindow" id="wiki_box">
+                                        <property name="hscrollbar-policy">never</property>
+                                        <property name="vexpand">true</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="orientation">1</property>
+                                            <property name="valign">start</property>
+                                            <child>
+                                              <object class="GtkLabel" id="wiki_text">
+                                                <property name="halign">start</property>
+                                                <property name="margin-end">12</property>
+                                                <property name="wrap">true</property>
+                                                <property name="justify">fill</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLinkButton" id="wiki_link">
+                                                <style>
+                                                  <class name="padding-0"/>
+                                                </style>
+                                                <property name="halign">start</property>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <style>
+                                                      <class name="caption"/>
+                                                    </style>
+                                                    <property name="label" translatable="true">Read more</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="wiki_attrib">
+                                                <property name="wrap">true</property>
+                                                <property name="halign">start</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                  <class name="dim-label"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
                                       </object>
                                     </child>
                                   </object>
@@ -326,11 +343,28 @@
                     <property name="has-frame">false</property>
                     <property name="vexpand">true</property>
                     <property name="child">
-                      <object class="GtkListView" id="content">
-                        <property name="show-separators">true</property>
-                        <style>
-                          <class name="no-bg"/>
-                        </style>
+                      <object class="GtkStack" id="content_spinner">
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="name">spinner</property>
+                            <property name="child">
+                              <object class="AdwSpinner"/>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="name">content</property>
+                            <property name="child">
+                              <object class="GtkListView" id="content">
+                                <property name="show-separators">true</property>
+                                <style>
+                                  <class name="no-bg"/>
+                                </style>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
                       </object>
                     </property>
                   </object>

--- a/src/gtk/library/artist-content-view.ui
+++ b/src/gtk/library/artist-content-view.ui
@@ -49,7 +49,20 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkBox" id="infobox_text">
+                          <object class="GtkStack" id="infobox_spinner">
+                            <child>
+                              <object class="GtkStackPage">
+                                <property name="name">spinner</property>
+                                <property name="child">
+                                  <object class="AdwSpinner"/>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkStackPage">
+                                <property name="name">content</property>
+                                <property name="child">
+                                  <object class="GtkBox" id="infobox_text">
                             <property name="orientation">1</property>
                             <property name="spacing">6</property>
                             <property name="hexpand">true</property>
@@ -163,6 +176,10 @@
                               </object>
                             </child>
                           </object>
+                                </property>
+                              </object>
+                            </child>
+                          </object>
                         </child>
                       </object>
                     </property>
@@ -246,14 +263,31 @@
                                 <property name="has-frame">false</property>
                                 <property name="vexpand">true</property>
                                 <property name="child">
-                                  <object class="GtkGridView" id="album_subview">
-                                    <property name="orientation">1</property>
-                                    <property name="min-columns">1</property>
-                                    <property name="single-click-activate">true</property>
-                                    <style>
-                                      <class name="no-bg"/>
-                                      <class name="padding-12"/>
-                                    </style>
+                                  <object class="GtkStack" id="album_spinner">
+                                    <child>
+                                      <object class="GtkStackPage">
+                                        <property name="name">spinner</property>
+                                        <property name="child">
+                                          <object class="AdwSpinner"/>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkStackPage">
+                                        <property name="name">content</property>
+                                        <property name="child">
+                                          <object class="GtkGridView" id="album_subview">
+                                            <property name="orientation">1</property>
+                                            <property name="min-columns">1</property>
+                                            <property name="single-click-activate">true</property>
+                                            <style>
+                                              <class name="no-bg"/>
+                                              <class name="padding-12"/>
+                                            </style>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
                                   </object>
                                 </property>
                               </object>
@@ -365,11 +399,28 @@
                                 <property name="has-frame">false</property>
                                 <property name="vexpand">true</property>
                                 <property name="child">
-                                  <object class="GtkListView" id="song_subview">
-                                    <property name="show-separators">true</property>
-                                    <style>
-                                      <class name="no-bg"/>
-                                    </style>
+                                  <object class="GtkStack" id="song_spinner">
+                                    <child>
+                                      <object class="GtkStackPage">
+                                        <property name="name">spinner</property>
+                                        <property name="child">
+                                          <object class="AdwSpinner"/>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkStackPage">
+                                        <property name="name">content</property>
+                                        <property name="child">
+                                          <object class="GtkListView" id="song_subview">
+                                            <property name="show-separators">true</property>
+                                            <style>
+                                              <class name="no-bg"/>
+                                            </style>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
                                   </object>
                                 </property>
                               </object>

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -32,7 +32,12 @@ mod imp {
         #[template_child]
         pub cover: TemplateChild<gtk::Image>,
         #[template_child]
+        pub content_spinner: TemplateChild<gtk::Stack>,
+        #[template_child]
         pub content: TemplateChild<gtk::ListView>,
+
+        #[template_child]
+        pub infobox_spinner: TemplateChild<gtk::Stack>,
         #[template_child]
         pub title: TemplateChild<gtk::Label>,
         #[template_child]
@@ -87,6 +92,7 @@ mod imp {
                 artist: TemplateChild::default(),
                 release_date: TemplateChild::default(),
                 track_count: TemplateChild::default(),
+                infobox_spinner: TemplateChild::default(),
                 infobox_revealer: TemplateChild::default(),
                 collapse_infobox: TemplateChild::default(),
                 wiki_box: TemplateChild::default(),
@@ -94,6 +100,7 @@ mod imp {
                 wiki_link: TemplateChild::default(),
                 wiki_attrib: TemplateChild::default(),
                 runtime: TemplateChild::default(),
+                content_spinner: TemplateChild::default(),
                 content: TemplateChild::default(),
                 song_list: gio::ListStore::new::<Song>(),
                 sel_model: gtk::MultiSelection::new(Option::<gio::ListStore>::None),
@@ -220,6 +227,10 @@ impl AlbumContentView {
                 wiki_attrib.set_label(&wiki.attribution);
             } else {
                 wiki_box.set_visible(false);
+            }
+            let infobox_spinner = self.imp().infobox_spinner.get();
+            if infobox_spinner.visible_child_name().unwrap() != "content" {
+                infobox_spinner.set_visible_child_name("content");
             }
         } else {
             wiki_box.set_visible(false);
@@ -485,9 +496,21 @@ impl AlbumContentView {
         // Unset metadata widgets
         self.imp().wiki_box.set_visible(false);
         self.imp().song_list.remove_all();
+        let content_spinner = self.imp().content_spinner.get();
+        if content_spinner.visible_child_name().unwrap() != "spinner" {
+            content_spinner.set_visible_child_name("spinner");
+        }
+        let infobox_spinner = self.imp().infobox_spinner.get();
+        if infobox_spinner.visible_child_name().unwrap() != "spinner" {
+            infobox_spinner.set_visible_child_name("spinner");
+        }
     }
 
     fn add_songs(&self, songs: &[Song]) {
+        let content_spinner = self.imp().content_spinner.get();
+        if content_spinner.visible_child_name().unwrap() != "content" {
+            content_spinner.set_visible_child_name("content");
+        }
         self.imp().song_list.extend_from_slice(songs);
         self.imp()
             .track_count

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -1,3 +1,4 @@
+use duplicate::duplicate;
 use adw::subclass::prelude::*;
 use glib::{clone, closure_local, signal::SignalHandlerId, Binding};
 use gtk::{gdk, gio, glib, prelude::*, CompositeTemplate, ListItem, SignalListItemFactory};
@@ -37,6 +38,8 @@ mod imp {
         #[template_child]
         pub infobox_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
+        pub infobox_spinner: TemplateChild<gtk::Stack>,
+        #[template_child]
         pub collapse_infobox: TemplateChild<gtk::ToggleButton>,
 
         #[template_child]
@@ -56,6 +59,8 @@ mod imp {
         pub subview_stack: TemplateChild<gtk::Stack>,
 
         // All songs sub-view
+        #[template_child]
+        pub song_spinner: TemplateChild<gtk::Stack>,
         #[template_child]
         pub song_subview: TemplateChild<gtk::ListView>,
         pub song_list: gio::ListStore,
@@ -77,6 +82,8 @@ mod imp {
 
         // Discography sub-view
         #[template_child]
+        pub album_spinner: TemplateChild<gtk::Stack>,
+        #[template_child]
         pub album_subview: TemplateChild<gtk::GridView>,
         pub album_list: gio::ListStore,
 
@@ -94,6 +101,7 @@ mod imp {
                 name: TemplateChild::default(),
                 song_count: TemplateChild::default(),
                 album_count: TemplateChild::default(),
+                infobox_spinner: TemplateChild::default(),
                 infobox_revealer: TemplateChild::default(),
                 collapse_infobox: TemplateChild::default(),
                 bio_box: TemplateChild::default(),
@@ -104,6 +112,7 @@ mod imp {
                 all_songs_btn: TemplateChild::default(),
                 subview_stack: TemplateChild::default(),
                 // All songs sub-view
+                song_spinner: TemplateChild::default(),
                 song_subview: TemplateChild::default(),
                 song_list: gio::ListStore::new::<Song>(),
                 song_sel_model: gtk::MultiSelection::new(Option::<gio::ListStore>::None),
@@ -115,6 +124,7 @@ mod imp {
                 sel_all: TemplateChild::default(),
                 sel_none: TemplateChild::default(),
                 // Discography sub-view
+                album_spinner: TemplateChild::default(),
                 album_subview: TemplateChild::default(),
                 album_list: gio::ListStore::new::<Album>(),
                 artist: RefCell::new(None),
@@ -280,6 +290,10 @@ impl ArtistContentView {
                 bio_attrib.set_label(&bio.attribution);
             } else {
                 bio_box.set_visible(false);
+            }
+            let stack = self.imp().infobox_spinner.get();
+            if stack.visible_child_name().unwrap() != "content" {
+                stack.set_visible_child_name("content");
             }
         } else {
             bio_box.set_visible(false);
@@ -600,6 +614,12 @@ impl ArtistContentView {
         self.imp().bio_box.set_visible(false);
         self.imp().avatar.set_text(None);
         self.clear_content();
+        duplicate!{
+            [stack; [infobox_spinner]; [song_spinner]; [album_spinner];]
+            if self.imp().stack.visible_child_name().unwrap() != "spinner" {
+                self.imp().stack.set_visible_child_name("spinner");
+            }
+        }
     }
 
     fn add_album(&self, album: Album, cache: Rc<Cache>) {
@@ -608,6 +628,10 @@ impl ArtistContentView {
         self.imp()
             .album_count
             .set_label(&self.imp().album_list.n_items().to_string());
+        let stack = self.imp().album_spinner.get();
+        if stack.visible_child_name().unwrap() != "content" {
+            stack.set_visible_child_name("content");
+        }
     }
 
     pub fn add_songs(&self, songs: &[Song], cache: Rc<Cache>) {
@@ -624,6 +648,10 @@ impl ArtistContentView {
         self.imp()
             .song_count
             .set_label(&self.imp().song_list.n_items().to_string());
+        let stack = self.imp().song_spinner.get();
+        if stack.visible_child_name().unwrap() != "content" {
+            stack.set_visible_child_name("content");
+        }
     }
 
     fn clear_content(&self) {

--- a/src/meta_providers/base.rs
+++ b/src/meta_providers/base.rs
@@ -1,6 +1,6 @@
 extern crate bson;
 use gtk::prelude::*;
-use std::{thread, time::Duration};
+use std::{path::PathBuf, thread, time::Duration};
 
 use crate::utils::settings_manager;
 
@@ -13,18 +13,33 @@ pub fn sleep_after_request() {
     ));
 }
 
-pub enum Metadata {
-    // folder-level URI, true for thumbnail
-    AlbumArt(String, bool),
-    // Reserved for MpdWrapper to notify that we don't have one locally.
-    // Used by cache controller to trigger downloading from daisy-chained metadata.
+/// Enum for communication with provider threads from the cache controller living on the main thread.
+/// Can be used for both request and response.
+pub enum ProviderMessage {
+    AlbumArt(String, bson::Document, PathBuf, PathBuf),
+    AlbumArtAvailable(String),
+    /// Negative response (currently only used by MpdWrapper)
     AlbumArtNotAvailable(String, bson::Document),
+    /// Both request and positive response
+    AlbumMeta(String, bson::Document),
+    AlbumMetaAvailable(String),
+    /// Both request and positive response
+    ArtistAvatar(bson::Document, PathBuf, PathBuf),
+    ArtistAvatarAvailable(String), // name
+    /// Both request and positive response. Includes downloading artist avatar.
+    ArtistMeta(bson::Document, PathBuf, PathBuf),
+    ArtistMetaAvailable(String)
+}
+
+pub enum MetadataType<'a> {
+    // folder-level URI, true for thumbnail
+    AlbumArt(&'a str, bool),
     // folder-level URI
-    AlbumMeta(String),
+    AlbumMeta(&'a str),
     // Tag, true for thumbnail
-    ArtistAvatar(String, bool),
+    ArtistAvatar(&'a str, bool),
     // Tag
-    ArtistMeta(String),
+    ArtistMeta(&'a str),
 }
 
 /// Common provider-agnostic utilities.

--- a/src/meta_providers/base.rs
+++ b/src/meta_providers/base.rs
@@ -2,7 +2,7 @@ extern crate bson;
 use gtk::prelude::*;
 use std::{path::PathBuf, thread, time::Duration};
 
-use crate::utils::settings_manager;
+use crate::{common::{AlbumInfo, ArtistInfo}, utils::settings_manager};
 
 use super::models;
 
@@ -16,19 +16,19 @@ pub fn sleep_after_request() {
 /// Enum for communication with provider threads from the cache controller living on the main thread.
 /// Can be used for both request and response.
 pub enum ProviderMessage {
-    AlbumArt(String, bson::Document, PathBuf, PathBuf),
-    AlbumArtAvailable(String),
+    AlbumArt(AlbumInfo, PathBuf, PathBuf),
+    AlbumArtAvailable(String), // Only return folder URI
     /// Negative response (currently only used by MpdWrapper)
-    AlbumArtNotAvailable(String, bson::Document),
+    AlbumArtNotAvailable(AlbumInfo),
     /// Both request and positive response
-    AlbumMeta(String, bson::Document),
-    AlbumMetaAvailable(String),
+    AlbumMeta(AlbumInfo),
+    AlbumMetaAvailable(String), // Only return folder URI
     /// Both request and positive response
-    ArtistAvatar(bson::Document, PathBuf, PathBuf),
-    ArtistAvatarAvailable(String), // name
+    ArtistAvatar(ArtistInfo, PathBuf, PathBuf),
+    ArtistAvatarAvailable(String), // Only return name
     /// Both request and positive response. Includes downloading artist avatar.
-    ArtistMeta(bson::Document, PathBuf, PathBuf),
-    ArtistMetaAvailable(String)
+    ArtistMeta(ArtistInfo, PathBuf, PathBuf),
+    ArtistMetaAvailable(String) // Only return name
 }
 
 pub enum MetadataType<'a> {
@@ -115,7 +115,7 @@ pub trait MetadataProvider: Send + Sync {
     /// data will always overwrite existing fields.
     fn get_album_meta(
         &self,
-        key: bson::Document,
+        key: &mut AlbumInfo,
         existing: Option<models::AlbumMeta>,
     ) -> Option<models::AlbumMeta>;
 
@@ -124,7 +124,7 @@ pub trait MetadataProvider: Send + Sync {
     /// data will always overwrite existing fields.
     fn get_artist_meta(
         &self,
-        key: bson::Document,
+        key: &mut ArtistInfo,
         existing: Option<models::ArtistMeta>,
     ) -> Option<models::ArtistMeta>;
 }

--- a/src/meta_providers/mod.rs
+++ b/src/meta_providers/mod.rs
@@ -4,7 +4,7 @@ pub mod lastfm;
 pub mod models;
 pub mod musicbrainz;
 
-pub use base::{utils, Metadata, MetadataProvider};
+pub use base::{utils, ProviderMessage, MetadataType, MetadataProvider};
 pub use chain::{get_provider_with_priority, MetadataChain};
 
 pub mod prelude {

--- a/src/meta_providers/models.rs
+++ b/src/meta_providers/models.rs
@@ -2,6 +2,8 @@ use chrono::NaiveDate;
 use musicbrainz_rs::entity::artist::ArtistType;
 use serde::{Deserialize, Serialize};
 
+use crate::common::{AlbumInfo, ArtistInfo};
+
 // Common building blocks that can be shared between different providers
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Tag {
@@ -84,16 +86,10 @@ pub struct AlbumMeta {
 impl AlbumMeta {
     /// Create a minimal AlbumMeta. Useful for blocking further calls to an album
     /// whose information are unavailable on any remote source.
-    pub fn from_key(key: &bson::Document) -> Self {
-        let mbid: Option<String>;
-        if let Ok(mbid_str) = key.get_str("mbid") {
-            mbid = Some(mbid_str.to_owned());
-        } else {
-            mbid = None;
-        }
+    pub fn from_key(key: &AlbumInfo) -> Self {
         Self {
-            name: key.get_str("name").unwrap_or_default().to_string(),
-            mbid,
+            name: key.title.to_owned(),
+            mbid: key.mbid.clone(),
             artist: None,
             tags: Vec::with_capacity(0),
             image: Vec::with_capacity(0),
@@ -169,16 +165,10 @@ pub struct ArtistMeta {
 impl ArtistMeta {
     /// Create a minimal ArtistMeta. Useful for blocking further calls to an artist
     /// whose information are unavailable on any remote source.
-    pub fn from_key(key: &bson::Document) -> Self {
-        let mbid: Option<String>;
-        if let Ok(mbid_str) = key.get_str("mbid") {
-            mbid = Some(mbid_str.to_owned());
-        } else {
-            mbid = None;
-        }
+    pub fn from_key(key: &ArtistInfo) -> Self {
         Self {
-            name: key.get_str("name").unwrap_or_default().to_string(),
-            mbid,
+            name: key.name.to_owned(),
+            mbid: key.mbid.clone(),
             similar: Vec::with_capacity(0),
             tags: Vec::with_capacity(0),
             image: Vec::with_capacity(0),

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1079,8 +1079,8 @@ impl Player {
             if let Some(album) = song.get_album() {
                 // Always read from disk
                 Some(
-                    cache.get_path_for(&crate::meta_providers::Metadata::AlbumArt(
-                        album.uri.to_owned(),
+                    cache.get_path_for(&crate::meta_providers::MetadataType::AlbumArt(
+                        &album.uri,
                         thumbnail,
                     )),
                 )

--- a/src/window.rs
+++ b/src/window.rs
@@ -599,9 +599,8 @@ mod imp {
                         (height - level * scale * 1000000.0).max(0.0),
                     );
                 }
-                path_builder.line_to(width, height);
             }
-
+            path_builder.line_to(width, height);
             let path = path_builder.to_path();
 
             snapshot.push_fill(&path, gsk::FillRule::Winding);


### PR DESCRIPTION
Starting from this PR we'll aim for a v1.0 release on Flathub, so the minor versions will be bumped up to 0.9x.

This resolves suboptimal decisions made early on in the dev process and should put us on better footing for the eventual v1.0 release.

- Replaced PoloDB with plain ol' SQLite - easier to inspect, composite indices are supported, etc. Actual metadata docs are still BSON blobs, but since they're only BSON when stored, BSON is now much less prevalent in our cache code. Also, I took this chance to significantly cut down on string clones. Closes #35.
- Replaced murmur2 hashing of URIs with simple base64url encoding. This also does what we need (avoiding special chars) but never collides and is completely reversible. Closes #36.
- Added loading spinners to artist bio, artist discography/songs subviews, album wiki and album content. Closes #39.
- Fixed spectrum equaliser "lifting off" from the window's bottom edge when smooth curves drawing (default) is enabled.