### PR TITLE
Auto accent, live bitrate & UI cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.90.0"
+version = "0.90.1"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "tokio",
@@ -282,6 +282,19 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-palette"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f696ad1fe2484635b38e0aa47704c5214cdd42aa67fc36539c8a8ce445ba3d1b"
+dependencies = [
+ "getrandom 0.3.2",
+ "image 0.25.1",
+ "num-traits",
+ "rand 0.9.0",
+ "rand_distr",
+]
 
 [[package]]
 name = "autocfg"
@@ -471,7 +484,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -832,7 +845,7 @@ dependencies = [
  "futures-util",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -983,6 +996,7 @@ dependencies = [
  "ashpd",
  "async-channel",
  "async-lock",
+ "auto-palette",
  "base64 0.22.1",
  "bson",
  "chrono",
@@ -1381,8 +1395,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2671,7 +2697,7 @@ checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3140,7 +3166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3150,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3407,6 +3433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "r2d2"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,8 +3473,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3452,7 +3495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3461,7 +3514,26 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -3490,8 +3562,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps 6.2.2",
  "thiserror",
@@ -3681,7 +3753,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -4093,9 +4165,9 @@ checksum = "70a313e115c2cd9a88d99d60386bc88641c853d468b2c3bc454c294f385fc084"
 dependencies = [
  "atomic",
  "crossbeam-channel",
- "getrandom",
+ "getrandom 0.2.15",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "seahash",
  "thiserror",
  "tracing",
@@ -4634,8 +4706,8 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "serde",
  "uuid-macro-internal",
 ]
@@ -4694,6 +4766,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5029,6 +5110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5139,7 +5229,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -5238,7 +5328,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -5246,6 +5345,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rusqlite = { version = "0.33.0", features = ["time"] }
 base64 = "0.22.1"
 r2d2_sqlite = "0.26.0"
 r2d2 = "0.8.10"
+auto-palette = "0.6.0"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.90.0"
+version = "0.90.1"
 edition = "2021"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ An MPD frontend with delusions of grandeur.
 
 ## Features
 - Responsive GTK4 LibAdwaita UI for most MPD features, from basic things like playback controls, queue reordering and ReplayGain to things like output control, crossfade and MixRamp configuration
-- Built-in, customisable spectrum visualiser, reading from MPD FIFO or system PipeWire.
+- Built-in, customisable spectrum visualiser, reading from MPD FIFO or system PipeWire
+- Automatic accent colours based on album art (optional)
 - Rate albums (requires MPD 0.24+)
 - Audio quality indicators (lossy, lossless, hi-res, DSD) for individual songs as well as albums & detailed format printout
 - Browse your library by album, artist and folders with multiselection support
@@ -34,27 +35,28 @@ An MPD frontend with delusions of grandeur.
 
 ## Screenshots
 
-- Album View in light mode[^1]
-  ![album-view-light](https://github.com/user-attachments/assets/302b0e37-ff4a-4151-b688-6d6b5e1dcb60)
+The below were captured with a mix of dark and light modes.
+
+- Album View[^1]
+  ![album-view](https://github.com/user-attachments/assets/26f9f3bb-3032-4ae5-ba46-15e4ece680ef)
 
 - UI at different sizes (v0.12+)[^1]
-![mini-layouts-light](https://github.com/user-attachments/assets/af7b2cb0-7f85-42ce-ac16-14a3c0cf2153)
+  ![mini-layouts-v2](https://github.com/user-attachments/assets/1caace0d-751e-41c6-be9c-5aa54ac67f91)
 
-- Queue View in dark mode[^1]
-  ![queue-view-dark](https://github.com/user-attachments/assets/0ed85f77-48dc-4dc6-9e43-850e731bcaaa)
+- Queue View[^1]
+  ![queue-view](https://github.com/user-attachments/assets/020faf32-33f3-4711-a86c-4934d058f3a1)
 
 - Artist bio as fetched from Last.fm[^1][^2][^3]
-  ![artist-content-view-dark](https://github.com/user-attachments/assets/659c0ca3-08f6-44f5-9840-26060057fad7)
+  ![artist-content-view](https://github.com/user-attachments/assets/54161399-1f16-490f-91b9-89b581b28839)
 
 - Album wiki as fetched from Last.fm[^1][^2]
-  ![album-content-view-dark](https://github.com/user-attachments/assets/2665a48a-e81c-43ff-b3c1-76a6d7443f5e)
+  ![album-content-view](https://github.com/user-attachments/assets/f3246730-3ad1-4056-a414-37807a145dc2)
   
-- Playlist Content View in dark mode[^1]
-  ![playlist-content-view-dark](https://github.com/user-attachments/assets/42c3b9c5-a4fe-4e70-9765-5326c75d6c5b)
-
+- Playlist Content View[^1]
+  ![playlist-content-view](https://github.com/user-attachments/assets/be9913e7-2378-4374-9a8a-d08512fc1e09)
   
 - Some of the available UI customisations[^1]
-![visualiser-customisation](https://github.com/user-attachments/assets/e21d0a36-6dba-4fea-84a2-0fdb0810bff5)
+  ![visualiser-customisation](https://github.com/user-attachments/assets/e21d0a36-6dba-4fea-84a2-0fdb0810bff5)
 
 [^1]: Actual album arts have been replaced with random pictures from [Pexels](https://www.pexels.com/). All credits go to the original authors.
 [^2]: Artist bios and album wikis are user-contributed and licensed by Last.fm under CC-BY-SA.

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -233,6 +233,9 @@
 		<key name="visualizer-stroke-width" type='d'>
 			<default>2.0</default>
 		</key>
+		<key name="auto-accent" type='b'>
+			<default>true</default>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.state" path="/org/euphonica/Euphonica/state/">

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -181,7 +181,7 @@
 			<default>16000</default>
 		</key>
 		<key name="visualizer-spectrum-curr-step-weight" type="d">
-			<default>0.12</default>
+			<default>0.09</default>
 
 		</key>
 	</schema>
@@ -212,10 +212,10 @@
 			<default>false</default>
 		</key>
 		<key name="visualizer-top-opacity" type="d">
-			<default>0.6</default>
+			<default>0.9</default>
 		</key>
 		<key name="visualizer-scale" type="d">
-			<default>2.0</default>
+			<default>5.0</default>
 		</key>
 		<key name="visualizer-blend-mode" type="u">
 			<default>6</default>
@@ -231,7 +231,7 @@
 			<default>true</default>
 		</key>
 		<key name="visualizer-stroke-width" type='d'>
-			<default>2.0</default>
+			<default>1.0</default>
 		</key>
 		<key name="auto-accent" type='b'>
 			<default>true</default>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.90.0',
+          version: '0.90.1',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/application.rs
+++ b/src/application.rs
@@ -57,7 +57,7 @@ mod imp {
             // Create cache folder. This is where the cached album arts go.
             let mut cache_path: PathBuf = glib::user_cache_dir();
             cache_path.push("euphonica");
-            println!("Cache path: {}", cache_path.to_str().unwrap());
+            // println!("Cache path: {}", cache_path.to_str().unwrap());
             create_dir_all(&cache_path).expect("Could not create temporary directories!");
 
             // Create cache controller

--- a/src/gtk/player/bar.ui
+++ b/src/gtk/player/bar.ui
@@ -85,26 +85,6 @@
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible" bind-source="format_desc" bind-property="visible" bind-flags="sync-create"/>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkImage" id="quality_grade">
-                    <property name="icon-name">format-base-symbolic</property>
-                    <property name="icon-size">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="format_desc">
-                    <property name="label">Unknown format</property>
-                    <style>
-                      <class name="caption" />
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
           </object>
         </child>
 

--- a/src/gtk/player/bar.ui
+++ b/src/gtk/player/bar.ui
@@ -22,7 +22,7 @@
             </style>
             <child>
               <object class="GtkImage" id="albumart">
-                <property name="pixel-size">96</property>
+                <property name="pixel-size">115</property>
                 <property name="resource">io/github/htkhiem/Euphonica/albumart-placeholder.png</property>
               </object>
             </child>
@@ -155,108 +155,94 @@
             </property>
           </object>
         </child>
+
         <child>
           <object class="AdwLayout">
             <property name="name">full</property>
             <property name="content">
-              <object class="EuphonicaRatioCenterBox" id="center_layout">
-                <property name="center-ratio">0.5</property>
+              <object class="GtkCenterBox">
                 <property name="hexpand">true</property>
-                <property name="left-widget">
-                  <object class="GtkRevealer" id="infobox_revealer">
-                    <property name="transition-type">slide-right</property>
-                    <property name="transition-duration">1000</property>
-                    <property name="child">
-                      <object class="GtkBox">
-                        <property name="valign">3</property>
-                        <property name="spacing">12</property>
-                        <property name="margin-end">24</property>
-                        <!-- Current song info (hidden when in queue view to avoid duplicated info) -->
-                        <child>
-                          <object class="AdwLayoutSlot">
-                            <property name="id">album-art</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwLayoutSlot">
-                            <property name="id">info-box</property>
-                          </object>
-                        </child>
-                      </object>
-                    </property>
+                <property name="start-widget">
+                  <object class="AdwLayoutSlot">
+                    <property name="id">album-art</property>
                   </object>
                 </property>
-
                 <property name="center-widget">
-                  <!-- Playback controls -->
                   <object class="GtkBox">
-                    <property name="orientation">1</property>
-                    <property name="valign">center</property>
                     <property name="hexpand">true</property>
-
+                    <property name="orientation">1</property>
                     <child>
-                      <object class="AdwLayoutSlot">
-                        <property name="id">playback-controls</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkRevealer">
-                        <property name="transition-type">slide-down</property>
-                        <property name="transition-duration">1000</property>
-                        <property name="reveal_child" bind-source="infobox_revealer" bind-property="reveal-child" bind-flags="sync-create"></property>
-                        <property name="child">
-                          <object class="EuphonicaSeekbar" id="seekbar">
-                            <property name="hexpand">true</property>
+                      <object class="GtkCenterBox">
+                        <property name="hexpand">true</property>
+                        <property name="shrink-center-last">true</property>
+                        <property name="margin-start">11</property>
+                        <property name="margin-end">11</property>
+                        <property name="start-widget">
+                          <object class="GtkRevealer" id="infobox_revealer">
+                            <property name="transition-type">slide-right</property>
+                            <property name="transition-duration">1000</property>
+                            <property name="child">
+                              <object class="AdwLayoutSlot">
+                                <property name="id">info-box</property>
+                              </object>
+                            </property>
+                          </object>
+                        </property>
+                        <property name="center-widget">
+                          <object class="AdwLayoutSlot">
+                            <property name="id">playback-controls</property>
+                          </object>
+                        </property>
+                        <property name="end-widget">
+                          <object class="GtkBox" id="output_section">
+                            <property name="visible">false</property>
+                            <child>
+                              <object class="GtkButton" id="prev_output">
+                                <property name="visible">false</property>
+                                <property name="sensitive">false</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">left-symbolic</property>
+                                <style>
+                                  <class name="flat"/>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkStack" id="output_stack">
+                                <property name="transition-type">slide-left-right</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="next_output">
+                                <property name="visible">false</property>
+                                <property name="sensitive">false</property>
+                                <property name="valign">center</property>
+                                <property name="icon-name">right-symbolic</property>
+                                <style>
+                                  <class name="flat"/>
+                                  <class name="circular"/>
+                                </style>
+                              </object>
+                            </child>
                           </object>
                         </property>
                       </object>
                     </child>
-                  </object>
-                </property>
-
-                <property name="right-widget">
-                  <object class="GtkBox">
-                    <property name="halign">end</property>
-                    <property name="spacing">12</property>
-                    <property name="margin-start">24</property>
                     <child>
-                      <object class="GtkBox" id="output_section">
-                        <property name="visible">false</property>
+                      <object class="GtkRevealer" id="seekbar_revealer">
+                        <property name="transition-type">slide-down</property>
                         <child>
-                          <object class="GtkButton" id="prev_output">
-                            <property name="visible">false</property>
-                            <property name="sensitive">false</property>
-                            <property name="valign">center</property>
-                            <property name="icon-name">left-symbolic</property>
-                            <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
-                            </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkStack" id="output_stack">
-                            <property name="transition-type">slide-left-right</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="next_output">
-                            <property name="visible">false</property>
-                            <property name="sensitive">false</property>
-                            <property name="valign">center</property>
-                            <property name="icon-name">right-symbolic</property>
-                            <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
-                            </style>
+                          <object class="EuphonicaSeekbar" id="seekbar">
+                            <property name="hexpand">true</property>
                           </object>
                         </child>
                       </object>
                     </child>
-                    <child>
-                      <object class="EuphonicaVolumeKnob" id="vol_knob"/>
-                    </child>
                   </object>
+                </property>
+                <property name="end-widget">
+                  <object class="EuphonicaVolumeKnob" id="vol_knob"/>
                 </property>
               </object>
             </property>

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -106,19 +106,18 @@
         <property name="vscrollbar-policy">automatic</property>
         <property name="propagate-natural-height">true</property>
         <property name="vexpand">true</property>
-
         <property name="child">
-          <object class="GtkBox">
-            <style>
-              <class name="player-pane"/>
-            </style>
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="AdwClamp">
-                <property name="maximum-size">480px</property>
-                <property name="tightening-threshold">360px</property>
-                <property name="child">
+          <object class="AdwClamp">
+            <property name="maximum-size">480px</property>
+            <property name="tightening-threshold">360px</property>
+            <property name="child">
+              <object class="GtkBox">
+                <style>
+                  <class name="player-pane"/>
+                </style>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
                   <object class="GtkBox"> <!-- Wraps around picture to give it rounded corners & card shadow -->
                     <property name="height-request">180sp</property>
                     <property name="halign">center</property>
@@ -132,133 +131,166 @@
                       </object>
                     </child>
                   </object>
-                </property>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkBox" id="info_box">
-                <property name="orientation">vertical</property>
-                <property name="visible">false</property>
+                </child>
                 <child>
-                  <object class="GtkLabel" id="song_name">
-                    <property name="wrap">true</property>
-                    <property name="label">Untitled Song</property>
-                    <property name="wrap">true</property>
-                    <property name="justify">2</property>
-                    <style>
-                      <class name="title-4"/>
-                    </style>
+                  <object class="GtkBox" id="info_box">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <property name="halign">center</property>
+                    <property name="visible">false</property>
+                    <child>
+                      <object class="GtkLabel" id="song_name">
+                        <property name="wrap">true</property>
+                        <property name="label">Untitled Song</property>
+                        <property name="wrap">true</property>
+                        <property name="justify">2</property>
+                        <style>
+                          <class name="heading"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="icon-name">music-artist-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="artist">
+                            <property name="wrap">true</property>
+                            <property name="label">Unknown</property>
+                            <property name="wrap">true</property>
+                            <property name="justify">2</property>
+                            <style>
+                              <class name="caption" />
+                            </style>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="halign">center</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="icon-name">library-music-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="album">
+                            <property name="wrap">true</property>
+                            <property name="label">Unknown</property>
+                            <property name="wrap">true</property>
+                            <property name="justify">2</property>
+                            <style>
+                              <class name="caption" />
+                            </style>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="artist">
-                    <property name="wrap">true</property>
-                    <property name="label">Unknown</property>
-                    <property name="wrap">true</property>
-                    <property name="justify">2</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="album">
-                    <property name="wrap">true</property>
-                    <property name="label">Unknown</property>
-                    <property name="wrap">true</property>
-                    <property name="justify">2</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkBox">
-                <property name="orientation">1</property>
-                <child>
-                  <object class="EuphonicaPlaybackControls" id="playback_controls"/>
-                </child>
-                <child>
-                  <object class="EuphonicaSeekbar" id="seekbar"/>
                 </child>
                 <child>
                   <object class="GtkBox">
-                    <property name="spacing">6</property>
-                    <property name="halign">center</property>
+                    <property name="orientation">1</property>
                     <child>
-                      <object class="GtkButton" id="rg_btn">
-                        <style>
-                          <class name="flat"/>
-                        </style>
-                        <property name="icon-name">rg-off-symbolic</property>
+                      <object class="EuphonicaPlaybackControls" id="playback_controls"/>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="spacing">6</property>
+                        <property name="halign">center</property>
+                        <child>
+                          <object class="GtkButton" id="rg_btn">
+                            <style>
+                              <class name="flat"/>
+                            </style>
+                            <property name="icon-name">rg-off-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuButton" id="crossfade_btn">
+                            <style>
+                              <class name="flat"/>
+                            </style>
+                            <property name="icon-name">crossfade-off-symbolic</property>
+                            <property name="tooltip-text" translatable="true">Crossfade</property>
+                            <property name="popover">crossfade_popover</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuButton" id="mixramp_btn">
+                            <style>
+                              <class name="flat"/>
+                            </style>
+                            <property name="icon-name">mixramp-off-symbolic</property>
+                            <property name="tooltip-text" translatable="true">MixRamp</property>
+                            <property name="popover">mixramp_popover</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkMenuButton" id="crossfade_btn">
-                        <style>
-                          <class name="flat"/>
-                        </style>
-                        <property name="icon-name">crossfade-off-symbolic</property>
-                        <property name="tooltip-text" translatable="true">Crossfade</property>
-                        <property name="popover">crossfade_popover</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuButton" id="mixramp_btn">
-                        <style>
-                          <class name="flat"/>
-                        </style>
-                        <property name="icon-name">mixramp-off-symbolic</property>
-                        <property name="tooltip-text" translatable="true">MixRamp</property>
-                        <property name="popover">mixramp_popover</property>
+                      <object class="GtkRevealer" id="seekbar_revealer">
+                        <property name="transition-type">slide-down</property>
+                        <child>
+                          <object class="EuphonicaSeekbar" id="seekbar">
+                            <property name="hexpand">true</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
                 </child>
-              </object>
-            </child>
 
-            <child>
-              <object class="GtkBox">
-                <property name="halign">center</property>
-                <property name="spacing">12</property>
                 <child>
-                  <object class="GtkBox" id="output_section">
-                    <property name="visible">false</property>
-                    <child>
-                      <object class="GtkButton" id="prev_output">
+                  <object class="GtkCenterBox">
+                    <property name="start-widget">
+                      <object class="GtkBox" id="output_section">
                         <property name="visible">false</property>
-                        <property name="sensitive">false</property>
-                        <property name="valign">center</property>
-                        <property name="icon-name">left-symbolic</property>
-                        <style>
-                          <class name="flat"/>
-                          <class name="circular"/>
-                        </style>
+                        <child>
+                          <object class="GtkButton" id="prev_output">
+                            <property name="visible">false</property>
+                            <property name="sensitive">false</property>
+                            <property name="valign">center</property>
+                            <property name="icon-name">left-symbolic</property>
+                            <style>
+                              <class name="flat"/>
+                              <class name="circular"/>
+                            </style>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStack" id="output_stack">
+                            <property name="transition-type">slide-left-right</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="next_output">
+                            <property name="visible">false</property>
+                            <property name="sensitive">false</property>
+                            <property name="valign">center</property>
+                            <property name="icon-name">right-symbolic</property>
+                            <style>
+                              <class name="flat"/>
+                              <class name="circular"/>
+                            </style>
+                          </object>
+                        </child>
                       </object>
-                    </child>
-                    <child>
-                      <object class="GtkStack" id="output_stack">
-                        <property name="transition-type">slide-left-right</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="next_output">
-                        <property name="visible">false</property>
-                        <property name="sensitive">false</property>
-                        <property name="valign">center</property>
-                        <property name="icon-name">right-symbolic</property>
-                        <style>
-                          <class name="flat"/>
-                          <class name="circular"/>
-                        </style>
-                      </object>
-                    </child>
+                    </property>
+                    <property name="end-widget">
+                      <object class="EuphonicaVolumeKnob" id="vol_knob"/>
+                    </property>
                   </object>
                 </child>
-                <child>
-                  <object class="EuphonicaVolumeKnob" id="vol_knob"/>
-                </child>
               </object>
-            </child>
+            </property>
           </object>
         </property>
       </object>

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -213,26 +213,6 @@
                     </child>
                   </object>
                 </child>
-                <child>
-                  <object class="GtkBox" id="format_info">
-                    <property name="halign">center</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkImage" id="quality_grade">
-                        <property name="icon-name">format-base-symbolic</property>
-                        <property name="icon-size">1</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="format_desc">
-                        <property name="label">Unknown format</property>
-                        <style>
-                          <class name="caption" />
-                        </style>
-                      </object>
-                    </child>
-                  </object>
-                </child>
               </object>
             </child>
 

--- a/src/gtk/player/queue-view.ui
+++ b/src/gtk/player/queue-view.ui
@@ -51,6 +51,9 @@
         </property>
         <property name="sidebar">
           <object class="AdwNavigationPage">
+            <style>
+              <class name="light-right-edge"/>
+            </style>
             <property name="title" translatable="yes">Queue</property>
             <property name="tag">queue</property>
             <property name="child">

--- a/src/gtk/player/queue-view.ui
+++ b/src/gtk/player/queue-view.ui
@@ -32,7 +32,7 @@
         </style>
         <property name="min-sidebar-width">240</property>
         <property name="max-sidebar-width">3840</property>
-        <property name="sidebar-width-fraction">0.65</property>
+        <property name="sidebar-width-fraction">0.45</property>
         <property name="content">
           <object class="AdwNavigationPage">
             <property name="title" translatable="yes">Now Playing</property>

--- a/src/gtk/player/seekbar.ui
+++ b/src/gtk/player/seekbar.ui
@@ -1,33 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <template class="EuphonicaSeekbar" parent="GtkWidget">
+  <template class="EuphonicaSeekbar" parent="GtkBox">
+    <property name="spacing">0</property>
+    <property name="orientation">1</property>
     <child>
-      <object class="GtkCenterBox" id="seekbar_box">
+      <object class="GtkScale" id="seekbar">
+        <property name="draw-value">false</property>
+        <property name="hexpand">true</property>
+        <property name="orientation">0</property>
+        <property name="width-request">120</property>
+        <property name="adjustment">
+          <object class="GtkAdjustment">
+            <property name="lower">0</property>
+            <property name="upper">0</property>
+            <property name="value">0</property>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkCenterBox">
         <property name="hexpand">true</property>
         <property name="start-widget">
           <object class="GtkLabel" id="elapsed">
+            <property name="margin-start">11</property>
             <style>
               <class name="caption"/>
             </style>
           </object>
         </property>
         <property name="center-widget">
-          <object class="GtkScale" id="seekbar">
-            <property name="draw-value">false</property>
-            <property name="hexpand">true</property>
-            <property name="orientation">0</property>
-            <property name="width-request">120</property>
-            <property name="adjustment">
-              <object class="GtkAdjustment">
-                <property name="lower">0</property>
-                <property name="upper">0</property>
-                <property name="value">0</property>
+          <object class="GtkBox">
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkImage" id="quality_grade"/>
+            </child>
+            <child>
+              <object class="GtkLabel" id="format_desc">
+                <style>
+                  <class name="caption"/>
+                </style>
               </object>
-            </property>
+            </child>
+            <child>
+              <object class="GtkSeparator"/>
+            </child>
+            <child>
+              <object class="GtkLabel" id="bitrate">
+                <style>
+                  <class name="caption"/>
+                </style>
+              </object>
+            </child>
           </object>
         </property>
         <property name="end-widget">
           <object class="GtkLabel" id="duration">
+            <property name="margin-end">11</property>
             <style>
               <class name="caption"/>
             </style>

--- a/src/gtk/player/volume-knob.ui
+++ b/src/gtk/player/volume-knob.ui
@@ -5,8 +5,8 @@
       <object class="GtkOverlay">
         <property name="child">
           <object class="GtkDrawingArea" id="draw_area">
-            <property name="width-request">96</property>
-            <property name="height-request">96</property>
+            <property name="width-request">115</property>
+            <property name="height-request">115</property>
           </object>
         </property>
         <child type="overlay">

--- a/src/gtk/player/volume-knob.ui
+++ b/src/gtk/player/volume-knob.ui
@@ -7,6 +7,9 @@
           <object class="GtkDrawingArea" id="draw_area">
             <property name="width-request">115</property>
             <property name="height-request">115</property>
+            <style>
+              <class name="fg-auto-accent"/>
+            </style>
           </object>
         </property>
         <child type="overlay">

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -7,7 +7,12 @@
     <property name="icon-name">brush-monitor-symbolic</property>
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title" translatable="true">Sidebar</property>
+        <property name="title" translatable="true">General</property>
+        <child>
+          <object class="AdwSwitchRow" id="auto_accent">
+            <property name="title" translatable="true">Recolour accent to album art</property>
+          </object>
+        </child>
         <child>
           <object class="AdwSpinRow" id="recent_playlists_count">
             <property name="title" translatable="true">Number of recent playlists to show</property>

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -52,6 +52,11 @@ windowhandle {
     padding: 12pt;
 }
 
+/* Fixes the weirdly dark vertical edges between panes */
+.light-right-edge {
+	border-right: 1px solid @borders;
+}
+
 .player-pane {
     padding-left: 12px;
     padding-right: 12px;

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -20,8 +20,7 @@ use super::{
     PlaybackControls,
     PlaybackState,
     Player,
-    VolumeKnob,
-    RatioCenterBox
+    VolumeKnob
 };
 
 mod imp {
@@ -39,8 +38,6 @@ mod imp {
     pub struct PlayerBar {
         #[template_child]
         pub multi_layout_view: TemplateChild<adw::MultiLayoutView>,
-        #[template_child]
-        pub center_layout: TemplateChild<RatioCenterBox>,
         // Left side: current song info
         #[template_child]
         pub albumart: TemplateChild<gtk::Image>,
@@ -60,6 +57,8 @@ mod imp {
         // Centre: playback controls
         #[template_child]
         pub playback_controls: TemplateChild<PlaybackControls>,
+        #[template_child]
+        pub seekbar_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
         pub seekbar: TemplateChild<Seekbar>,
 
@@ -128,7 +127,7 @@ mod imp {
                         if collapsed {
                             Some(48)
                         } else {
-                            Some(96)
+                            Some(115)
                         }
                     },
                 )
@@ -266,6 +265,7 @@ impl PlayerBar {
 
         let infobox_revealer = imp.infobox_revealer.get();
         let mini_infobox_revealer = imp.mini_infobox_revealer.get();
+        let seekbar_revealer = imp.seekbar_revealer.get();
         // Also controls seekbar revealer, see binding in bar.ui
         player
             .bind_property("playback-state", &infobox_revealer, "reveal_child")
@@ -275,6 +275,12 @@ impl PlayerBar {
 
         player
             .bind_property("playback-state", &mini_infobox_revealer, "reveal_child")
+            .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
+            .sync_create()
+            .build();
+
+        player
+            .bind_property("playback-state", &seekbar_revealer, "reveal_child")
             .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
             .sync_create()
             .build();

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -56,10 +56,6 @@ mod imp {
         pub artist: TemplateChild<gtk::Label>,
         #[template_child]
         pub album: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub quality_grade: TemplateChild<gtk::Image>,
-        #[template_child]
-        pub format_desc: TemplateChild<gtk::Label>,
 
         // Centre: playback controls
         #[template_child]
@@ -146,16 +142,6 @@ mod imp {
 
             // Hide certain widgets when in compact mode
             obj.bind_property("collapsed", &self.album.get(), "visible")
-                .invert_boolean()
-                .sync_create()
-                .build();
-
-            obj.bind_property("collapsed", &self.quality_grade.get(), "visible")
-                .invert_boolean()
-                .sync_create()
-                .build();
-
-            obj.bind_property("collapsed", &self.format_desc.get(), "visible")
                 .invert_boolean()
                 .sync_create()
                 .build();
@@ -308,25 +294,6 @@ impl PlayerBar {
         let artist = imp.artist.get();
         player
             .bind_property("artist", &artist, "label")
-            .sync_create()
-            .build();
-
-        let quality_grade = imp.quality_grade.get();
-        player
-            .bind_property("quality-grade", &quality_grade, "icon-name")
-            .transform_to(|_, grade: QualityGrade| Some(grade.to_icon_name()))
-            .sync_create()
-            .build();
-
-        player
-            .bind_property("quality-grade", &quality_grade, "visible")
-            .transform_to(|_, grade: QualityGrade| Some(grade != QualityGrade::Lossy))
-            .sync_create()
-            .build();
-
-        let format_desc = imp.format_desc.get();
-        player
-            .bind_property("format-desc", &format_desc, "label")
             .sync_create()
             .build();
 

--- a/src/player/knob.rs
+++ b/src/player/knob.rs
@@ -246,8 +246,8 @@ impl VolumeKnob {
         draw_area.set_draw_func(clone!(
             #[weak(rename_to = this)]
             self,
-            move |_, cr, w, h| {
-                let fg = this.color();
+            move |da, cr, w, h| {
+                let fg = da.color();
                 cr.set_source_rgb(fg.red() as f64, fg.green() as f64, fg.blue() as f64);
                 // Match seekbar thickness
                 cr.set_line_width(4.0);

--- a/src/player/knob.rs
+++ b/src/player/knob.rs
@@ -256,7 +256,7 @@ impl VolumeKnob {
                 // At 0 => 5pi/4
                 let angle = -1.25 * PI + 1.5 * PI * this.imp().value.get() / 100.0;
                 // u w0t m8
-                cr.arc(w as f64 / 2.0, h as f64 / 2.0, 40.0, -1.25 * PI, angle);
+                cr.arc(w as f64 / 2.0, h as f64 / 2.0, 50.0, -1.25 * PI, angle);
                 let _ = cr.stroke();
             }
         ));

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -46,6 +46,8 @@ mod imp {
         #[template_child]
         pub seekbar: TemplateChild<Seekbar>,
         #[template_child]
+        pub seekbar_revealer: TemplateChild<gtk::Revealer>,
+        #[template_child]
         pub rg_btn: TemplateChild<gtk::Button>,
         #[template_child]
         pub crossfade_btn: TemplateChild<gtk::MenuButton>,
@@ -264,6 +266,13 @@ impl PlayerPane {
         let info_box = imp.info_box.get();
         player
             .bind_property("playback-state", &info_box, "visible")
+            .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
+            .sync_create()
+            .build();
+
+        let seekbar_revealer = imp.seekbar_revealer.get();
+        player
+            .bind_property("playback-state", &seekbar_revealer, "reveal_child")
             .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
             .sync_create()
             .build();

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -57,8 +57,6 @@ mod imp {
         pub mixramp_db: TemplateChild<gtk::SpinButton>,
         #[template_child]
         pub mixramp_delay: TemplateChild<gtk::SpinButton>,
-        #[template_child]
-        pub format_info: TemplateChild<gtk::Box>,
 
         // Bottom: output info, volume control & quality
         #[template_child]
@@ -71,10 +69,6 @@ mod imp {
         pub next_output: TemplateChild<gtk::Button>,
         #[template_child]
         pub vol_knob: TemplateChild<VolumeKnob>,
-        #[template_child]
-        pub quality_grade: TemplateChild<gtk::Image>,
-        #[template_child]
-        pub format_desc: TemplateChild<gtk::Label>,
 
         // Kept here so we can access it in snapshot()
         pub bg_paintable: FadePaintable,
@@ -268,15 +262,8 @@ impl PlayerPane {
     fn bind_state(&self, player: &Player) {
         let imp = self.imp();
         let info_box = imp.info_box.get();
-        let format_info = imp.format_info.get();
         player
             .bind_property("playback-state", &info_box, "visible")
-            .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
-            .sync_create()
-            .build();
-
-        player
-            .bind_property("playback-state", &format_info, "visible")
             .transform_to(|_, state: PlaybackState| Some(state != PlaybackState::Stopped))
             .sync_create()
             .build();
@@ -296,25 +283,6 @@ impl PlayerPane {
         let artist = imp.artist.get();
         player
             .bind_property("artist", &artist, "label")
-            .sync_create()
-            .build();
-
-        let quality_grade = imp.quality_grade.get();
-        player
-            .bind_property("quality-grade", &quality_grade, "icon-name")
-            .transform_to(|_, grade: QualityGrade| Some(grade.to_icon_name()))
-            .sync_create()
-            .build();
-
-        player
-            .bind_property("quality-grade", &quality_grade, "visible")
-            .transform_to(|_, grade: QualityGrade| Some(grade != QualityGrade::Lossy))
-            .sync_create()
-            .build();
-
-        let format_desc = imp.format_desc.get();
-        player
-            .bind_property("format-desc", &format_desc, "label")
             .sync_create()
             .build();
 

--- a/src/player/seekbar.rs
+++ b/src/player/seekbar.rs
@@ -2,6 +2,8 @@ use glib::{clone, closure_local, Object};
 use gtk::{gio, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
 use std::cell::Cell;
 
+use crate::{common::QualityGrade, utils};
+
 use super::Player;
 
 mod imp {
@@ -23,6 +25,12 @@ mod imp {
         pub elapsed: TemplateChild<gtk::Label>,
         #[template_child]
         pub duration: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub quality_grade: TemplateChild<gtk::Image>,
+        #[template_child]
+        pub format_desc: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub bitrate: TemplateChild<gtk::Label>,
         pub seekbar_clicked: Cell<bool>,
     }
 
@@ -32,7 +40,7 @@ mod imp {
         // `NAME` needs to match `class` attribute of template
         const NAME: &'static str = "EuphonicaSeekbar";
         type Type = super::Seekbar;
-        type ParentType = gtk::Widget;
+        type ParentType = gtk::Box;
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
@@ -44,7 +52,6 @@ mod imp {
         }
     }
 
-    // Trait shared by all GObjects
     impl ObjectImpl for Seekbar {
         fn constructed(&self) {
             self.parent_constructed();
@@ -159,6 +166,8 @@ mod imp {
     }
 
     impl WidgetImpl for Seekbar {}
+
+    impl BoxImpl for Seekbar {}
 }
 
 glib::wrapper! {
@@ -253,6 +262,23 @@ impl Seekbar {
 
         player
             .bind_property("duration", self, "duration")
+            .sync_create()
+            .build();
+
+        player
+            .bind_property("quality-grade", &self.imp().quality_grade.get(), "icon-name")
+            .transform_to(|_, grade: QualityGrade| Some(grade.to_icon_name()))
+            .sync_create()
+            .build();
+
+        player
+            .bind_property("format-desc", &self.imp().format_desc.get(), "label")
+            .sync_create()
+            .build();
+
+        player
+            .bind_property("bitrate", &self.imp().bitrate.get(), "label")
+            .transform_to(|_, val: u32| Some(utils::format_bitrate(val))) 
             .sync_create()
             .build();
     }

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -15,6 +15,8 @@ mod imp {
     pub struct UIPreferences {
         #[template_child]
         pub recent_playlists_count: TemplateChild<adw::SpinRow>,
+        #[template_child]
+        pub auto_accent: TemplateChild<adw::SwitchRow>,
 
         #[template_child]
         pub use_album_art_as_bg: TemplateChild<adw::ExpanderRow>,
@@ -97,6 +99,10 @@ impl UIPreferences {
         let recent_playlists_count = imp.recent_playlists_count.get();
         ui_settings
             .bind("recent-playlists-count", &recent_playlists_count, "value")
+            .build();
+        let auto_accent = imp.auto_accent.get();
+        ui_settings
+            .bind("auto-accent", &auto_accent, "active")
             .build();
         let use_album_art_as_bg = imp.use_album_art_as_bg.get();
         let bg_blur_radius = imp.bg_blur_radius.get();

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,6 +37,7 @@ use image::{imageops::FilterType, DynamicImage};
 use libblur::{stack_blur, FastBlurChannels, ThreadingPolicy};
 use mpd::Subsystem;
 use std::{cell::RefCell, ops::Deref, path::PathBuf, thread, time::Duration};
+use auto_palette::{ImageData, Palette, Theme, color::RGB};
 
 #[derive(Debug)]
 pub struct BlurConfig {
@@ -71,11 +72,22 @@ fn run_blur(di: &DynamicImage, config: &BlurConfig) -> gdk::MemoryTexture {
     )
 }
 
-pub enum BlurMessage {
-    New(PathBuf, BlurConfig), // Load new image at FULL PATH & blur with given configuration. Will fade.
-    Update(BlurConfig),       // Re-blur current image but do not fade.
-    Clear,                    // Clears last-blurred cache.
-    Result(gdk::MemoryTexture, bool), // GPU texture and whether to fade to this one.
+fn get_dominant_color(img: &DynamicImage) -> RGB {
+    let colors = img.as_rgb8().unwrap().pixels().flat_map(|pixel| {
+        [pixel[0], pixel[1], pixel[2], 255]
+    }).collect::<Vec::<u8>>();
+
+    let palette = Palette::<f32>::extract(&ImageData::new(img.width(), img.height(), &colors).unwrap()).unwrap();
+
+    palette.find_swatches_with_theme(1, Theme::Colorful).first().unwrap().color().to_rgb()
+}
+
+
+pub enum WindowMessage {
+    NewBackground(PathBuf, BlurConfig), // Load new image at FULL PATH & blur with given configuration. Will fade.
+    UpdateBackground(BlurConfig),       // Re-blur current image but do not fade.
+    ClearBackground,                    // Clears last-blurred cache.
+    Result(gdk::MemoryTexture, Option<RGB>, bool), // GPU texture and whether to fade to this one.
     Stop,
 }
 
@@ -97,7 +109,7 @@ mod imp {
 
     use async_channel::Sender;
     use glib::Properties;
-    use gtk::{gdk, graphene, gsk};
+    use gtk::{gdk, graphene, gsk, CssProvider};
     use image::io::Reader;
     use utils::settings_manager;
 
@@ -156,7 +168,7 @@ mod imp {
         pub bg_opacity: Cell<f64>,
         pub bg_paintable: FadePaintable,
         pub player: OnceCell<Player>,
-        pub sender_to_bg: OnceCell<Sender<BlurMessage>>, // sending a None will terminate the thread
+        pub sender_to_bg: OnceCell<Sender<WindowMessage>>, // sending a None will terminate the thread
         pub bg_handle: OnceCell<gio::JoinHandle<()>>,
         pub prev_size: Cell<(u32, u32)>,
 
@@ -177,8 +189,13 @@ mod imp {
         pub visualizer_use_splines: Cell<bool>,
         #[property(get, set)]
         pub visualizer_stroke_width: Cell<f64>,
+        #[property(get, set)]
+        pub auto_accent: Cell<bool>,
         pub tick_callback: RefCell<Option<gtk::TickCallbackId>>,
         pub fft_data: OnceCell<Arc<Mutex<(Vec<f32>, Vec<f32>)>>>,
+        pub accent_color: RefCell<Option<RGB>>,
+
+        pub provider: CssProvider,
     }
 
     #[glib::object_subclass]
@@ -283,6 +300,11 @@ mod imp {
                 .get_only()
                 .build();
 
+            settings
+                .bind("auto-accent", obj, "auto-accent")
+                .get_only()
+                .build();
+
             self.set_always_redraw(self.use_visualizer.get());
             settings.connect_changed(
                 Some("use-visualizer"),
@@ -350,10 +372,15 @@ mod imp {
                 ),
             );
 
-            // Set up blur thread
-            let (sender_to_bg, bg_receiver) = async_channel::unbounded::<BlurMessage>();
+            // Set up accent colour provider
+            if let Some(display) = gdk::Display::default() {
+                gtk::style_context_add_provider_for_display(&display, &self.provider, gtk::STYLE_PROVIDER_PRIORITY_USER);
+            }
+
+            // Set up blur & accent thread
+            let (sender_to_bg, bg_receiver) = async_channel::unbounded::<WindowMessage>();
             let _ = self.sender_to_bg.set(sender_to_bg);
-            let (sender_to_fg, fg_receiver) = async_channel::bounded::<BlurMessage>(1); // block background thread until sent
+            let (sender_to_fg, fg_receiver) = async_channel::bounded::<WindowMessage>(1); // block background thread until sent
             let bg_handle = gio::spawn_blocking(move || {
                 println!("Starting background blur thread...");
                 let settings = settings_manager().child("ui");
@@ -363,7 +390,7 @@ mod imp {
                 'outer: loop {
                     let curr_path_mut = curr_path.as_mut();
                     // Check if there is work to do (block until there is)
-                    let mut last_msg: BlurMessage = bg_receiver
+                    let mut last_msg: WindowMessage = bg_receiver
                         .recv_blocking()
                         .expect("Fatal: invalid message sent to window's blur thread");
                     // In case the queue has more than one item, get the last one.
@@ -373,7 +400,7 @@ mod imp {
                             .expect("Fatal: invalid message sent to window's blur thread");
                     }
                     match last_msg {
-                        BlurMessage::New(path, config) => {
+                        WindowMessage::NewBackground(path, config) => {
                             if (curr_path_mut.is_some() && path != *curr_path_mut.unwrap())
                                 || curr_path.is_none()
                             {
@@ -383,8 +410,9 @@ mod imp {
                                 // we should still record the image data here as the next calls (with sizes)
                                 // will only be Updates.
                                 if config.width > 0 && config.height > 0 {
-                                    let _ = sender_to_fg.send_blocking(BlurMessage::Result(
+                                    let _ = sender_to_fg.send_blocking(WindowMessage::Result(
                                         run_blur(&di, &config),
+                                        Some(get_dominant_color(&di)),
                                         true,
                                     ));
                                     thread::sleep(Duration::from_millis(
@@ -392,16 +420,18 @@ mod imp {
                                             as u64,
                                     ));
                                 }
+
                                 curr_data.replace(di);
                             }
                             // Else no need to blur again
                             // (size/radius updates are never sent via this message)
                         }
-                        BlurMessage::Update(config) => {
+                        WindowMessage::UpdateBackground(config) => {
                             if let Some(data) = curr_data.as_ref() {
                                 if config.width > 0 && config.height > 0 {
-                                    let _ = sender_to_fg.send_blocking(BlurMessage::Result(
+                                    let _ = sender_to_fg.send_blocking(WindowMessage::Result(
                                         run_blur(data, &config),
+                                        Some(get_dominant_color(&data)),  // No need to update accent colour
                                         config.fade,
                                     ));
                                 }
@@ -413,11 +443,11 @@ mod imp {
                                 }
                             }
                         }
-                        BlurMessage::Clear => {
+                        WindowMessage::ClearBackground => {
                             curr_data = None;
                             curr_path = None;
                         }
-                        BlurMessage::Stop => {
+                        WindowMessage::Stop => {
                             break 'outer;
                         }
                         _ => unreachable!(), // we shouldn't ever send BlurResult to the child thread
@@ -439,7 +469,11 @@ mod imp {
                     let mut receiver = std::pin::pin!(fg_receiver);
                     while let Some(blur_msg) = receiver.next().await {
                         match blur_msg {
-                            BlurMessage::Result(tex, do_fade) => this.push_tex(Some(tex), do_fade),
+                            WindowMessage::Result(tex, maybe_accent, do_fade) => {
+                                this.push_tex(Some(tex), do_fade);
+                                let _ = this.accent_color.replace(maybe_accent);
+                                this.update_accent_color();
+                            }
                             _ => unreachable!(),
                         }
                     }
@@ -490,7 +524,13 @@ mod imp {
             if self.use_visualizer.get() {
                 let mutex = self.fft_data.get().unwrap();
                 let scale = self.visualizer_scale.get() as f32;
-                let fg = widget.color();
+                let fg: gdk::RGBA;
+                if let Some(rgb) = self.accent_color.borrow().as_ref() {
+                    fg = gdk::RGBA::new(rgb.r as f32 / 255.0, rgb.g as f32 / 255.0, rgb.b as f32 / 255.0, 1.0);
+                }
+                else {
+                    fg = widget.color();
+                }
                 // Halve configured opacity since we're drawing two channels
                 let width32 = widget.width() as f32;
                 let height32 = widget.height() as f32;
@@ -512,6 +552,44 @@ mod imp {
     impl AdwApplicationWindowImpl for EuphonicaWindow {}
 
     impl EuphonicaWindow {
+        pub fn set_auto_accent(&self, new: bool) {
+            let old = self.auto_accent.replace(new);
+            if old != new {
+                if new {
+                    self.obj().queue_background_update(false);
+                }
+                else {
+                    let _ = self.accent_color.take();
+                    self.update_accent_color();
+                }
+                self.obj().notify("auto-accent");
+            }
+        }
+
+        pub fn update_accent_color(&self) {
+            if let (Some(color), true) = (self.accent_color.borrow().as_ref(), self.auto_accent.get()) {
+                // Is the generated accent colour too bright?
+                // Luminance formula: L = 0.2126 * R + 0.7152 * G + 0.0722 * B
+                let lum = 0.2126 * color.r as f32 / 255.0 + 0.7152 * color.g as f32 / 255.0 + 0.0722 * color.b as f32 / 255.0;
+                if lum > 0.5 {
+                    self.provider.load_from_string(&format!(
+                        ":root {{ --accent-bg-color: rgb({}, {}, {}); --accent-fg-color: rgb(0 0 0 / 80%); }}",
+                        color.r, color.g, color.b
+                    ));
+                }
+                else {
+                    self.provider.load_from_string(&format!(
+                        ":root {{ --accent-bg-color: rgb({}, {}, {}); }}",
+                        color.r, color.g, color.b
+                    ));
+                }
+            }
+            else {
+                // If no accent colour is given, revert to system accent colour
+                self.provider.load_from_string("");
+            }
+        }
+
         /// Force window to be redrawn on each frame.
         ///
         /// This is currently necessary for the visualiser to get updated.
@@ -540,7 +618,7 @@ mod imp {
             height: f32,
             data: &[f32],
             scale: f32,
-            color: &gdk::RGBA,
+            color: &gdk::RGBA
         ) {
             let band_width = width / (data.len() as f32 - 1.0);
 
@@ -953,13 +1031,13 @@ impl EuphonicaWindow {
                             radius: settings.uint("bg-blur-radius"),
                             fade: true, // new image, must fade
                         };
-                        let _ = sender.send_blocking(BlurMessage::New(path, config));
+                        let _ = sender.send_blocking(WindowMessage::NewBackground(path, config));
                     } else {
-                        let _ = sender.send_blocking(BlurMessage::Clear);
+                        let _ = sender.send_blocking(WindowMessage::ClearBackground);
                         self.imp().push_tex(None, true);
                     }
                 } else {
-                    let _ = sender.send_blocking(BlurMessage::Clear);
+                    let _ = sender.send_blocking(WindowMessage::ClearBackground);
                     self.imp().push_tex(None, true);
                 }
             } else {
@@ -977,7 +1055,7 @@ impl EuphonicaWindow {
                 radius: settings.uint("bg-blur-radius"),
                 fade,
             };
-            let _ = sender.send_blocking(BlurMessage::Update(config));
+            let _ = sender.send_blocking(WindowMessage::UpdateBackground(config));
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -382,7 +382,6 @@ mod imp {
             let _ = self.sender_to_bg.set(sender_to_bg);
             let (sender_to_fg, fg_receiver) = async_channel::bounded::<WindowMessage>(1); // block background thread until sent
             let bg_handle = gio::spawn_blocking(move || {
-                println!("Starting background blur thread...");
                 let settings = settings_manager().child("ui");
                 // Cached here to avoid having to load the same image multiple times
                 let mut curr_data: Option<DynamicImage> = None;
@@ -553,7 +552,6 @@ mod imp {
 
     impl EuphonicaWindow {
         pub fn set_auto_accent(&self, new: bool) {
-            println!("Setting auto accent...");
             let old = self.auto_accent.replace(new);
             if old != new {
                 if new {

--- a/src/window.rs
+++ b/src/window.rs
@@ -189,7 +189,7 @@ mod imp {
         pub visualizer_use_splines: Cell<bool>,
         #[property(get, set)]
         pub visualizer_stroke_width: Cell<f64>,
-        #[property(get, set)]
+        #[property(get, set = Self::set_auto_accent)]
         pub auto_accent: Cell<bool>,
         pub tick_callback: RefCell<Option<gtk::TickCallbackId>>,
         pub fft_data: OnceCell<Arc<Mutex<(Vec<f32>, Vec<f32>)>>>,
@@ -553,6 +553,7 @@ mod imp {
 
     impl EuphonicaWindow {
         pub fn set_auto_accent(&self, new: bool) {
+            println!("Setting auto accent...");
             let old = self.auto_accent.replace(new);
             if old != new {
                 if new {

--- a/src/window.rs
+++ b/src/window.rs
@@ -572,14 +572,29 @@ mod imp {
                 // Luminance formula: L = 0.2126 * R + 0.7152 * G + 0.0722 * B
                 let lum = 0.2126 * color.r as f32 / 255.0 + 0.7152 * color.g as f32 / 255.0 + 0.0722 * color.b as f32 / 255.0;
                 if lum > 0.5 {
-                    self.provider.load_from_string(&format!(
-                        ":root {{ --accent-bg-color: rgb({}, {}, {}); --accent-fg-color: rgb(0 0 0 / 80%); }}",
+                    self.provider.load_from_string(&format!("
+:root {{
+    --accent-bg-color: rgb({}, {}, {});
+    --accent-fg-color: rgb(0 0 0 / 80%);
+}}
+.fg-auto-accent {{
+    color: rgb({}, {}, {});
+}}
+",
+                        color.r, color.g, color.b,
                         color.r, color.g, color.b
                     ));
                 }
                 else {
-                    self.provider.load_from_string(&format!(
-                        ":root {{ --accent-bg-color: rgb({}, {}, {}); }}",
+                    self.provider.load_from_string(&format!("
+:root {{
+    --accent-bg-color: rgb({}, {}, {});
+}}
+.fg-auto-accent {{
+    color: rgb({}, {}, {});
+}}
+",
+                        color.r, color.g, color.b,
                         color.r, color.g, color.b
                     ));
                 }

--- a/src/window.ui
+++ b/src/window.ui
@@ -38,6 +38,9 @@
                 <property name="vexpand">true</property>
                 <property name="sidebar">
                   <object class="AdwNavigationPage">
+                    <style>
+                      <class name="light-right-edge"/>
+                    </style>
                     <property name="title">Euphonica</property>
                     <property name="child">
                       <object class="AdwToolbarView">


### PR DESCRIPTION
This PR adds automatic accents to the UI. The background accent colour is picked from the album art. If it is too bright, the foreground accent colour (used for some button labels, for example) will be set to black.

Additionally, the UI has been slightly reorganised. The bottom bar is where most of the changes happened. The new design allows the seekbar to always have sufficient width regardless of song and album title, which now live on another row. The right-hand pane used in Queue View also received minor touchups.

Thanks to the newly available space, I've also thrown in a bitrate readout, updated every second along the seekbar. Low-hanging fruit but I only got around to adding it now.

