### PR TITLE
Prioritise idle tasks whenever needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.90.3"
+version = "0.90.4"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.90.3"
+version = "0.90.4"
 edition = "2021"
 
 [dev-dependencies]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.90.3',
+          version: '0.90.4',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
This PR makes the child client prioritise idle messages without being blocked for undefined periods by adding a mechanism to inform it that whenever it could safely enter idle mode and return immediately.

This fixes #38 and #50.