### PR TITLE
Background MPRIS capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.90.4"
+version = "0.91.0"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.91.0"
+version = "0.92.0"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.91.0"
+version = "0.92.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 
 An MPD frontend with delusions of grandeur. 
 
+It exists to sate my need for something that's got the bling and the features to back that bling up.
+
 ## Features
 - Responsive GTK4 LibAdwaita UI for most MPD features, from basic things like playback controls, queue reordering and ReplayGain to things like output control, crossfade and MixRamp configuration
+- Integrated MPRIS client with background run supported. The background instance can be reopened via your shell's MPRIS applet, the "Background applications" section in GNOME's quick settings shade (if installed via Flatpak) or simply by launching Euphonica again.
 - Built-in, customisable spectrum visualiser, reading from MPD FIFO or system PipeWire
 - Automatic accent colours based on album art (optional)
 - Rate albums (requires MPD 0.24+)
@@ -27,7 +30,6 @@ An MPD frontend with delusions of grandeur.
 - Album wikis & artist bios are supported too
 - All externally-acquired metadata are cached locally & persisted on disk to avoid needless API calls
 - Volume knob with dBFS readout support ('cuz why not?)
-- MPRIS support (can be disabled if you're running `mpdris2` instead)
 - User-friendly configuration UI & GSettings backend
 - MPD passwords are securely stored in your user's login keyring
 - Commands are bundled into lists for efficient MPD-side processing where possible.
@@ -99,7 +101,7 @@ It is the most lightweight option, but has only been tested on Arch Linux.
   - `rustup` >= 1.27
   - `meson` >= 1.5
   - `gettext` >= 0.23
-  - `mpd` >= 0.21 (Euphonica relies on the new filter syntax)
+  - `mpd` >= 0.24 (Euphonica relies on the new filter syntax and expanded tagging)
   
     If you are on Arch Linux, `gettext` should have been installed as part of the `base-devel` metapackage, which also includes `git` (to clone this repo :) ).
 
@@ -141,7 +143,6 @@ Euphonica is developed with Beets tagging in mind and can take advantage of its 
 Most libraries, especially those that ran well with other MPD clients like [Cantata](https://github.com/CDrummond/cantata), should require no reorganisation.
 
 ## TODO
-- Local storage management UI (to allow re-fetching metadata, clearing album art cache and the like)
 - Support more stickers-based features:
   - Recently played
   - Per-song ratings

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -36,7 +36,6 @@
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.client" path="/org/euphonica/Euphonica/client/">
-		<!-- TODO: bool key for whether there's a password. Store password with oo7. -->
 		<key name="mpd-host" type="s">
 			<default>'localhost'</default>
 		</key>
@@ -250,6 +249,17 @@
 		</key>
 		<key name="last-window-height" type="i">
 			<default>400</default>
+		</key>
+
+		<!-- Background & autostart -->
+		<key name="run-in-background" type="b">
+			<default>false</default>
+		</key>
+		<key name="autostart" type="b">
+			<default>false</default>
+		</key>
+		<key name="start-minimized" type="b">
+			<default>true</default>
 		</key>
 	</schema>
 

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -65,6 +65,15 @@
   </screenshots>
 
   <releases>
+    <release version="0.92.0-alpha" date="2025-06-14">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.92.0-alpha</url>
+      <description>
+        <p>New: Background mode. Euphonica can now run in the background, allowing it to serve as your MPRIS daemon. Visualisation backends and album art blur thread will be shut down upon entering background mode, reducing CPU usage to pretty much zero. Polling will still be performed to support shell applets with seekbars (GNOME does with an extension).</p>
+        <p>New: Command-line argument to start Euphonica minimised (--minimized). This allows setting up autostart scripts.</p>
+        <p>Fix: Playback controls are now properly centered instead of being forced to the right by long titles (which will scroll like a marquee instead).</p>
+        <p>Fix: Album info and artist bio spinners not going away in case no metadata could be found.</p>
+      </description>
+    </release>
     <release version="0.91.0-alpha" date="2025-05-24">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.91.0-alpha</url>
       <description>

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -25,6 +25,7 @@
     </p>
     <ul>
       <li>Responsive GTK4 LibAdwaita UI for most MPD features, from basic things like playback controls, queue reordering and ReplayGain to things like output control, crossfade and MixRamp configuration</li>
+      <li>Integrated MPRIS client with background running supported (via the XDG Background protocol).</li>
       <li>Built-in, customisable spectrum visualiser, reading from MPD FIFO or system PipeWire.</li>
       <li>Rate albums (requires MPD 0.24+)</li>
       <li>Live bitrate readout + audio quality indicators (lossy, lossless, hi-res, DSD) for individual songs as well as albums &amp; detailed format printout</li>
@@ -39,7 +40,6 @@
       <li>Album wikis &amp; artist bios are supported too</li>
       <li>All externally-acquired metadata are cached locally &amp; persisted on disk to avoid needless API calls</li>
       <li>Volume knob with dBFS readout support ('cuz why not?)</li>
-      <li>MPRIS support (can be disabled if you're running `mpdris2` instead)</li>
       <li>User-friendly configuration UI &amp; GSettings backend</li>
       <li>MPD passwords are securely stored in your user's login keyring</li>
       <li>Commands are bundled into lists for efficient MPD-side processing where possible.</li>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.91.0',
+          version: '0.92.0',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/application.rs
+++ b/src/application.rs
@@ -29,7 +29,6 @@ use crate::{
     utils, EuphonicaWindow
 };
 use adw::subclass::prelude::*;
-use glib::clone;
 use gtk::{gio, glib};
 use std::{
     cell::{Cell, OnceCell, RefCell},
@@ -67,9 +66,6 @@ pub fn update_xdg_background_request() {
 
         if let Ok(response) = response {
             let state_settings = utils::settings_manager().child("state");
-
-            println!("Autostart: {}", response.auto_start());
-            println!("Background: {}", run_in_background && response.run_in_background());
 
             // Might have to turn them off if system replies negatively
             let _ = state_settings.set_boolean("autostart", response.auto_start());

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -203,7 +203,6 @@ impl Cache {
                                         if let Some(album) = res {
                                             doc_cache.write_album_meta(&key, &album)
                                                 .expect("Unable to store downloaded album meta");
-                                            let _ = fg_sender.send_blocking(ProviderMessage::AlbumMetaAvailable(folder_uri));
                                         }
                                         else {
                                             // Push an empty AlbumMeta to block further calls for this album.
@@ -211,6 +210,7 @@ impl Cache {
                                             doc_cache.write_album_meta(&key, &models::AlbumMeta::from_key(&key))
                                                 .expect("Unable to store placeholder album meta");
                                         }
+                                        let _ = fg_sender.send_blocking(ProviderMessage::AlbumMetaAvailable(folder_uri));
                                         sleep_after_request();
                                     }
                                 }
@@ -250,7 +250,6 @@ impl Cache {
                                             }
                                             doc_cache.write_artist_meta(&key, &artist)
                                                 .expect("Unable to write downloaded artist meta");
-                                            let _ = fg_sender.send_blocking(ProviderMessage::ArtistMetaAvailable(name));
                                         }
 
                                         else {
@@ -258,6 +257,7 @@ impl Cache {
                                             println!("No artist meta could be found for {:?}. Pushing empty document...", &key);
                                             doc_cache.write_artist_meta(&key, &models::ArtistMeta::from_key(&key)).expect("Unable to write downloaded artist meta");
                                         }
+                                        let _ = fg_sender.send_blocking(ProviderMessage::ArtistMetaAvailable(name));
                                         sleep_after_request();
                                     }
                                 }

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -271,7 +271,7 @@ end;
         }
         else {
             tx.execute(
-                "delete from albums where name = ?1",
+                "delete from artists where name = ?1",
                 params![&artist.name]
             ).map_err(|e| Error::DbError(e))?;
         }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -211,6 +211,7 @@ mod background {
     }
 
     pub fn fetch_all_albums(client: &mut mpd::Client, sender_to_fg: &Sender<AsyncClientMessage>) {
+        println!("FETCH_ALL_ALBUMS called");
         fetch_albums_by_query(client, &Query::new(), |info| {
             sender_to_fg.send_blocking(AsyncClientMessage::AlbumBasicInfoDownloaded(info))
         });
@@ -674,14 +675,6 @@ impl MpdWrapper {
         } else {
             panic!("Cannot queue background task (background sender not initialised)");
         }
-    }
-
-    pub fn fetch_albums(&self) {
-        self.queue_background(BackgroundTask::FetchAlbums, false);
-    }
-
-    pub fn fetch_artists(&self, use_albumartists: bool) {
-        self.queue_background(BackgroundTask::FetchArtists(use_albumartists), false);
     }
 
     pub fn queue_connect(&self) {

--- a/src/common/album.rs
+++ b/src/common/album.rs
@@ -2,7 +2,7 @@ use gtk::gdk::Texture;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{OnceCell, RefCell};
 use time::Date;
 
 use super::{artists_to_string, parse_mb_artist_tag, ArtistInfo, QualityGrade, SongInfo, Stickers};

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,7 +8,7 @@ pub mod paintables;
 pub mod song;
 pub mod sticker;
 
-pub use sticker::{Stickers, Thumbs};
+pub use sticker::Stickers;
 pub use album::{Album, AlbumInfo};
 pub use artist::{artists_to_string, parse_mb_artist_tag, Artist, ArtistInfo};
 pub use inode::{INode, INodeType};

--- a/src/gtk/player/bar.ui
+++ b/src/gtk/player/bar.ui
@@ -173,12 +173,12 @@
                     <property name="valign">center</property>
                     <property name="orientation">1</property>
                     <child>
-                      <object class="GtkCenterBox">
+                      <object class="EuphonicaRatioCenterBox" id="full_layout_box">
+                        <property name="max-center-ratio">0.95</property>
                         <property name="hexpand">true</property>
-                        <property name="shrink-center-last">true</property>
                         <property name="margin-start">11</property>
                         <property name="margin-end">11</property>
-                        <property name="start-widget">
+                        <property name="left-widget">
                           <object class="GtkRevealer" id="infobox_revealer">
                             <property name="transition-type">slide-right</property>
                             <property name="transition-duration">1000</property>
@@ -194,8 +194,9 @@
                             <property name="id">playback-controls</property>
                           </object>
                         </property>
-                        <property name="end-widget">
+                        <property name="right-widget">
                           <object class="GtkBox" id="output_section">
+                            <property name="halign">end</property>
                             <property name="visible">false</property>
                             <child>
                               <object class="GtkButton" id="prev_output">

--- a/src/gtk/preferences/integrations.ui
+++ b/src/gtk/preferences/integrations.ui
@@ -19,18 +19,19 @@
 				<child>
 					<object class="AdwSwitchRow" id="run_in_background">
 						<property name="title" translatable="true">Run in background</property>
-						<property name="subtitle" translatable="true">Allow Euphonica to keep running after its window is closed.</property>
+						<property name="subtitle" translatable="true">Allow Euphonica to keep running after its window is closed. If Euphonica is installed via Flatpak and your shell supports the XDG Background protocol, Euphonica can additionally show up in your shell's background apps section.</property>
 					</object>
 				</child>
 				<child>
 					<object class="AdwSwitchRow" id="autostart">
 						<property name="title" translatable="true">Autostart</property>
-						<property name="subtitle" translatable="true">Start Euphonica on system startup.</property>
+						<property name="subtitle" translatable="true">Start Euphonica on shell login. This option only works when installed via Flatpak and on shells supporting the XDG Background protocol. For other setups, please use their preferred autostarting mechanisms.</property>
 					</object>
 				</child>
 				<child>
 					<object class="AdwSwitchRow" id="start_minimized">
-						<property name="title" translatable="true">Start minimised</property>
+						<property name="title" translatable="true">Autostart minimised</property>
+						<property name="subtitle" translatable="true">You may also launch Euphonica minimised using the --minimized command-line argument.</property>
 					</object>
 				</child>
 			</object>

--- a/src/gtk/preferences/integrations.ui
+++ b/src/gtk/preferences/integrations.ui
@@ -8,12 +8,29 @@
 
 		<child>
 			<object class="AdwPreferencesGroup">
-				<property name="title" translatable="true">MPRIS</property>
-				<property name="description" translatable="true">Control Euphonica from your shell or other applications via the MPRIS protocol.</property>
+				<property name="title" translatable="true">MPRIS Daemon</property>
+				<property name="description" translatable="true">Control your MPD instance via keyboard shortcuts and shell applets without having to keep the Euphonica window open.</property>
 				<child>
 					<object class="AdwSwitchRow" id="enable_mpris">
 						<property name="title" translatable="true">Enable MPRIS integration</property>
 						<property name="subtitle" translatable="true">Requires a relaunch.</property>
+					</object>
+				</child>
+				<child>
+					<object class="AdwSwitchRow" id="run_in_background">
+						<property name="title" translatable="true">Run in background</property>
+						<property name="subtitle" translatable="true">Allow Euphonica to keep running after its window is closed.</property>
+					</object>
+				</child>
+				<child>
+					<object class="AdwSwitchRow" id="autostart">
+						<property name="title" translatable="true">Autostart</property>
+						<property name="subtitle" translatable="true">Start Euphonica on system startup.</property>
+					</object>
+				</child>
+				<child>
+					<object class="AdwSwitchRow" id="start_minimized">
+						<property name="title" translatable="true">Start minimised</property>
 					</object>
 				</child>
 			</object>

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -63,7 +63,6 @@ mod imp {
         #[template_child]
         pub content_view: TemplateChild<AlbumContentView>,
 
-        pub album_list: gio::ListStore,
         // Search & filter models
         pub search_filter: gtk::CustomFilter,
         pub sorter: gtk::CustomSorter,
@@ -98,7 +97,6 @@ mod imp {
                 grid_view: TemplateChild::default(),
                 content_page: TemplateChild::default(),
                 content_view: TemplateChild::default(),
-                album_list: gio::ListStore::new::<Album>(),
                 // Search & filter models
                 search_filter: gtk::CustomFilter::default(),
                 sorter: gtk::CustomSorter::default(),
@@ -199,7 +197,7 @@ impl AlbumView {
             .library
             .set(library.clone())
             .expect("Cannot init AlbumView with Library");
-        self.setup_gridview(client_state.clone(), cache.clone());
+        self.setup_gridview(cache.clone());
 
         let content_view = self.imp().content_view.get();
         content_view.setup(library.clone(), client_state, cache);
@@ -518,35 +516,9 @@ impl AlbumView {
         self.imp().nav_view.push_by_tag("content");
     }
 
-    fn setup_gridview(&self, client_state: ClientState, cache: Rc<Cache>) {
-        // Refresh upon reconnection.
-        // User-initiated refreshes will also trigger a reconnection, which will
-        // in turn trigger this.
-        client_state.connect_notify_local(
-            Some("connection-state"),
-            clone!(
-                #[weak(rename_to = this)]
-                self,
-                move |state, _| {
-                    if state.get_connection_state() == ConnectionState::Connected {
-                        this.clear();
-                        this.imp().library.get().unwrap().init_albums();
-                    }
-                }
-            ),
-        );
-        client_state.connect_closure(
-            "album-basic-info-downloaded",
-            false,
-            closure_local!(
-                #[strong(rename_to = this)]
-                self,
-                move |_: ClientState, album: Album| {
-                    this.add_album(album);
-                }
-            ),
-        );
+    fn setup_gridview(&self, cache: Rc<Cache>) {
         // Setup search bar
+        let album_list = self.imp().library.get().unwrap().albums();
         let search_bar = self.imp().search_bar.get();
         let search_entry = self.imp().search_entry.get();
         search_bar.connect_entry(&search_entry);
@@ -559,7 +531,7 @@ impl AlbumView {
 
         // Chain search & sort. Put sort after search to reduce number of sort items.
         let search_model = gtk::FilterListModel::new(
-            Some(self.imp().album_list.clone()),
+            Some(album_list.clone()),
             Some(self.imp().search_filter.clone()),
         );
         search_model.set_incremental(true);
@@ -652,14 +624,5 @@ impl AlbumView {
                 this.on_album_clicked(&album);
             }
         ));
-    }
-
-    fn add_album(&self, album: Album) {
-        self.imp().album_list.append(&album);
-        // self.imp().album_count.set_label(&self.imp().album_list.n_items().to_string());
-    }
-
-    pub fn clear(&self) {
-        self.imp().album_list.remove_all();
     }
 }

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -2,7 +2,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{
     gio,
-    glib::{self, closure_local},
+    glib::{self},
     CompositeTemplate, ListItem, SignalListItemFactory, SingleSelection,
 };
 use std::{cell::Cell, cmp::Ordering, rc::Rc};
@@ -12,7 +12,7 @@ use glib::{clone, Properties};
 use super::{AlbumCell, AlbumContentView, Library};
 use crate::{
     cache::Cache,
-    client::{ClientState, ConnectionState},
+    client::ClientState,
     common::Album,
     utils::{g_cmp_options, g_cmp_str_options, g_search_substr, settings_manager},
 };

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -308,7 +308,6 @@ impl Library {
     }
 
     pub fn get_folder_contents(&self, uri: &str) {
-        println!("get_folder_contents...");
         self.client()
             .queue_background(BackgroundTask::FetchFolderContents(uri.to_owned()), true);
     }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -12,6 +12,8 @@ use adw::subclass::prelude::*;
 use mpd::{error::Error as MpdError, search::Operation, EditAction, Query, SaveMode, Term};
 
 mod imp {
+    use std::cell::{Cell, RefCell};
+
     use super::*;
 
     #[derive(Debug)]
@@ -29,6 +31,13 @@ mod imp {
         pub playlists: gio::ListStore,
         pub albums: gio::ListStore,
         pub artists: gio::ListStore,
+
+        // Folder view
+        // Files and folders
+        pub folder_history: RefCell<Vec<String>>,
+        pub folder_curr_idx: Cell<usize>, // 0 means at root.
+        pub folder_inodes: gio::ListStore,
+
         pub cache: OnceCell<Rc<Cache>>,
     }
 
@@ -44,6 +53,10 @@ mod imp {
                 artists: gio::ListStore::new::<Artist>(),
                 client: OnceCell::new(),
                 cache: OnceCell::new(),
+
+                folder_history: RefCell::new(Vec::new()),
+                folder_curr_idx: Cell::new(0),
+                folder_inodes: gio::ListStore::new::<INode>(),
             }
         }
     }
@@ -295,6 +308,7 @@ impl Library {
     }
 
     pub fn get_folder_contents(&self, uri: &str) {
+        println!("get_folder_contents...");
         self.client()
             .queue_background(BackgroundTask::FetchFolderContents(uri.to_owned()), true);
     }

--- a/src/library/folder_view.rs
+++ b/src/library/folder_view.rs
@@ -314,6 +314,16 @@ impl FolderView {
         self.imp().loading_stack.set_visible_child_name("loading");
     }
 
+    pub fn reset(&self, state: &ClientState) {
+        println!("Attempting to reset folder view...");
+        if state.get_connection_state() == ConnectionState::Connected {
+            // Newly-connected? Reset path to ""
+            let _ = self.imp().history.replace(Vec::new()); 
+            let _ = self.imp().curr_idx.replace(0);
+            self.imp().library.get().unwrap().get_folder_contents("");
+        }
+    }
+
     pub fn setup(&self, library: Library, cache: Rc<Cache>, client_state: ClientState) {
         self.setup_sort();
         self.setup_search();
@@ -322,21 +332,6 @@ impl FolderView {
             .library
             .set(library.clone())
             .expect("Cannot init FolderView with Library");
-        client_state.connect_notify_local(
-            Some("connection-state"),
-            clone!(
-                #[weak(rename_to = this)]
-                self,
-                move |state, _| {
-                    if state.get_connection_state() == ConnectionState::Connected {
-                        // Newly-connected? Reset path to ""
-                        let _ = this.imp().history.replace(Vec::new());
-                        let _ = this.imp().curr_idx.replace(0);
-                        this.imp().library.get().unwrap().get_folder_contents("");
-                    }
-                }
-            ),
-        );
         client_state.connect_closure(
             "folder-contents-downloaded",
             false,
@@ -354,6 +349,18 @@ impl FolderView {
                             .extend_from_slice(entries.borrow::<Vec<INode>>().as_ref());
                         this.imp().loading_stack.set_visible_child_name("content");
                     }
+                }
+            ),
+        );
+        // Always reset on window creation (when coming back from background mode)
+        self.reset(&client_state);
+        client_state.connect_notify_local(
+            Some("connection-state"),
+            clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |state, _| {
+                    this.reset(&state);
                 }
             ),
         );

--- a/src/library/folder_view.rs
+++ b/src/library/folder_view.rs
@@ -315,7 +315,6 @@ impl FolderView {
     }
 
     pub fn reset(&self, state: &ClientState) {
-        println!("Attempting to reset folder view...");
         if state.get_connection_state() == ConnectionState::Connected {
             // Newly-connected? Reset path to ""
             let _ = self.imp().history.replace(Vec::new()); 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
 mod application;
 mod cache;
 mod client;
@@ -69,6 +70,14 @@ fn main() -> glib::ExitCode {
     // desktop features such as file opening and single-instance applications.
     let app = EuphonicaApplication::new("io.github.htkhiem.Euphonica", &gio::ApplicationFlags::empty());
     app.connect_startup(|_| load_css());
+    app.add_main_option(
+        "minimized",
+        glib::Char::from(b'm'),
+        glib::OptionFlags::IN_MAIN | glib::OptionFlags::OPTIONAL_ARG,
+        glib::OptionArg::None,
+        "Start Euphonica without opening a window",
+        None
+    );
 
     // Run the application. This function will block until the application
     // exits. Upon return, we have our exit code to return to the shell. (This

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -1,4 +1,4 @@
-use glib::{clone, closure_local, BoxedAnyObject};
+use glib::{clone, closure_local};
 use gtk::{
     gdk,
     glib::{self, Variant},
@@ -6,12 +6,11 @@ use gtk::{
     subclass::prelude::*,
     CompositeTemplate,
 };
-use mpd::output::Output;
 use std::cell::{Cell, RefCell};
 
 use crate::{
     cache::placeholders::ALBUMART_PLACEHOLDER,
-    common::{Marquee, QualityGrade},
+    common::Marquee,
     utils::settings_manager,
 };
 

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -28,7 +28,7 @@ mod imp {
 
     use glib::{subclass::Signal, Properties};
 
-    use crate::player::seekbar::Seekbar;
+    use crate::player::{ratio_center_box::RatioCenterBox, seekbar::Seekbar};
 
     use super::*;
 
@@ -38,6 +38,8 @@ mod imp {
     pub struct PlayerBar {
         #[template_child]
         pub multi_layout_view: TemplateChild<adw::MultiLayoutView>,
+        #[template_child]
+        pub full_layout_box: TemplateChild<RatioCenterBox>,
         // Left side: current song info
         #[template_child]
         pub albumart: TemplateChild<gtk::Image>,

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -305,14 +305,15 @@ impl PlayerBar {
             .sync_create()
             .build();
 
+        self.update_outputs(&player);
         player.connect_closure(
             "outputs-changed",
             false,
             closure_local!(
                 #[strong(rename_to = this)]
                 self,
-                move |player: Player, outputs: BoxedAnyObject| {
-                    this.update_outputs(player, outputs.borrow::<Vec<Output>>().as_ref());
+                move |player: Player| {
+                    this.update_outputs(&player);
                 }
             ),
         );
@@ -360,10 +361,13 @@ impl PlayerBar {
         }
     }
 
-    fn update_outputs(&self, player: Player, outputs: &[Output]) {
+    fn update_outputs(&self, player: &Player) {
+        let outputs = player.outputs();
+        let outputs: Vec<glib::BoxedAnyObject> = (0..outputs.n_items())
+            .map(|i| outputs.item(i).unwrap().downcast::<glib::BoxedAnyObject>().unwrap()).collect();
         let section = self.imp().output_section.get();
         let stack = self.imp().output_stack.get();
-        let new_len = outputs.len();
+        let new_len = outputs.len() as usize;
         if new_len == 0 {
             section.set_visible(false);
         } else {
@@ -391,18 +395,18 @@ impl PlayerBar {
                 // Note that this does not re-populate the stack, so the visible
                 // child won't be changed.
                 for (w, o) in output_widgets.iter().zip(outputs) {
-                    w.update_state(o);
+                    w.update_state(&o.borrow());
                 }
             } else {
                 // Need to add more widgets
                 // Override state of all current widgets. Personal reminder:
                 // zip() is auto-truncated to the shorter of the two iters.
-                for (w, o) in output_widgets.iter().zip(outputs) {
-                    w.update_state(o);
+                for (w, o) in output_widgets.iter().zip(&outputs) {
+                    w.update_state(&o.borrow());
                 }
                 output_widgets.reserve_exact(new_len - curr_len);
                 for o in &outputs[curr_len..] {
-                    let w = MpdOutput::from_output(o, &player);
+                    let w = MpdOutput::from_output(&o.borrow(), &player);
                     stack.add_child(&w);
                     output_widgets.push(w);
                 }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -180,7 +180,7 @@ mod imp {
     use glib::{
         ParamSpec, ParamSpecBoolean, ParamSpecDouble, ParamSpecEnum, ParamSpecFloat, ParamSpecInt, ParamSpecObject, ParamSpecString, ParamSpecUInt, ParamSpecUInt64
     };
-    use mpd::Output;
+    
     use once_cell::sync::Lazy;
 
     pub struct Player {

--- a/src/player/fft_backends/fft.rs
+++ b/src/player/fft_backends/fft.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 // Option 2: read from local Pipewire output (works in Flatpak)
-use pipewire as pw;
 
 use mpd::status::AudioFormat;
 
@@ -54,7 +53,6 @@ pub fn try_open_pipe(
     // Bits per sample * 2 (stereo) * n_samples * 4 (safety factor)
     let buf_bytes = ((format.bits as usize * 8 * n_samples) as f64 / 8.0).ceil() as usize;
 
-    println!("FIFO buffer size: {} bytes", buf_bytes);
     let pipe = BufReader::with_capacity(buf_bytes, open_named_pipe_readonly(path)?);
     Ok(pipe)
 }
@@ -186,7 +184,6 @@ pub fn get_magnitudes(
     min_freq: f32,
     max_freq: f32,
 ) {
-    let samples_len_f32 = input_buf.len() as f32;
     blackman_harris_4term_inplace(input_buf);
 
     let fft_res = spectrum_analyzer::samples_fft_to_spectrum(

--- a/src/player/fft_backends/pipewire.rs
+++ b/src/player/fft_backends/pipewire.rs
@@ -135,11 +135,6 @@ impl FftBackend for PipeWireFftBackend {
                             .format
                             .parse(param)
                             .expect("Failed to parse param 'changed' to AudioInfoRaw");
-
-                        println!(
-                            "PipeWire stream format: {:?}",
-                            &user_data.format
-                        );
                     })
                     .process(move |stream, user_data| match stream.dequeue_buffer() {
                         None => {return;},
@@ -318,7 +313,6 @@ impl FftBackend for PipeWireFftBackend {
     }
 
     fn stop(&self) {
-        println!("Stopping pipewire thread");
         let fft_stop = self.fft_stop.clone();
         fft_stop.store(true, Ordering::Relaxed);
         if let Some(sender) = self.pw_sender.take() {

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -13,7 +13,6 @@ mod seekbar;
 use knob::VolumeKnob;
 use output::MpdOutput;
 use queue_row::QueueRow;
-use ratio_center_box::RatioCenterBox;
 
 pub use fft_backends::backend::FftStatus;
 pub use bar::PlayerBar;

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -1,4 +1,4 @@
-use glib::{clone, closure_local, BoxedAnyObject};
+use glib::{clone, closure_local};
 use gtk::{
     gdk,
     glib::{self, Variant},
@@ -6,12 +6,11 @@ use gtk::{
     subclass::prelude::*,
     CompositeTemplate,
 };
-use mpd::output::Output;
 use std::cell::{Cell, RefCell};
 
 use crate::{
     cache::placeholders::ALBUMART_PLACEHOLDER,
-    common::{paintables::FadePaintable, QualityGrade},
+    common::paintables::FadePaintable,
     utils::settings_manager,
 };
 
@@ -295,14 +294,15 @@ impl PlayerPane {
             .sync_create()
             .build();
 
+        self.update_outputs(&player);
         player.connect_closure(
             "outputs-changed",
             false,
             closure_local!(
                 #[strong(rename_to = this)]
                 self,
-                move |player: Player, outputs: BoxedAnyObject| {
-                    this.update_outputs(player, outputs.borrow::<Vec<Output>>().as_ref());
+                move |player: Player| {
+                    this.update_outputs(&player);
                 }
             ),
         );
@@ -350,10 +350,13 @@ impl PlayerPane {
         }
     }
 
-    fn update_outputs(&self, player: Player, outputs: &[Output]) {
+    fn update_outputs(&self, player: &Player) {
+        let outputs = player.outputs();
+        let outputs: Vec<glib::BoxedAnyObject> = (0..outputs.n_items())
+            .map(|i| outputs.item(i).unwrap().downcast::<glib::BoxedAnyObject>().unwrap()).collect();
         let section = self.imp().output_section.get();
         let stack = self.imp().output_stack.get();
-        let new_len = outputs.len();
+        let new_len = outputs.len() as usize;
         if new_len == 0 {
             section.set_visible(false);
         } else {
@@ -366,7 +369,7 @@ impl PlayerPane {
                 self.imp().next_output.set_visible(false);
             }
         }
-        // Handle new/removed outputs.
+        // Handle new/removed outputs
         // Pretty rare though...
         {
             let mut output_widgets = self.imp().output_widgets.borrow_mut();
@@ -381,18 +384,18 @@ impl PlayerPane {
                 // Note that this does not re-populate the stack, so the visible
                 // child won't be changed.
                 for (w, o) in output_widgets.iter().zip(outputs) {
-                    w.update_state(o);
+                    w.update_state(&o.borrow());
                 }
             } else {
                 // Need to add more widgets
                 // Override state of all current widgets. Personal reminder:
                 // zip() is auto-truncated to the shorter of the two iters.
-                for (w, o) in output_widgets.iter().zip(outputs) {
-                    w.update_state(o);
+                for (w, o) in output_widgets.iter().zip(&outputs) {
+                    w.update_state(&o.borrow());
                 }
                 output_widgets.reserve_exact(new_len - curr_len);
                 for o in &outputs[curr_len..] {
-                    let w = MpdOutput::from_output(o, &player);
+                    let w = MpdOutput::from_output(&o.borrow(), &player);
                     stack.add_child(&w);
                     output_widgets.push(w);
                 }

--- a/src/player/ratio_center_box.rs
+++ b/src/player/ratio_center_box.rs
@@ -6,16 +6,11 @@ mod imp {
 
     use super::*;
 
-    /// A fixed-ratio version of GtkCenterBox.
-    /// Given a centre ratio of C (0 < C < 1), this version always assigns
-    /// the centre widget C*100% of its width, centering it horizontally if
-    /// the centre widget does not expand to the allocated width. The left(right)
-    /// side always gets (1-C)/2*100% of the total width, and will be left-(right-)
-    /// aligned if they do not use up all the allocated width. All widgets will
-    /// be vertically top-aligned.
-    ///
+    /// A version of GtkCenterBox that tries to keep the centre widget always centered
+    /// and allocates it at least its minimum width.
+
     /// This widget follows height-for-width sizing with the following rules:
-    /// - Minimum or natural width is the center widget's minimum or natural width divided by C, rounded up
+    /// - Minimum or natural width is the sum of all child widgets' minimum or natural heights, rounded up.
     /// - Minimum or natural height is the maximum of the three widgets' minimum or natural heights.
     ///
     /// Minimum and natural baselines are not defined for this widget.
@@ -28,8 +23,11 @@ mod imp {
         pub center_widget: RefCell<Option<gtk::Widget>>,
         #[property(get, set = Self::set_right_widget)]
         pub right_widget: RefCell<Option<gtk::Widget>>,
-        #[property(get, set)]
-        pub center_ratio: Cell<f32>,
+
+        #[property(get, set, default = 0.95)]
+        pub max_center_ratio: Cell<f32>,
+        pub nat_center_width: Cell<i32>,
+        pub nat_side_width: Cell<i32>,
     }
 
     #[glib::object_subclass]
@@ -64,11 +62,12 @@ mod imp {
             } else {
                 (0, 0, -1, -1)
             };
-            let center_ratio = self.center_ratio.get();
             if orientation == gtk::Orientation::Horizontal {
+                self.nat_center_width.set(m_center.1);
+                self.nat_side_width.set(m_left.1.max(m_right.1));
                 (
-                    (m_center.0 as f32 / center_ratio).ceil() as i32,
-                    (m_center.0 as f32 / center_ratio).ceil() as i32,
+                    (m_center.0 as f32 + m_left.0 as f32 + m_right.0 as f32).ceil() as i32,
+                    (m_center.1 as f32 + m_left.1 as f32 + m_right.1 as f32).ceil() as i32,
                     -1,
                     -1,
                 )
@@ -83,18 +82,30 @@ mod imp {
         }
 
         fn size_allocate(&self, w: i32, h: i32, baseline: i32) {
-            let w_center = (w as f32 * self.center_ratio.get()).ceil() as i32;
-            let w_left = ((w - w_center) as f32 / 2.0).ceil() as i32;
-            let w_right = w - w_left - w_center;
-            // Allocate C*100% to the centre
+            let nat_side_width = self.nat_side_width.get();
+            let min_center_width = self.nat_center_width.get().min((w as f32 * self.max_center_ratio.get()).floor() as i32);
+            let available_center_width = w - 2 * nat_side_width;
+
+            let final_side_width: i32;
+            let final_center_width: i32;
+            if available_center_width < min_center_width {
+                // Shrink both sides symmetrically to keep centre widget centered
+                final_side_width = ((w - min_center_width) as f32 / 2.0).floor() as i32;
+                final_center_width = w - 2 * final_side_width;
+            }
+            else {
+                final_side_width = nat_side_width;
+                final_center_width = available_center_width;
+            }
+
             if let Some(widget) = self.center_widget.borrow().as_ref() {
-                widget.size_allocate(&gtk::Allocation::new(w_left + 1, 0, w_center, h), baseline);
+                widget.size_allocate(&gtk::Allocation::new(final_side_width + 1, 0, final_center_width, h), baseline);
             }
             if let Some(widget) = self.left_widget.borrow().as_ref() {
-                widget.size_allocate(&gtk::Allocation::new(0, 0, w_left, h), baseline);
+                widget.size_allocate(&gtk::Allocation::new(0, 0, final_side_width, h), baseline);
             }
             if let Some(widget) = self.right_widget.borrow().as_ref() {
-                widget.size_allocate(&gtk::Allocation::new(w_left + w_center + 1, 0, w_right, h), baseline);
+                widget.size_allocate(&gtk::Allocation::new(final_side_width + final_center_width + 1, 0, final_side_width, h), baseline);
             }
         }
 

--- a/src/preferences/library.rs
+++ b/src/preferences/library.rs
@@ -80,7 +80,7 @@ mod imp {
                 self,
                 move |_| {
                     if let Some(cache) = this.cache.get() {
-                        open::that(cache.get_app_cache_path());
+                        let _ = open::that(cache.get_app_cache_path());
                     }
                 }
             ));

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -82,6 +82,19 @@ impl Sidebar {
         Self::default()
     }
 
+    // Dirty hack to remove the highlight effect on hover
+    // (as the items themselves are toggle buttons already, there is no need
+    // for the ListBoxRows to do this)
+    pub fn hide_highlights(&self) {
+        let settings = utils::settings_manager().child("ui");
+        let recent_playlists_widget = self.imp().recent_playlists.get();
+        for idx in 0..settings.uint("recent-playlists-count") {
+            if let Some(row) = recent_playlists_widget.row_at_index(idx as i32) {
+                row.set_activatable(false);
+            }
+        }
+    }
+
     pub fn setup(&self, win: &EuphonicaWindow, app: &EuphonicaApplication) {
         let settings = utils::settings_manager().child("ui");
         let stack = win.get_stack();
@@ -192,21 +205,11 @@ impl Sidebar {
             ),
         );
 
-        // Dirty hack to remove the highlight effect on hover
-        // (as the items themselves are toggle buttons already, there is no need
-        // for the ListBoxRows to do this)
+        self.hide_highlights();
         playlists.connect_items_changed(clone!(
-            #[weak]
-            recent_playlists_widget,
-            #[strong]
-            settings,
-            move |_, _, _, _| {
-                for idx in 0..settings.uint("recent-playlists-count") {
-                    if let Some(row) = recent_playlists_widget.row_at_index(idx as i32) {
-                        row.set_activatable(false);
-                    }
-                }
-            }
+            #[weak(rename_to = this)]
+            self,
+            move |_, _, _, _| {this.hide_highlights();}
         ));
 
         // Hide the list widget when there is no playlist at all to avoid

--- a/src/window.rs
+++ b/src/window.rs
@@ -928,6 +928,9 @@ impl EuphonicaWindow {
 
         win.bind_state();
         win.setup_signals();
+
+        // Refresh background
+        win.queue_new_background();
         win
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -885,8 +885,8 @@ impl EuphonicaWindow {
         );
         win.imp().artist_view.setup(
             app.get_library(),
-            app.get_cache(),
             app.get_client().get_client_state(),
+            app.get_cache(),
         );
         win.imp().folder_view.setup(
             app.get_library(),

--- a/src/window.ui
+++ b/src/window.ui
@@ -177,6 +177,10 @@
         <attribute name="label" translatable="yes">_About Euphonica</attribute>
         <attribute name="action">app.about</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+      </item>
     </section>
   </menu>
 </interface>

--- a/src/window.ui
+++ b/src/window.ui
@@ -154,7 +154,7 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">_Toggle full screen</attribute>
+        <attribute name="label" translatable="yes">_Toggle Full Screen</attribute>
         <attribute name="action">app.fullscreen</attribute>
       </item>
       <item>
@@ -162,7 +162,7 @@
         <attribute name="action">app.refresh</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_Update database</attribute>
+        <attribute name="label" translatable="yes">_Update Database</attribute>
         <attribute name="action">app.update-db</attribute>
       </item>
       <item>


### PR DESCRIPTION
This PR allows Euphonica to run in the background as an MPRIS client.

Many people (me included) use multimedia buttons or a player applet in their shell's notification shade to control mpd without a foreground app. So far the solution had been to use something like `mpdris2`, which provides an always-on MPRIS client to control MPD. Euphonica, on the other hand, has had an MPRIS client for a while, but is a bit useless in that it goes down when you close the app window. Using both Euphonica and mpdris2 results in two player applets in the notification shade controlling the same thing.

So my solution is to use Euphonica itself as my background MPRIS client. Coupled with autostart, this negates the need for `mpdris2` completely. If background running is enabled, closing the Euphonica window leaves the app running in the background. 

When installed as Flatpak, you should also see an entry in GNOME (47+)'s background apps section:

![image](https://github.com/user-attachments/assets/d4386646-f7b4-4d64-b692-b62dedb82dfa)

 All future launches, including by clicking on the player applet in the notification shade, simply reopens the window to the existing process instead of starting a new one.

**Changes needed to enable background running**

- [x] Register background permission with the XDG background portal & hold gio::Application to keep app alive.
- [x] Move all ListStores to the controllers' side, which live as long as the gio::Application is held. This allows them to remain available for the next time the window is opened (without having to re-fetch). The view structs have their lifetimes bound to the window instead of the application and as such are yeeted as the window is closed.
- [x] Add a Quit option to stop Euphonica when background mode is enabled (currently the only way to stop it is to disable background mode before closing the window, or kill the process via Terminal or your GUI process monitor).
- [ ] Ensure all widgets explicitly update their states upon window creation too, not just upon app startup (currently some rely on the login success signal).
- [x] Pause the FFT & background blur thread when the app is in background mode.
- [x] Reconsider autostart strategy (might just ask the user to add an autostart entry in their init instead of relying on the sandbox-only XDG background portal).