### PR TITLE
v0.94.0-alpha: Local (UNIX) socket support & queue view scroll fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.93.2"
+version = "0.94.0"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "aho-corasick",
  "ashpd",
@@ -1024,6 +1044,7 @@ dependencies = [
  "r2d2_sqlite",
  "regex",
  "reqwest 0.12.5",
+ "resolve-path",
  "ringbuffer",
  "rusqlite",
  "rustc-hash 2.0.0",
@@ -2451,6 +2472,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "librsvg"
 version = "2.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,6 +3687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3762,6 +3804,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg 0.52.0",
+]
+
+[[package]]
+name = "resolve-path"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321e5e41b3b192dab6f1e75b9deacb6688b4b8c5e68906a78e8f43e7c2887bb5"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.93.2"
+version = "0.94.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.93.1"
+version = "0.93.2"
 edition = "2021"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ r2d2 = "0.8.10"
 auto-palette = "0.6.0"
 urlencoding = "2.1.3"
 open = "5.3.2"
+resolve-path = "0.1.0"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Most libraries, especially those that ran well with other MPD clients like [Cant
   - User-editable album wikis and artist bios
   - Metadata sync between Euphonica instances (instead of being stored locally)
   - Should follow existing sticker schemas, such as that proposed by myMPD, where possible.
-- Special support for local socket connection, or remote filesystem access, to enable the following features:
+- Local socket-exclusive features:
   - Library management operations such as tag editing (will require access to the files themselves)
   - Save downloaded album arts and artist avatars directly into the music folders themselves so other instances
     and clients can use them.

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -36,6 +36,12 @@
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.client" path="/io/github/htkhiem/Euphonica/client/">
+		<key name="mpd-use-unix-socket" type="b">
+			<default>false</default>
+		</key>
+		<key name="mpd-unix-socket" type="s">
+			<default>''</default>
+		</key>
 		<key name="mpd-host" type="s">
 			<default>'localhost'</default>
 		</key>

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -40,7 +40,7 @@
 			<default>false</default>
 		</key>
 		<key name="mpd-unix-socket" type="s">
-			<default>''</default>
+			<default>'/run/mpd/socket'</default>
 		</key>
 		<key name="mpd-host" type="s">
 			<default>'localhost'</default>

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -25,20 +25,18 @@
     </p>
     <ul>
       <li>Responsive GTK4 LibAdwaita UI for most MPD features, from basic things like playback controls, queue reordering and ReplayGain to things like output control, crossfade and MixRamp configuration</li>
+      <li>Automatically fetch album arts, artist avatars and (synced) song lyrics from external sources (currently supports Last.fm, MusicBrainz and LRCLIB). All external metadata are cached locally &amp; persisted on disk to avoid needless API calls.</li>
+      <li>Playlist browser and editor</li>
       <li>Integrated MPRIS client with background running supported (via the XDG Background protocol).</li>
       <li>Built-in, customisable spectrum visualiser, reading from MPD FIFO or system PipeWire.</li>
       <li>Rate albums (requires MPD 0.24+)</li>
       <li>Live bitrate readout + audio quality indicators (lossy, lossless, hi-res, DSD) for individual songs as well as albums &amp; detailed format printout</li>
       <li>Browse your library by album, artist and folders with multiselection support. Browsing by genre and other criteria are planned.</li>
-      <li>Playlist browser and editor</li>
       <li>Sort albums by name, AlbumArtist or release date (provided you have the tags)</li>
       <li>Asynchronous search for large collections</li>
       <li>Configurable multi-artist tag syntax, works with anything you throw at it. In other words, your artist tags can be pretty messy and Euphonica will still be able to correctly split them into individual artists.</li>
       <li>Performant album art fetching &amp; display (cached with Stretto)</li>
-      <li>Super-fast, **multithreaded**, **statically-cached** background blur powered by libblur's stack blur implementation</li>
-      <li>Automatically fetch album arts &amp; artist avatars from external sources (currently supports Last.fm and MusicBrainz)</li>
-      <li>Album wikis &amp; artist bios are supported too</li>
-      <li>All externally-acquired metadata are cached locally &amp; persisted on disk to avoid needless API calls</li>
+      <li>Super-fast, multithreaded, statically-cached background blur powered by libblur.</li>
       <li>Volume knob with dBFS readout support ('cuz why not?)</li>
       <li>User-friendly configuration UI &amp; GSettings backend</li>
       <li>MPD passwords are securely stored in your user's login keyring</li>
@@ -65,6 +63,23 @@
   </screenshots>
 
   <releases>
+    <release version="0.94.0-alpha" date="2025-06-28">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.94.0-alpha</url>
+      <description>
+        <p>New: Local socket connection support. This also opens up MPD capabilities only available via local sockets, such as configuration editing.</p>
+        <p>Refactor: Folder view state is now preserved across window launches (when background running is enabled)</p>
+        <p>Fix: "Queue all" button in playlist content view queuing twice.</p>
+        <p>Fix: Queue View resetting scroll position upon removing a track.</p>
+        <p>Fix: Queue View subtitle not updating upon clearing queue.</p>
+        <p>Fix: Connection error popups now work again.</p>
+      </description>
+    </release>
+    <release version="0.93.1-alpha" date="2025-06-22">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.93.1-alpha</url>
+      <description>
+        <p>Fix: MPRIS duration using the wrong unit, causing seekbars in shell applets to malfunction.</p>
+      </description>
+    </release>
     <release version="0.93.0-alpha" date="2025-06-21">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.93.0-alpha</url>
       <description>

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -69,7 +69,7 @@
         <p>New: Local socket connection support. This also opens up MPD capabilities only available via local sockets, such as configuration editing.</p>
         <p>Refactor: Folder view state is now preserved across window launches (when background running is enabled)</p>
         <p>Fix: "Queue all" button in playlist content view queuing twice.</p>
-        <p>Fix: Queue View resetting scroll position upon removing a track.</p>
+        <p>Fix: Queue View &amp; Playlist Editor resetting scroll position upon removing a track.</p>
         <p>Fix: Queue View subtitle not updating upon clearing queue.</p>
         <p>Fix: Connection error popups now work again.</p>
       </description>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.93.1',
+          version: '0.93.2',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.93.2',
+          version: '0.94.0',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,4 @@
+mod stream;
 pub mod state;
 pub mod wrapper;
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -17,7 +17,6 @@ pub enum ConnectionState {
     Unauthenticated, // Either no password is provided or the one provided is insufficiently privileged
     CredentialStoreError, // Cannot access underlying credential store to fetch or save password
     WrongPassword,   // The provided password does not match any of the configured passwords
-    LocalSocketError,
     Connected,
 }
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -100,6 +100,11 @@ mod imp {
                             BoxedAnyObject::static_type(), // mpd::Subsystem::to_str
                         ])
                         .build(),
+                    Signal::builder("queue-changed")
+                        .param_types([
+                            BoxedAnyObject::static_type(), // Vec<Song> (diff only)
+                        ])
+                        .build(),
                     Signal::builder("album-art-downloaded")
                         .param_types([
                             String::static_type(),         // folder URI

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -17,6 +17,7 @@ pub enum ConnectionState {
     Unauthenticated, // Either no password is provided or the one provided is insufficiently privileged
     CredentialStoreError, // Cannot access underlying credential store to fetch or save password
     WrongPassword,   // The provided password does not match any of the configured passwords
+    LocalSocketError,
     Connected,
 }
 

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -13,6 +13,8 @@ use crate::common::{Album, Artist};
 pub enum ConnectionState {
     #[default]
     NotConnected,
+    ConnectionRefused,
+    SocketNotFound,
     Connecting,
     Unauthenticated, // Either no password is provided or the one provided is insufficiently privileged
     CredentialStoreError, // Cannot access underlying credential store to fetch or save password

--- a/src/client/stream.rs
+++ b/src/client/stream.rs
@@ -1,0 +1,84 @@
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::os::unix::net::UnixStream;
+
+/// A wrapper struct that can hold either a TcpStream or a UnixStream,
+/// implementing the Read and Write traits.
+///
+/// This is because mpd::Client takes a stream as a generic parameter
+/// which complicates its usage: a TcpStream is needed when connecting
+/// to MPD via TCP socket (localhost, IP, etc) while a UnixStream is
+/// needed for local socket connection.
+/// By using this wrapper struct instead, we sacrifice a (tiny?) bit
+/// of runtime performance while getting a simpler MpdWrapper codebase
+/// in return.
+#[derive(Debug)]
+pub struct StreamWrapper {
+    tcp_stream: Option<TcpStream>,
+    unix_stream: Option<UnixStream>,
+}
+
+impl StreamWrapper {
+    pub fn new_tcp(stream: TcpStream) -> Self {
+        StreamWrapper {
+            tcp_stream: Some(stream),
+            unix_stream: None, // Ensure UnixStream is None
+        }
+    }
+
+    pub fn new_unix(stream: UnixStream) -> Self {
+        StreamWrapper {
+            tcp_stream: None, // Ensure TcpStream is None
+            unix_stream: Some(stream),
+        }
+    }
+}
+
+impl Read for StreamWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Check if a TcpStream is present and attempt to read from it.
+        if let Some(ref mut s) = self.tcp_stream {
+            s.read(buf)
+        // Check if a UnixStream is present and attempt to read from it.
+        } else if let Some(ref mut s) = self.unix_stream {
+            s.read(buf)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Uninitialised StreamWrapper",
+            ))
+        }
+    }
+}
+
+impl Write for StreamWrapper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Check if a TcpStream is present and attempt to write to it.
+        if let Some(ref mut s) = self.tcp_stream {
+            s.write(buf)
+        // Check if a UnixStream is present and attempt to write to it.
+        } else if let Some(ref mut s) = self.unix_stream {
+            s.write(buf)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Uninitialised StreamWrapper",
+            ))
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Check if a TcpStream is present and attempt to flush it.
+        if let Some(ref mut s) = self.tcp_stream {
+            s.flush()
+        // Check if a UnixStream is present and attempt to flush it.
+        } else if let Some(ref mut s) = self.unix_stream {
+            s.flush()
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Uninitialised StreamWrapper",
+            ))
+        }
+    }
+}

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1111,7 +1111,6 @@ impl MpdWrapper {
             Some(Ok(status)) => {
                 // Check whether we need to perform a full queue reload (inefficient)
                 let old_version = self.queue_version.replace(status.queue_version);
-                println!("Queue: old {}, new {}, expected {}", old_version, status.queue_version, self.expected_queue_version.get());
                 if status.queue_version > old_version {
                     if status.queue_version > self.expected_queue_version.get() {
                         self.expected_queue_version.set(status.queue_version);

--- a/src/gtk/library/folder-view.ui
+++ b/src/gtk/library/folder-view.ui
@@ -91,40 +91,21 @@
               </object>
             </child>
             <child>
-              <object class="GtkStack" id="loading_stack">
-                <child>
-                  <object class="GtkStackPage">
-                    <property name="name">loading</property>
-                    <property name="child">
-                      <object class="AdwSpinner">
-
-                      </object>
-                    </property>
+              <object class="GtkScrolledWindow">
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">automatic</property>
+                <property name="propagate-natural-height">true</property>
+                <property name="has-frame">false</property>
+                <property name="vexpand">true</property>
+                <property name="child">
+                  <object class="GtkListView" id="list_view">
+                    <property name="show-separators">true</property>
+                    <property name="single-click-activate">true</property>
+                    <style>
+                      <class name="no-bg"/>
+                    </style>
                   </object>
-                </child>
-                <child>
-                  <object class="GtkStackPage">
-                    <property name="name">content</property>
-                    <property name="child">
-                      <object class="GtkScrolledWindow">
-                        <property name="hscrollbar-policy">never</property>
-                        <property name="vscrollbar-policy">automatic</property>
-                        <property name="propagate-natural-height">true</property>
-                        <property name="has-frame">false</property>
-                        <property name="vexpand">true</property>
-                        <property name="child">
-                          <object class="GtkListView" id="list_view">
-                            <property name="show-separators">true</property>
-                            <property name="single-click-activate">true</property>
-                            <style>
-                              <class name="no-bg"/>
-                            </style>
-                          </object>
-                        </property>
-                      </object>
-                    </property>
-                  </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>

--- a/src/gtk/player/queue-view.ui
+++ b/src/gtk/player/queue-view.ui
@@ -133,7 +133,7 @@
                       <object class="GtkStackPage">
                         <property name="name">queue</property>
                         <property name="child">
-                          <object class="GtkScrolledWindow">
+                          <object class="GtkScrolledWindow" id="scrolled_window">
                             <property name="hscrollbar-policy">never</property>
                             <property name="vscrollbar-policy">automatic</property>
                             <property name="propagate-natural-height">true</property>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -11,7 +11,7 @@
         <property name="description" translatable="true">Change how Euphonica connects to your Music Player Daemon instance. Click Reconnect to save these settings and initiate a new connection.</property>
         <child>
           <object class="AdwEntryRow" id="mpd_host">
-            <property name="title" translatable="true">Host address</property>
+            <property name="title" translatable="true">Host address or local socket</property>
           </object>
         </child>
         <child>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -10,8 +10,19 @@
         <property name="title" translatable="true">Music Player Daemon</property>
         <property name="description" translatable="true">Change how Euphonica connects to your Music Player Daemon instance. Click Reconnect to save these settings and initiate a new connection.</property>
         <child>
+          <object class="AdwSwitchRow" id="mpd_use_unix_socket">
+            <property name="title" translatable="true">Connect via local socket</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwEntryRow" id="mpd_unix_socket">
+            <property name="title" translatable="true">Local socket (absolute path)</property>
+            <property name="visible">false</property>
+          </object>
+        </child>
+        <child>
           <object class="AdwEntryRow" id="mpd_host">
-            <property name="title" translatable="true">Host address or local socket</property>
+            <property name="title" translatable="true">Host address</property>
           </object>
         </child>
         <child>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -16,7 +16,7 @@
         </child>
         <child>
           <object class="AdwEntryRow" id="mpd_unix_socket">
-            <property name="title" translatable="true">Local socket (absolute path)</property>
+            <property name="title" translatable="true">Local socket</property>
             <property name="visible">false</property>
           </object>
         </child>

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -14,6 +14,9 @@ use mpd::{error::Error as MpdError, search::Operation, EditAction, Query, SaveMo
 mod imp {
     use std::cell::{Cell, RefCell};
 
+    use glib::{ParamSpec, ParamSpecString, ParamSpecUInt};
+    use once_cell::sync::Lazy;
+
     use super::*;
 
     #[derive(Debug)]
@@ -35,7 +38,7 @@ mod imp {
         // Folder view
         // Files and folders
         pub folder_history: RefCell<Vec<String>>,
-        pub folder_curr_idx: Cell<usize>, // 0 means at root.
+        pub folder_curr_idx: Cell<u32>, // 0 means at root.
         pub folder_inodes: gio::ListStore,
 
         pub cache: OnceCell<Rc<Cache>>,
@@ -62,6 +65,33 @@ mod imp {
     }
 
     impl ObjectImpl for Library {
+        fn properties() -> &'static [ParamSpec] {
+            static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
+                vec![
+                    ParamSpecUInt::builder("folder-curr-idx")
+                        .read_only()
+                        .build(),
+                    ParamSpecUInt::builder("folder-his-len")
+                        .read_only()
+                        .build(),
+                    ParamSpecString::builder("folder-path")
+                        .read_only()
+                        .build()
+                ]
+            });
+            PROPERTIES.as_ref()
+        }
+
+        fn property(&self, _id: usize, pspec: &ParamSpec) -> glib::Value {
+            let obj = self.obj();
+            match pspec.name() {
+                "folder-curr-idx" => self.folder_curr_idx.get().to_value(),
+                "folder-his-len" => (self.folder_history.borrow().len() as u32).to_value(),
+                "folder-path" => obj.folder_path().to_value(),
+                _ => {unimplemented!()}
+            }
+        }
+
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
@@ -102,12 +132,15 @@ impl Library {
                         ConnectionState::Connected => {
                             this.init_albums();
                             this.init_artists(false);
+                            this.get_folder_contents("");
                         }
                         ConnectionState::Connecting => {
                             this.imp().albums.remove_all();
                             this.imp().artists.remove_all();
                             this.imp().playlists.remove_all();
                             this.imp().folder_inodes.remove_all();
+                            let _ = this.imp().folder_history.replace(Vec::new());
+                            let _ = this.imp().folder_curr_idx.replace(0);
                         }
                         _ => {}
                     }
@@ -135,6 +168,25 @@ impl Library {
                 self,
                 move |_: ClientState, artist: Artist| {
                     this.imp().artists.append(&artist);
+                }
+            ),
+        );
+
+        client_state.connect_closure(
+            "folder-contents-downloaded",
+            false,
+            closure_local!(
+                #[weak(rename_to = this)]
+                self,
+                move |_: ClientState, uri: String, entries: glib::BoxedAnyObject| {
+                    // If original URI matches current URI, refresh current view
+                    println!("Requested URI: {}", &uri);
+                    if uri == this.folder_path() {
+                        this.imp().folder_inodes.remove_all();
+                        this.imp()
+                            .folder_inodes
+                            .extend_from_slice(entries.borrow::<Vec<INode>>().as_ref());
+                    }
                 }
             ),
         );
@@ -235,6 +287,62 @@ impl Library {
             .get_artist_content(artist.get_name().to_owned());
     }
 
+    pub fn folder_inodes(&self) -> gio::ListStore {
+        self.imp().folder_inodes.clone()
+    }
+
+    pub fn folder_curr_idx(&self) -> u32 {
+        self.imp().folder_curr_idx.get()
+    }
+
+    pub fn folder_history_len(&self) -> u32 {
+        self.imp().folder_history.borrow().len() as u32
+    }
+
+    pub fn folder_path(&self) -> String {
+        let history = self.imp().folder_history.borrow();
+        let curr_idx = self.imp().folder_curr_idx.get();
+        if history.len() > 0 && curr_idx > 0 {
+            history[..curr_idx as usize].join("/")
+        } else {
+            "".to_string()
+        }
+    }
+
+    pub fn folder_backward(&self) {
+        let curr_idx = self.imp().folder_curr_idx.get();
+        if curr_idx > 0 {
+            self.imp().folder_curr_idx.set(curr_idx - 1);
+            self.notify("folder-curr-idx");
+            self.get_folder_contents(&self.folder_path());
+            self.notify("folder-path");
+        }
+    }
+
+    pub fn folder_forward(&self) {
+        let curr_idx = self.imp().folder_curr_idx.get();
+        if curr_idx < self.imp().folder_history.borrow().len() as u32 {
+            self.imp().folder_curr_idx.set(curr_idx + 1);
+            self.notify("folder-curr-idx");
+            self.get_folder_contents(&self.folder_path());
+            self.notify("folder-path");
+        }
+    }
+
+    pub fn navigate_to(&self, name: &str) {
+        let curr_idx = self.imp().folder_curr_idx.get();
+        {
+            // Limit scope of mut borrow
+            let mut history = self.imp().folder_history.borrow_mut();
+            let hist_len = history.len();
+            if curr_idx < hist_len as u32 {
+                history.truncate(curr_idx as usize);
+            }
+            history.push(name.to_owned());
+        }
+        self.folder_forward();
+    }
+    
     /// Queue a song or folder (when recursive == true) for playback.
     pub fn queue_uri(&self, uri: &str, replace: bool, play: bool, recursive: bool) {
         if replace {

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -98,11 +98,18 @@ impl Library {
                 #[weak(rename_to = this)]
                 self,
                 move |state, _| {
-                    if state.get_connection_state() == ConnectionState::Connected {
-                        this.imp().albums.remove_all();
-                        this.imp().artists.remove_all();
-                        this.init_albums();
-                        this.init_artists(false);
+                    match state.get_connection_state() {
+                        ConnectionState::Connected => {
+                            this.init_albums();
+                            this.init_artists(false);
+                        }
+                        ConnectionState::Connecting => {
+                            this.imp().albums.remove_all();
+                            this.imp().artists.remove_all();
+                            this.imp().playlists.remove_all();
+                            this.imp().folder_inodes.remove_all();
+                        }
+                        _ => {}
                     }
                 }
             ),

--- a/src/library/folder_view.rs
+++ b/src/library/folder_view.rs
@@ -315,11 +315,16 @@ impl FolderView {
     }
 
     pub fn reset(&self, state: &ClientState) {
-        if state.get_connection_state() == ConnectionState::Connected {
-            // Newly-connected? Reset path to ""
-            let _ = self.imp().history.replace(Vec::new()); 
-            let _ = self.imp().curr_idx.replace(0);
-            self.imp().library.get().unwrap().get_folder_contents("");
+        // Newly-connected? Reset path to ""
+        match state.get_connection_state() {
+            ConnectionState::Connected => {
+                self.imp().library.get().unwrap().get_folder_contents("");
+            }
+            ConnectionState::Connecting => {
+                let _ = self.imp().history.replace(Vec::new());
+                let _ = self.imp().curr_idx.replace(0);
+            }
+            _ => {}
         }
     }
 

--- a/src/library/folder_view.rs
+++ b/src/library/folder_view.rs
@@ -2,7 +2,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{
     gio,
-    glib::{self, closure_local},
+    glib,
     CompositeTemplate, ListItem, SignalListItemFactory, SingleSelection,
 };
 use std::{cell::Cell, cmp::Ordering, rc::Rc};
@@ -12,7 +12,6 @@ use glib::clone;
 use super::{generic_row::GenericRow, Library};
 use crate::{
     cache::Cache,
-    client::{ClientState, ConnectionState},
     common::{INode, INodeType},
     utils::{g_cmp_str_options, g_search_substr, settings_manager},
 };
@@ -41,9 +40,9 @@ use crate::{
 // 2. Repeat steps 3-5 as above. If curr_idx is 0 after decrementing, simply use ""
 // as path.
 mod imp {
-    use std::{cell::{OnceCell, RefCell}, sync::OnceLock};
+    use std::{cell::OnceCell, sync::OnceLock};
 
-    use glib::{subclass::Signal, ParamSpec, ParamSpecBoolean, ParamSpecString};
+    use glib::{subclass::Signal, ParamSpec, ParamSpecBoolean};
     use once_cell::sync::Lazy;
 
     use super::*;
@@ -55,8 +54,6 @@ mod imp {
         pub show_sidebar: TemplateChild<gtk::Button>,
         #[template_child]
         pub path_widget: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub loading_stack: TemplateChild<gtk::Stack>,
         #[template_child]
         pub back_btn: TemplateChild<gtk::Button>,
         #[template_child]
@@ -80,10 +77,6 @@ mod imp {
         #[template_child]
         pub list_view: TemplateChild<gtk::ListView>,
 
-        // Files and folders
-        pub history: RefCell<Vec<String>>,
-        pub curr_idx: Cell<usize>, // 0 means at root.
-        pub inodes: gio::ListStore,
         // Search & filter models
         pub search_filter: gtk::CustomFilter,
         pub sorter: gtk::CustomSorter,
@@ -102,7 +95,6 @@ mod imp {
             Self {
                 show_sidebar: TemplateChild::default(),
                 path_widget: TemplateChild::default(),
-                loading_stack: TemplateChild::default(),
                 back_btn: TemplateChild::default(),
                 forward_btn: TemplateChild::default(),
                 // Search & filter widgets
@@ -113,10 +105,7 @@ mod imp {
                 search_bar: TemplateChild::default(),
                 search_entry: TemplateChild::default(),
                 // Content
-                history: RefCell::new(Vec::new()),
-                curr_idx: Cell::new(0),
                 list_view: TemplateChild::default(),
-                inodes: gio::ListStore::new::<INode>(),
                 // Search & filter models
                 search_filter: gtk::CustomFilter::default(),
                 sorter: gtk::CustomSorter::default(),
@@ -157,21 +146,25 @@ mod imp {
 
         fn constructed(&self) {
             self.parent_constructed();
-            self.obj()
-                .bind_property("path", &self.path_widget.get(), "label")
-                .sync_create()
-                .build();
 
             self.back_btn.connect_clicked(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |_| this.move_back()
+                move |_| {
+                    if let Some(lib) = this.library.get() {
+                        lib.folder_backward();
+                    }
+                }
             ));
 
             self.forward_btn.connect_clicked(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |_| this.move_forward()
+                move |_| {
+                    if let Some(lib) = this.library.get() {
+                        lib.folder_forward();
+                    }
+                }
             ));
 
             self.obj()
@@ -195,16 +188,13 @@ mod imp {
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> =
                 Lazy::new(|| vec![
-                    ParamSpecString::builder("path").read_only().build(),
                     ParamSpecBoolean::builder("collapsed").build()
                 ]);
             PROPERTIES.as_ref()
         }
 
         fn property(&self, _id: usize, pspec: &ParamSpec) -> glib::Value {
-            let obj = self.obj();
             match pspec.name() {
-                "path" => obj.get_path().to_value(),
                 "collapsed" => self.collapsed.get().to_value(),
                 _ => unimplemented!(),
             }
@@ -237,9 +227,10 @@ mod imp {
     impl WidgetImpl for FolderView {}
 
     impl FolderView {
-        fn update_nav_btn_sensitivity(&self) {
-            let curr_idx = self.curr_idx.get();
-            let hist_len = self.history.borrow().len();
+        pub fn update_nav_btn_sensitivity(&self) {
+            let lib = self.library.get().unwrap();
+            let curr_idx = lib.folder_curr_idx();
+            let hist_len = lib.folder_history_len();
             println!("Curr idx: {}", curr_idx);
             println!("Hist len: {}", hist_len);
             if curr_idx == 0 {
@@ -251,26 +242,6 @@ mod imp {
                 self.forward_btn.set_sensitive(false);
             } else {
                 self.forward_btn.set_sensitive(true);
-            }
-        }
-        pub fn move_back(&self) {
-            let curr_idx = self.curr_idx.get();
-            if curr_idx > 0 {
-                self.curr_idx.replace(curr_idx - 1);
-                self.obj().navigate();
-                self.update_nav_btn_sensitivity();
-            }
-        }
-
-        pub fn move_forward(&self) {
-            let curr_idx = self.curr_idx.get();
-            let hist_len = self.history.borrow().len();
-            // Reminder: this index is 1-based because 0 means root (before first
-            // element in history).
-            if curr_idx < hist_len {
-                self.curr_idx.replace(curr_idx + 1);
-                self.obj().navigate();
-                self.update_nav_btn_sensitivity();
             }
         }
     }
@@ -293,80 +264,44 @@ impl FolderView {
         glib::Object::new()
     }
 
-    pub fn get_path(&self) -> String {
-        let imp = self.imp();
-        let history = imp.history.borrow();
-        let curr_idx = imp.curr_idx.get();
-        if history.len() > 0 && curr_idx > 0 {
-            history[..curr_idx].join("/")
-        } else {
-            "".to_string()
-        }
+    fn library(&self) -> &Library {
+        self.imp().library.get().unwrap()
     }
 
-    pub fn navigate(&self) {
-        self.notify("path");
-        self.imp()
-            .library
-            .get()
-            .unwrap()
-            .get_folder_contents(&self.get_path());
-        self.imp().loading_stack.set_visible_child_name("loading");
-    }
-
-    pub fn reset(&self, state: &ClientState) {
-        // Newly-connected? Reset path to ""
-        match state.get_connection_state() {
-            ConnectionState::Connected => {
-                self.imp().library.get().unwrap().get_folder_contents("");
-            }
-            ConnectionState::Connecting => {
-                let _ = self.imp().history.replace(Vec::new());
-                let _ = self.imp().curr_idx.replace(0);
-            }
-            _ => {}
-        }
-    }
-
-    pub fn setup(&self, library: Library, cache: Rc<Cache>, client_state: ClientState) {
-        self.setup_sort();
-        self.setup_search();
-        self.setup_listview(cache.clone(), library.clone());
+    pub fn setup(&self, library: Library, cache: Rc<Cache>) {
         self.imp()
             .library
             .set(library.clone())
             .expect("Cannot init FolderView with Library");
-        client_state.connect_closure(
-            "folder-contents-downloaded",
-            false,
-            closure_local!(
-                #[weak(rename_to = this)]
-                self,
-                move |_: ClientState, uri: String, entries: glib::BoxedAnyObject| {
-                    // If original URI matches current URI, refresh current view
-                    println!("Requested URI: {}", &uri);
-                    println!("Current URI: {}", &this.get_path());
-                    if uri == this.get_path() {
-                        this.imp().inodes.remove_all();
-                        this.imp()
-                            .inodes
-                            .extend_from_slice(entries.borrow::<Vec<INode>>().as_ref());
-                        this.imp().loading_stack.set_visible_child_name("content");
-                    }
-                }
-            ),
-        );
-        // Always reset on window creation (when coming back from background mode)
-        self.reset(&client_state);
-        client_state.connect_notify_local(
-            Some("connection-state"),
+        self.setup_sort();
+        self.setup_search();
+        self.setup_listview(cache.clone(), library.clone());
+
+        library
+            .bind_property("folder-path", &self.imp().path_widget.get(), "label")
+            .sync_create()
+            .build();
+
+        library.connect_notify_local(
+            Some("folder-curr-idx"),
             clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |state, _| {
-                    this.reset(&state);
+                move |_, _| {
+                    this.imp().update_nav_btn_sensitivity();
                 }
-            ),
+            )
+        );
+
+        library.connect_notify_local(
+            Some("folder-his-len"),
+            clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |_, _| {
+                    this.imp().update_nav_btn_sensitivity();
+                }
+            )
         );
     }
 
@@ -558,16 +493,7 @@ impl FolderView {
         // - Else: do nothing (adding songs and playlists are done with buttons to the right of each row).
         if let Some(name) = inode.get_name() {
             if inode.get_info().inode_type == INodeType::Folder {
-                {
-                    let curr_idx = self.imp().curr_idx.get();
-                    let mut history = self.imp().history.borrow_mut();
-                    let hist_len = history.len();
-                    if curr_idx < hist_len {
-                        history.truncate(curr_idx);
-                    }
-                    history.push(name.to_owned());
-                }
-                self.imp().move_forward();
+                self.library().navigate_to(name);
             }
         }
     }
@@ -597,7 +523,7 @@ impl FolderView {
 
         // Chain search & sort. Put sort after search to reduce number of sort items.
         let search_model = gtk::FilterListModel::new(
-            Some(self.imp().inodes.clone()),
+            Some(self.library().folder_inodes()), 
             Some(self.imp().search_filter.clone()),
         );
         search_model.set_incremental(true);

--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -113,6 +113,10 @@ mod imp {
         #[template_child]
         pub editing_content: TemplateChild<gtk::ListView>,
         #[template_child]
+        pub content_scroller: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
+        pub editing_content_scroller: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
         pub title: TemplateChild<gtk::Label>,
 
         #[template_child]
@@ -172,6 +176,10 @@ mod imp {
         pub selecting_all: Cell<bool>, // Enables queuing the entire playlist efficiently
         pub window: OnceCell<EuphonicaWindow>,
         pub library: OnceCell<Library>,
+
+        // FIXME: Working around the scroll position bug. See src/player/queue_view.rs (same issue).
+        pub last_scroll_pos: Cell<f64>,
+        pub restore_last_pos: Cell<u8>
     }
 
     impl Default for PlaylistContentView {
@@ -186,6 +194,8 @@ mod imp {
                 content_stack: TemplateChild::default(),
                 content: TemplateChild::default(),
                 editing_content: TemplateChild::default(),
+                content_scroller: TemplateChild::default(),
+                editing_content_scroller: TemplateChild::default(),
                 song_list: gio::ListStore::new::<Song>(),
                 editing_song_list: gio::ListStore::new::<Song>(),
                 is_editing: Cell::new(false),
@@ -216,6 +226,8 @@ mod imp {
                 selecting_all: Cell::new(true), // When nothing is selected, default to select-all
                 window: OnceCell::new(),
                 library: OnceCell::new(),
+                last_scroll_pos: Cell::new(0.0),
+                restore_last_pos: Cell::new(0)
             }
         }
     }
@@ -741,11 +753,44 @@ impl PlaylistContentView {
             }
         ));
 
+        editing_factory.connect_teardown(clone!(
+            #[weak(rename_to = this)]
+            self,
+            move |_, _| {
+                // The above scroll bug only manifests after this, so now is the best time to set
+                // the corresponding values.
+                this.imp().last_scroll_pos.set(this.imp().editing_content_scroller.vadjustment().value());
+                this.imp().restore_last_pos.set(2);
+            }
+        ));
+
         // Set the factory of the list view
         self.imp().content.set_factory(Some(&factory));
         self.imp()
             .editing_content
             .set_factory(Some(&editing_factory));
+
+        // Disgusting workaround until I can pinpoint whenever this is a GTK problem.
+        self.imp().editing_content_scroller.vadjustment().connect_notify_local(
+            Some("value"),
+            clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |adj, _| {
+                    let checks_left = this.imp().restore_last_pos.get();
+                    if checks_left > 0 {
+                        let old_pos = this.imp().last_scroll_pos.get();
+                        if adj.value() == 0.0 {
+                            adj.set_value(old_pos);
+                        }
+                        else {
+                            this.imp().restore_last_pos.set(checks_left - 1);
+                            // this.imp().restore_last_pos.set(false);
+                        }
+                    }
+                }
+            )
+        );
     }
 
     /// Returns true if an album art was successfully retrieved.

--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -651,30 +651,6 @@ impl PlaylistContentView {
             }
         ));
 
-        append_queue_btn.connect_clicked(clone!(
-            #[strong(rename_to = this)]
-            self,
-            move |_| {
-                let library = this.imp().library.get().unwrap();
-                if let Some(playlist) = this.imp().playlist.borrow().as_ref() {
-                    if this.imp().selecting_all.get() {
-                        library.queue_playlist(playlist.get_name().unwrap(), false, false);
-                    } else {
-                        let store = &this.imp().song_list;
-                        // Get list of selected songs
-                        let sel = &this.imp().sel_model.selection();
-                        let mut songs: Vec<Song> = Vec::with_capacity(sel.size() as usize);
-                        let (iter, first_idx) = BitsetIter::init_first(sel).unwrap();
-                        songs.push(store.item(first_idx).and_downcast::<Song>().unwrap());
-                        iter.for_each(|idx| {
-                            songs.push(store.item(idx).and_downcast::<Song>().unwrap())
-                        });
-                        library.queue_songs(&songs, false, false);
-                    }
-                }
-            }
-        ));
-
         delete_btn.connect_clicked(clone!(
             #[strong(rename_to = this)]
             self,

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -220,7 +220,7 @@ mod imp {
         pub fft_data: Arc<Mutex<(Vec<f32>, Vec<f32>)>>, // Binned magnitudes, in stereo
         pub use_visualizer: Cell<bool>,
         pub fft_backend_idx: Cell<i32>,
-        pub outputs: gio::ListStore
+        pub outputs: gio::ListStore,
     }
 
     #[glib::object_subclass]
@@ -275,7 +275,7 @@ mod imp {
                 ))),
                 use_visualizer: Cell::new(false),
                 fft_backend_idx: Cell::new(0),
-                outputs: gio::ListStore::new::<BoxedAnyObject>()
+                outputs: gio::ListStore::new::<BoxedAnyObject>(),
             }
         }
     }
@@ -475,6 +475,8 @@ mod imp {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
                 vec![
+                    Signal::builder("queue-updating").build(),
+                    Signal::builder("queue-updated").build(),
                     Signal::builder("outputs-changed")
                         .build(),
                     // Reserved for EXTERNAL changes (i.e. changes made by this client won't
@@ -675,16 +677,7 @@ impl Player {
                 self,
                 move |_: ClientState, subsys: glib::BoxedAnyObject| {
                     match subsys.borrow::<Subsystem>().deref() {
-                        Subsystem::Player | Subsystem::Options => {
-                            if let Some(status) = this.client().get_status() {
-                                this.update_status(&status);
-                            }
-                        }
-                        Subsystem::Queue => {
-                            if let Some(songs) = this.client().get_queue_changes() {
-                                this.update_queue(&songs, false);
-                            }
-                            // Need to also update queue length
+                        Subsystem::Player | Subsystem::Queue | Subsystem::Options => {
                             if let Some(status) = this.client().get_status() {
                                 this.update_status(&status);
                             }
@@ -693,9 +686,21 @@ impl Player {
                             if let Some(outs) = this.client().get_outputs() {
                                 this.update_outputs(outs);
                             }
-                        }
+                        } 
                         _ => {}
                     }
+                }
+            ),
+        );
+
+        client_state.connect_closure(
+            "queue-changed",
+            false,
+            closure_local!(
+                #[weak(rename_to = this)]
+                self,
+                move |_: ClientState, songs: BoxedAnyObject| {
+                    this.update_queue(songs.borrow::<Vec<Song>>().as_ref(), false);
                 }
             ),
         );
@@ -1049,9 +1054,9 @@ impl Player {
     /// before update_status() (by MPD's idle change notifier) and as such has no way to know the
     /// new queue length. The update_status() function will instead truncate the queue to the new
     /// length for us once called.
-    ///
     /// If an MPRIS server is running, it will also emit property change signals.
-    pub fn update_queue(&self, songs: &[Song], replace: bool) {
+    pub fn update_queue(&self, songs: &[Song], replace: bool) { 
+        println!("RUNNING UPDATE_QUEUE");
         let queue = &self.imp().queue;
         if replace {
             if songs.len() == 0 {
@@ -1112,7 +1117,6 @@ impl Player {
             // Might queue downloads, depending on user settings
             cache.ensure_cached_album_arts(&infos);
         }
-        // Downstream widgets should now receive an item-changed signal.
     }
 
     fn client(&self) -> &Rc<MpdWrapper> {
@@ -1344,20 +1348,46 @@ impl Player {
         self.client().play_at(song.get_queue_id(), true);
     }
 
-    pub fn remove_song_id(&self, id: u32) {
-        self.client().delete_at(id, true);
+    fn pos_of_id(&self, id: u32) -> Option<u32> {
+        for (i, song_obj) in self.imp().queue.iter::<Song>().enumerate() {
+            let song: Song = song_obj.unwrap().downcast::<Song>().unwrap();
+            if song.get_queue_id() == id {
+                return Some(i as u32);
+            }
+        }
+        None
     }
 
-    pub fn swap_dir(&self, pos: u32, direction: SwapDirection) {
-        match direction {
-            SwapDirection::Up => {
-                if pos > 0 {
-                    self.client().swap(pos, pos - 1, false);
+    pub fn remove_song_id(&self, id: u32) {
+        if let Some(pos) = self.pos_of_id(id) {
+            self.emit_by_name::<()>("queue-updating", &[]);
+            self.client().register_local_queue_changes(1);
+            self.imp().queue.remove(pos);
+            self.client().delete_at(id, true);
+            self.emit_by_name::<()>("queue-updated", &[]);
+        }
+    }
+
+    pub fn swap_dir(&self, id: u32, direction: SwapDirection) {
+        // Find position of given queue_id
+        if let Some(pos) = self.pos_of_id(id) {
+            self.client().register_local_queue_changes(1);
+            match direction {
+                SwapDirection::Up => {
+                    if pos > 0 {
+                        let target = self.imp().queue.item(pos).unwrap();
+                        let upper = self.imp().queue.item(pos - 1).unwrap();
+                        self.imp().queue.splice(pos - 1, 2, &[target, upper]);
+                        self.client().swap(pos, pos - 1, false);
+                    }
                 }
-            }
-            SwapDirection::Down => {
-                if pos < self.imp().queue.n_items() - 1 {
-                    self.client().swap(pos, pos + 1, false);
+                SwapDirection::Down => {
+                    if pos < self.imp().queue.n_items() - 1 {
+                        let target = self.imp().queue.item(pos).unwrap();
+                        let lower = self.imp().queue.item(pos + 1).unwrap();
+                        self.imp().queue.splice(pos, 2, &[lower, target]);
+                        self.client().swap(pos, pos + 1, false);
+                    }
                 }
             }
         }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -475,8 +475,6 @@ mod imp {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
                 vec![
-                    Signal::builder("queue-updating").build(),
-                    Signal::builder("queue-updated").build(),
                     Signal::builder("outputs-changed")
                         .build(),
                     // Reserved for EXTERNAL changes (i.e. changes made by this client won't
@@ -1360,11 +1358,9 @@ impl Player {
 
     pub fn remove_song_id(&self, id: u32) {
         if let Some(pos) = self.pos_of_id(id) {
-            self.emit_by_name::<()>("queue-updating", &[]);
             self.client().register_local_queue_changes(1);
             self.imp().queue.remove(pos);
             self.client().delete_at(id, true);
-            self.emit_by_name::<()>("queue-updated", &[]);
         }
     }
 

--- a/src/player/queue_row.rs
+++ b/src/player/queue_row.rs
@@ -46,7 +46,6 @@ mod imp {
         #[template_child]
         pub remove: TemplateChild<Button>,
         pub queue_id: Cell<u32>,
-        pub queue_pos: Cell<u32>,
         pub thumbnail_signal_id: RefCell<Option<SignalHandlerId>>,
         // pub marquee_tick_callback_id: RefCell<Option<TickCallbackId>>,
         // pub marquee_forward: Cell<bool>,
@@ -80,7 +79,6 @@ mod imp {
                     ParamSpecString::builder("album").build(),
                     ParamSpecBoolean::builder("is-playing").build(),
                     ParamSpecUInt::builder("queue-id").build(),
-                    ParamSpecUInt::builder("queue-pos").build(),
                     // ParamSpecString::builder("duration").build(),
                     ParamSpecString::builder("quality-grade").build(),
                 ]
@@ -95,7 +93,6 @@ mod imp {
                 "album" => self.album_name.label().to_value(),
                 "is-playing" => self.playing_indicator.is_child_revealed().to_value(),
                 "queue-id" => self.queue_id.get().to_value(),
-                "queue-pos" => self.queue_pos.get().to_value(),
                 // "duration" => self.duration.label().to_value(),
                 "quality-grade" => self.quality_grade.icon_name().to_value(),
                 _ => unimplemented!(),
@@ -128,11 +125,6 @@ mod imp {
                 "queue-id" => {
                     if let Ok(id) = value.get::<u32>() {
                         self.queue_id.replace(id);
-                    }
-                }
-                "queue-pos" => {
-                    if let Ok(pos) = value.get::<u32>() {
-                        self.queue_pos.replace(pos);
                     }
                 }
                 // "duration" => {
@@ -194,7 +186,7 @@ impl QueueRow {
             #[weak]
             player,
             move |_| {
-                player.swap_dir(this.imp().queue_pos.get(), SwapDirection::Up);
+                player.swap_dir(this.imp().queue_id.get(), SwapDirection::Up);
             }
         ));
 
@@ -204,7 +196,7 @@ impl QueueRow {
             #[weak]
             player,
             move |_| {
-                player.swap_dir(this.imp().queue_pos.get(), SwapDirection::Down);
+                player.swap_dir(this.imp().queue_id.get(), SwapDirection::Down);
             }
         ));
 
@@ -239,9 +231,6 @@ impl QueueRow {
         item.property_expression("item")
             .chain_property::<Song>("queue-id")
             .bind(self, "queue-id", gtk::Widget::NONE);
-        item.property_expression("item")
-            .chain_property::<Song>("queue-pos")
-            .bind(self, "queue-pos", gtk::Widget::NONE);
 
         // Bind marquee controller only once here
         // Run only while hovered

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -310,6 +310,22 @@ impl ClientPreferences {
                     self.imp().reconnect.set_sensitive(true);
                 }
             }
+            ConnectionState::ConnectionRefused => {
+                self.imp().mpd_status.set_subtitle("Connection refused");
+                self.imp().mpd_status.set_enable_expansion(false);
+                set_status_icon(&self.imp().mpd_status_icon.get(), StatusIconState::Disabled);
+                if !self.imp().mpd_port.has_css_class("error") {
+                    self.imp().reconnect.set_sensitive(true);
+                }
+            }
+            ConnectionState::SocketNotFound => {
+                self.imp().mpd_status.set_subtitle("Socket not found");
+                self.imp().mpd_status.set_enable_expansion(false);
+                set_status_icon(&self.imp().mpd_status_icon.get(), StatusIconState::Disabled);
+                if !self.imp().mpd_port.has_css_class("error") {
+                    self.imp().reconnect.set_sensitive(true);
+                }
+            }
             ConnectionState::Connected => {
                 self.imp().mpd_status.set_subtitle("Connected");
                 self.imp().mpd_status.set_enable_expansion(true);

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -82,6 +82,10 @@ mod imp {
     pub struct ClientPreferences {
         // MPD
         #[template_child]
+        pub mpd_use_unix_socket: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub mpd_unix_socket: TemplateChild<adw::EntryRow>,
+        #[template_child]
         pub mpd_host: TemplateChild<adw::EntryRow>,
         #[template_child]
         pub mpd_port: TemplateChild<adw::EntryRow>,
@@ -146,6 +150,35 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
+            self.mpd_use_unix_socket
+                .bind_property(
+                    "active",
+                    &self.mpd_unix_socket.get(),
+                    "visible"
+                )
+                .sync_create()
+                .build();
+
+            self.mpd_use_unix_socket
+                .bind_property(
+                    "active",
+                    &self.mpd_host.get(),
+                    "visible"
+                )
+                .invert_boolean()
+                .sync_create()
+                .build();
+
+            self.mpd_use_unix_socket
+                .bind_property(
+                    "active",
+                    &self.mpd_port.get(),
+                    "visible"
+                )
+                .invert_boolean()
+                .sync_create()
+                .build();
+
             let viz_settings = utils::settings_manager().child("client");
             let fifo_path_row = self.fifo_path.get();
             viz_settings
@@ -192,7 +225,7 @@ mod imp {
                         }
                     }
                     else {
-                        Option::<glib::Value>::None
+                         Option::<glib::Value>::None
                     }
                 })
                 .set_mapping(|val, _| {
@@ -238,7 +271,7 @@ impl Default for ClientPreferences {
 
 impl ClientPreferences {
     fn on_connection_state_changed(&self, cs: &ClientState) {
-        match cs.get_connection_state() {
+        match cs.get_connection_state() { 
             ConnectionState::NotConnected => {
                 self.imp().mpd_status.set_subtitle("Failed to connect");
                 self.imp().mpd_status.set_enable_expansion(false);
@@ -327,7 +360,13 @@ impl ClientPreferences {
         // These should only be saved when the Apply button is clicked.
         // As such we won't bind the widgets directly to the settings.
         let conn_settings = settings.child("client");
+        conn_settings.bind(
+            "mpd-use-unix-socket",
+            &imp.mpd_use_unix_socket.get(),
+            "active"
+        ).build();
         imp.mpd_host.set_text(&conn_settings.string("mpd-host"));
+        imp.mpd_unix_socket.set_text(&conn_settings.string("mpd-unix-socket"));
         imp.mpd_port
             .set_text(&conn_settings.uint("mpd-port").to_string());
         let maybe_keyring_entry = Entry::new("euphonica", "mpd-password");
@@ -347,14 +386,20 @@ impl ClientPreferences {
         // TODO: more input validation
         // Prevent entering anything other than digits into the port entry row
         // This is needed since using a spinbutton row for port entry feels a bit weird
+        // Don't perform this check when we're connecting to a local socket.
         imp.mpd_port.connect_changed(clone!(
             #[weak(rename_to = this)]
             self,
             move |entry| {
-                if entry.text().parse::<u32>().is_err() {
-                    if !entry.has_css_class("error") {
-                        entry.add_css_class("error");
-                        this.imp().reconnect.set_sensitive(false);
+                if !this.imp().mpd_use_unix_socket.is_active() {
+                    if entry.text().parse::<u32>().is_err() {
+                        if !entry.has_css_class("error") {
+                            entry.add_css_class("error");
+                            this.imp().reconnect.set_sensitive(false);
+                        }
+                    } else if entry.has_css_class("error") {
+                        entry.remove_css_class("error");
+                        this.imp().reconnect.set_sensitive(true);
                     }
                 } else if entry.has_css_class("error") {
                     entry.remove_css_class("error");
@@ -408,11 +453,16 @@ impl ClientPreferences {
             #[weak]
             client,
             move |_| {
-                let _ = conn_settings.set_string("mpd-host", &this.imp().mpd_host.text());
-                let _ = conn_settings.set_uint(
-                    "mpd-port",
-                    this.imp().mpd_port.text().parse::<u32>().unwrap(),
-                );
+                if this.imp().mpd_use_unix_socket.is_active() {
+                    let _ = conn_settings.set_string("mpd-unix-socket", &this.imp().mpd_unix_socket.text());
+                }
+                else {
+                    let _ = conn_settings.set_string("mpd-host", &this.imp().mpd_host.text());
+                    let _ = conn_settings.set_uint(
+                        "mpd-port",
+                        this.imp().mpd_port.text().parse::<u32>().unwrap(),
+                    );
+                }
 
                 if let Ok(ref keyring_entry) = maybe_keyring_entry {
                     let password = this.imp().mpd_password.text();

--- a/src/window.rs
+++ b/src/window.rs
@@ -869,8 +869,7 @@ impl EuphonicaWindow {
         );
         win.imp().folder_view.setup(
             app.get_library(),
-            app.get_cache(),
-            app.get_client().get_client_state(),
+            app.get_cache()
         );
         win.imp().playlist_view.setup(
             app.get_library(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -829,36 +829,14 @@ impl EuphonicaWindow {
                 }
             ),
         );
+        win.handle_connection_state(client_state.get_connection_state());
         client_state.connect_notify_local(
             Some("connection-state"),
             clone!(
                 #[weak(rename_to = this)]
                 win,
                 move |state: &ClientState, _| {
-                    match state.get_connection_state() {
-                        ConnectionState::WrongPassword => {
-                            this.show_error_dialog(
-                                "Incorrect password",
-                                "MPD has refused the provided password. Please note that if your MPD instance is not password-protected, providing one will also cause this error.",
-                                true
-                            );
-                        }
-                        ConnectionState::Unauthenticated => {
-                            this.show_error_dialog(
-                                "Authentication Failed",
-                                "Your MPD instance requires a password, which was either not provided or lacks the necessary privileges for Euphonica to function correctly.",
-                                true
-                            );
-                        }
-                        ConnectionState::CredentialStoreError => {
-                            this.show_error_dialog(
-                                "Credential Store Error",
-                                "Your MPD instance requires a password, but Euphonica could not access your default credential store to retrieve it. Please ensure that it has been unlocked before starting Euphonica.",
-                                false
-                            );
-                        }
-                        _ => {}
-                    }
+                    this.handle_connection_state(state.get_connection_state());
                 }
             )
         );
@@ -998,6 +976,56 @@ impl EuphonicaWindow {
         }
     }
 
+    fn handle_connection_state(&self, state: ConnectionState) {
+        match state {
+            ConnectionState::ConnectionRefused => {
+                let conn_settings = utils::settings_manager().child("client");
+                self.show_error_dialog(
+                    "Connection refused",
+                    &format!(
+                        "Euphonica could not connect to {}:{}. Please check your connection and network configuration and try again.",
+                        conn_settings.string("mpd-host").as_str(),
+                        conn_settings.uint("mpd-port")
+                    ),
+                    true
+                );
+            }
+            ConnectionState::SocketNotFound => {
+                let conn_settings = utils::settings_manager().child("client");
+                self.show_error_dialog(
+                    "Socket not found",
+                    &format!(
+                        "Euphonica couldn't connect to your socket at {}. Please ensure that MPD has been configured to bind to that socket and try again.",
+                        conn_settings.string("mpd-unix-socket").as_str(),
+                    ),
+                    true
+                );
+            }
+            ConnectionState::WrongPassword => {
+                self.show_error_dialog(
+                    "Incorrect password",
+                    "MPD has refused the provided password. Please note that if your MPD instance is not password-protected, providing one will also cause this error.",
+                    true
+                );
+            }
+            ConnectionState::Unauthenticated => {
+                self.show_error_dialog(
+                    "Authentication Failed",
+                    "Your MPD instance requires a password, which was either not provided or lacks the necessary privileges for Euphonica to function correctly.",
+                    true
+                );
+            }
+            ConnectionState::CredentialStoreError => {
+                self.show_error_dialog(
+                    "Credential Store Error",
+                    "Your MPD instance requires a password, but Euphonica could not access your default credential store to retrieve it. Please ensure that it has been unlocked before starting Euphonica.",
+                    false
+                );
+            }
+            _ => {}
+        }
+    }
+
     pub fn show_dialog(&self, heading: &str, body: &str) {
         let diag = adw::AlertDialog::builder()
             .heading(heading)
@@ -1102,12 +1130,12 @@ impl EuphonicaWindow {
         state
             .bind_property("connection-state", &title, "subtitle")
             .transform_to(|_, state: ConnectionState| match state {
-                ConnectionState::NotConnected => Some("Not connected"),
                 ConnectionState::Connecting => Some("Connecting"),
                 ConnectionState::Unauthenticated
                 | ConnectionState::WrongPassword
                 | ConnectionState::CredentialStoreError => Some("Unauthenticated"),
                 ConnectionState::Connected => Some("Connected"),
+                _ => Some("Not connected")
             })
             .sync_create()
             .build();


### PR DESCRIPTION
# New

This PR adds local socket connection support to Euphonica and closes #55. Named sockets should probably work already, I guess?

# Bugfixes

- Fix "Queue all" in playlist view queuing twice
- Worked around Queue View & Playlist Editor scroll position resetting upon row removal (closes #62)
- Restored startup connection error pop-ups
- Fix Queue View subtitle not updating upon clearing queue.

# Refactors

- Moved folder view state code into library controller (finishing what the background client PR started). As an added bonus folder view now retains state across window launches when background running is enabled.