### PR TITLE
Add double click action for album_song_row

### DIFF
--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -472,7 +472,7 @@ impl AlbumContentView {
                     this.get_library()
                 ) {
                     if this.imp().selecting_all.get() {
-                        library.queue_album(album.clone(), true, true);
+                        library.queue_album(album.clone(), true, true, None);
                     } else {
                         let store = &this.imp().song_list;
                         // Get list of selected songs
@@ -498,7 +498,7 @@ impl AlbumContentView {
                     this.get_library()
                 ) { 
                     if this.imp().selecting_all.get() {
-                        library.queue_album(album.clone(), false, false);
+                        library.queue_album(album.clone(), false, false, None);
                     } else {
                         let store = &this.imp().song_list;
                         // Get list of selected songs
@@ -588,6 +588,20 @@ impl AlbumContentView {
 
         // Set the factory of the list view
         self.imp().content.set_factory(Some(&factory));
+
+        // Setup click action
+        self.imp().content.connect_activate(clone!(
+            #[strong(rename_to = this)]
+            self,
+            move |_, position| {
+                if let (Some(album), Some(library)) = (
+                    this.imp().album.borrow().as_ref(),
+                    this.get_library()
+                ) {
+                    library.queue_album(album.clone(), true, true, Some(position as u32));
+                }
+            }
+        ));
     }
 
     /// Returns true if an album art was successfully retrieved.

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -231,7 +231,7 @@ impl Library {
     }
 
     /// Queue all songs in a given album by track order.
-    pub fn queue_album(&self, album: Album, replace: bool, play: bool) {
+    pub fn queue_album(&self, album: Album, replace: bool, play: bool, play_from: Option<u32>) {
         if replace {
             self.client().clear_queue();
         }
@@ -242,7 +242,7 @@ impl Library {
         );
         self.client().find_add(query);
         if replace && play {
-            self.client().play_at(0, false);
+            self.client().play_at(play_from.unwrap_or(0), false);
         }
     }
 


### PR DESCRIPTION
Makes double clicking an album_song_row behave like most music players (replacing the current queue with the album and playing from the selected track)