### PR TITLE
Add queue next to album content view

### DIFF
--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -907,6 +907,14 @@ impl MpdWrapper {
         }
     }
 
+    pub fn insert_multi(&self, uris: &[String], pos: usize) {
+        if let Some(client) = self.main_client.borrow_mut().as_mut() {
+            
+            client.insert_multiple(uris, pos).expect("Could not add multiple songs into queue");
+            self.force_idle();
+        }
+    }
+
     pub fn volume(&self, vol: i8) {
         if let Some(client) = self.main_client.borrow_mut().as_mut() {
             let _ = client.volume(vol);
@@ -1355,6 +1363,18 @@ impl MpdWrapper {
                         .map(|mpd_song| Song::from(std::mem::take(mpd_song)))
                         .collect(),
                 );
+            }
+            return None;
+        }
+        return None;
+    }
+
+    pub fn get_current_song(&self) -> Option<Song> {
+        if let Some(client) = self.main_client.borrow_mut().as_mut() {
+            if let Ok(song) = client.currentsong() {
+                if let Some(song) = song {
+                    return Some(Song::from(song));
+                }
             }
             return None;
         }

--- a/src/gtk/library/album-content-view.ui
+++ b/src/gtk/library/album-content-view.ui
@@ -323,6 +323,26 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkButton" id="insert_queue">
+                            <property name="tooltip-text" translatable="true">Addselected songs next in the queue</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="icon-name">list-add-symbolic</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="insert_queue_text">
+                                    <property name="label" translatable="true">Queue all next</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
                           <object class="EuphonicaAddToPlaylistButton" id="add_to_playlist"/>
                         </child>
                       </object>

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -76,6 +76,10 @@ mod imp {
         #[template_child]
         pub append_queue_text: TemplateChild<gtk::Label>,
         #[template_child]
+        pub insert_queue: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub insert_queue_text: TemplateChild<gtk::Label>,
+        #[template_child]
         pub add_to_playlist: TemplateChild<AddToPlaylistButton>,
         #[template_child]
         pub sel_all: TemplateChild<gtk::Button>,
@@ -118,6 +122,8 @@ mod imp {
                 sel_model: gtk::MultiSelection::new(Option::<gio::ListStore>::None),
                 replace_queue: TemplateChild::default(),
                 append_queue: TemplateChild::default(),
+                insert_queue: TemplateChild::default(),
+                insert_queue_text: TemplateChild::default(),
                 replace_queue_text: TemplateChild::default(),
                 append_queue_text: TemplateChild::default(),
                 add_to_playlist: TemplateChild::default(),
@@ -177,6 +183,7 @@ mod imp {
                         this.selecting_all.replace(true);
                         this.replace_queue_text.set_label("Play all");
                         this.append_queue_text.set_label("Queue all");
+                        this.insert_queue_text.set_label("Queue all next");
                     } else {
                         // TODO: l10n
                         this.selecting_all.replace(false);
@@ -184,6 +191,8 @@ mod imp {
                             .set_label(format!("Play {}", n_sel).as_str());
                         this.append_queue_text
                             .set_label(format!("Queue {}", n_sel).as_str());
+                        this.insert_queue_text
+                            .set_label(format!("Queue {} next", n_sel).as_str());
                     }
                 }
             ));
@@ -510,6 +519,36 @@ impl AlbumContentView {
                             songs.push(store.item(idx).and_downcast::<Song>().unwrap())
                         });
                         library.queue_songs(&songs, false, false);
+                    }
+                }
+            }
+        ));
+        let insert_queue_btn = self.imp().insert_queue.get();
+        insert_queue_btn.connect_clicked(clone!(
+            #[strong(rename_to = this)]
+            self,
+            move |_| {
+                if let (Some(album), Some(library)) = (
+                    this.imp().album.borrow().as_ref(),
+                    this.get_library()
+                ) {
+                    let store = &this.imp().song_list;
+                    if this.imp().selecting_all.get() {
+                        let mut songs: Vec<Song> = Vec::with_capacity(store.n_items() as usize);
+                        for i in 0..store.n_items() {
+                            songs.push(store.item(i).and_downcast::<Song>().unwrap());
+                        }
+                        library.insert_songs_next(&songs);
+                    } else {
+                        // Get list of selected songs
+                        let sel = &this.imp().sel_model.selection();
+                        let mut songs: Vec<Song> = Vec::with_capacity(sel.size() as usize);
+                        let (iter, first_idx) = BitsetIter::init_first(sel).unwrap();
+                        songs.push(store.item(first_idx).and_downcast::<Song>().unwrap());
+                        iter.for_each(|idx| {
+                            songs.push(store.item(idx).and_downcast::<Song>().unwrap())
+                        });
+                        library.insert_songs_next(&songs);
                     }
                 }
             }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -230,6 +230,23 @@ impl Library {
         }
     }
 
+    pub fn insert_songs_next(&self, songs: &[Song]) {
+        let pos = if let Some(current_song) = self.client().get_current_song() {
+            // Insert after the position of the current song
+            current_song.get_queue_pos() + 1
+        } else {
+            // If no current song, insert at the start of the queue
+            0
+        };
+        self.client().insert_multi(
+                &songs
+                    .iter()
+                    .map(|s| s.get_uri().to_owned())
+                    .collect::<Vec<String>>(),
+                pos as usize,
+            );
+    }
+
     /// Queue all songs in a given album by track order.
     pub fn queue_album(&self, album: Album, replace: bool, play: bool, play_from: Option<u32>) {
         if replace {


### PR DESCRIPTION
Adds queue next button (along with backend support) to the album content page. This should be easily expandable to other views.