### PR TITLE
Handle setups without XDG Background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.95.0"
+version = "0.95.2"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.95.1"
+version = "0.95.2"
 edition = "2021"
 
 [dev-dependencies]

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -33,6 +33,10 @@
 		<child schema="io.github.htkhiem.Euphonica.metaprovider" name="metaprovider"/>
 		<child schema="io.github.htkhiem.Euphonica.player" name="player"/>
 		<child schema="io.github.htkhiem.Euphonica.client" name="client"/>
+
+		<key name="background-portal-available" type="b">
+			<default>true</default>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.client" path="/io/github/htkhiem/Euphonica/client/">

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -63,6 +63,12 @@
   </screenshots>
 
   <releases>
+    <release version="0.95.2-beta" date="2025-07-14">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.95.2-beta</url>
+      <description>
+        <p>Fix: crash on systems without XDG Background support.</p>
+      </description>
+    </release>
     <release version="0.95.1-beta" date="2025-07-12">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.95.1-beta</url>
       <description>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.95.1',
+          version: '0.95.2',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/gtk/preferences/integrations.ui
+++ b/src/gtk/preferences/integrations.ui
@@ -34,6 +34,21 @@
 						<property name="subtitle" translatable="true">You may also launch Euphonica minimised using the --minimized command-line argument.</property>
 					</object>
 				</child>
+				<child>
+					<object class="AdwActionRow" id="xdg_warn_row">
+						<property name="visible">false</property>
+						<property name="title" translatable="true">XDG Background Portal not available</property>
+						<property name="subtitle" translatable="true">Required for shell integration.</property>
+						<child type="prefix">
+							<object class="GtkImage">
+								<style>
+									<class name="warning"/>
+								</style>
+								<property name="icon-name">content-loading-symbolic</property>
+							</object>
+						</child>
+					</object>
+				</child>
 			</object>
 		</child>
 

--- a/src/preferences/integrations.rs
+++ b/src/preferences/integrations.rs
@@ -23,6 +23,8 @@ mod imp {
         pub autostart: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub start_minimized: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub xdg_warn_row: TemplateChild<adw::ActionRow>,
 
         #[template_child]
         pub lastfm_key: TemplateChild<adw::EntryRow>,
@@ -88,6 +90,7 @@ impl IntegrationsPreferences {
         let run_in_background = imp.run_in_background.get();
         let autostart = imp.autostart.get();
         let start_minimized = imp.start_minimized.get();
+        let xdg_warn = imp.xdg_warn_row.get();
 
         // Init background & autostart toggle states
         // Do NOT bind the widgets directly to the settings to avoid an infinite loo
@@ -116,6 +119,10 @@ impl IntegrationsPreferences {
             let _ = settings.set_boolean("start-minimized", sw.is_active());
             update_xdg_background_request();
         });
+
+        if !settings.boolean("background-portal-available") {
+            xdg_warn.set_visible(true);
+        }
 
         // Set up Last.fm settings
         let lastfm_settings = utils::meta_provider_settings("lastfm");


### PR DESCRIPTION
We'll now no longer crash and will instead show a warning in the preferences page for background capability.

Should fix #85.

Background running should still work, albeit without shell integration.