### PR TITLE
FFT backends rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -89,6 +89,10 @@
 		<key name="pipewire-last-device" type="s">
 			<default>''</default>
 		</key>
+
+		<key name="pipewire-restart-between-songs" type="b">
+			<default>true</default>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.library" path="/io/github/htkhiem/Euphonica/library/">

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -85,6 +85,10 @@
 			<default>'44100:16:2'</default>
 			<summary>Audio format of FIFO output for use by the visualiser (specified in the same form as in your mpd.conf).</summary>
 		</key>
+
+		<key name="pipewire-last-device" type="s">
+			<default>''</default>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.library" path="/io/github/htkhiem/Euphonica/library/">

--- a/src/gtk/library/recent-view.ui
+++ b/src/gtk/library/recent-view.ui
@@ -72,7 +72,7 @@
                                               <object class="GtkImage">
                                                 <property name="icon_name">library-music-symbolic</property>
                                                 <style>
-                                                  <class name="title-2"/>
+                                                  <class name="title-3"/>
                                                 </style>
                                               </object>
                                             </child>
@@ -80,7 +80,7 @@
                                               <object class="GtkLabel">
                                                 <property name="label" translatable="true">Albums</property>
                                                 <style>
-                                                  <class name="title-2"/>
+                                                  <class name="title-3"/>
                                                 </style>
                                               </object>
                                             </child>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -117,6 +117,11 @@
           </object>
         </child>
         <child>
+          <object class="AdwComboRow" id="pipewire_devices">
+            <property name="title">Monitor device</property>
+          </object>
+        </child>
+        <child>
           <object class="AdwActionRow" id="fifo_path">
             <property name="title" translatable="true">FIFO file</property>
             <property name="subtitle">(none)</property>
@@ -187,7 +192,7 @@
             <property name="title" translatable="true">Status</property>
             <property name="subtitle">Invalid</property>
             <child type="suffix">
-              <object class="GtkButton" id="fifo_reconnect">
+              <object class="GtkButton" id="fft_reconnect">
                 <property name="label" translatable="true">Apply</property>
                 <property name="valign">center</property>
                 <style>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -118,7 +118,14 @@
         </child>
         <child>
           <object class="AdwComboRow" id="pipewire_devices">
-            <property name="title">Monitor device</property>
+            <property name="title" translatable="true">Monitor device</property>
+            <property name="subtitle" translatable="true">The visualiser captures audio from all source devices by default. This may turn microphones on and degrade sound quality of Bluetooth headsets. In that case, please select a specific device to capture from.</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwSwitchRow" id="pipewire_restart_between_songs">
+            <property name="title" translatable="true">Restart monitor thread between songs (experimental)</property>
+            <property name="subtitle" translatable="true">Allow PipeWire to vary sample rate and bit depth between songs by temporarily stopping the monitor thread ahead of song changes. Only works when songs are changed via Euphonica or by normal queue playback.</property>
           </object>
         </child>
         <child>

--- a/src/player/fft_backends/backend.rs
+++ b/src/player/fft_backends/backend.rs
@@ -23,7 +23,7 @@ pub trait FftBackendImpl {
     fn set_param(&self, key: &str, val: glib::Variant);
 
     fn start(self: Rc<Self>, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()>;
-    fn stop(&self);
+    fn stop(&self, block: bool);
 }
 
 pub trait FftBackendExt: FftBackendImpl {

--- a/src/player/fft_backends/backend.rs
+++ b/src/player/fft_backends/backend.rs
@@ -1,4 +1,10 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::Cell,
+    sync::{Arc, Mutex, OnceLock}
+};
+use glib::{Properties, prelude::*, subclass::{prelude::*, Signal}, Class};
+
+use crate::player::Player;
 
 #[derive(Clone, Copy, Debug, glib::Enum, PartialEq, Default)]
 #[enum_type(name = "EuphonicaFftStatus")]
@@ -10,13 +16,27 @@ pub enum FftStatus {
     Reading,
 }
 
-pub trait FftBackend {
-    /// Start a new FFT thread reading from a particular data source.
-    /// This function must not block the main thread.
+pub trait FftBackendImpl {
+    fn player(&self) -> &Player;
+    fn get_param(&self, key: &str) -> Option<glib::Variant>;
+    fn set_param(&self, key: &str, val: glib::Variant);
+
     fn start(&self, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()>;
-
-    /// Stop the FFT thread of this backend.
     fn stop(&self);
-
-    fn status(&self) -> FftStatus;
 }
+
+pub trait FftBackendExt: FftBackendImpl {
+    fn status(&self) -> FftStatus {
+        self.player().fft_status()
+    }
+
+    fn set_status(&self, new: FftStatus) {
+        self.player().set_fft_status(new);
+    }
+
+    fn emit_param_changed(&self, key: &str, val: &glib::Variant) {
+        self.player().emit_by_name::<()>("fft-param-changed", &[&key, val]);
+    }
+}
+
+impl<O: FftBackendImpl> FftBackendExt for O {}

--- a/src/player/fft_backends/fifo.rs
+++ b/src/player/fft_backends/fifo.rs
@@ -1,25 +1,53 @@
 use gio::{self, prelude::*};
+use glib::{subclass::prelude::*, clone};
 use std::{
-    cell::RefCell, str::FromStr, sync::{Arc, Mutex, RwLock}, thread, time::Duration
+    cell::RefCell, str::FromStr, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration
 };
 
 use mpd::status::AudioFormat;
 
-use crate::utils::settings_manager;
-use super::backend::{FftStatus, FftBackend};
+use crate::{player::Player, utils::settings_manager};
+use super::backend::{FftBackendImpl, FftStatus, FftBackendExt};
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct FifoFftBackend {
-    fft_status: Arc<RwLock<FftStatus>>,
-    fft_handle: RefCell<Option<gio::JoinHandle<()>>>
+    fft_handle: RefCell<Option<gio::JoinHandle<()>>>,
+    fg_handle: RefCell<Option<glib::JoinHandle<()>>>,
+    player: Player,
+    stop_flag: Arc<AtomicBool>
 }
 
-impl FftBackend for FifoFftBackend {
+impl FifoFftBackend {
+    pub fn new(player: Player) -> Self {
+        Self {
+            fft_handle: RefCell::default(),
+            fg_handle: RefCell::default(),
+            player,
+            stop_flag: Arc::new(AtomicBool::new(false))
+        }
+    }
+}
+
+impl FftBackendImpl for FifoFftBackend {
+    fn player(&self) -> &Player {
+        &self.player
+    }
+
+    /// FIFO backend does not make use of runtime configuration
+    fn get_param(&self, _key: &str) -> Option<glib::Variant> {
+        None
+    }
+
+    /// FIFO backend does not make use of runtime configuration
+    fn set_param(&self, _key: &str, _val: glib::Variant) {}
+
     fn start(&self, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()> {
-        let curr_status: FftStatus = *self.fft_status.read().unwrap();
+        self.stop_flag.store(false, Ordering::Relaxed);
+        let curr_status = self.status();
         println!("Current status: {:?}", curr_status);
         if curr_status != FftStatus::Reading && curr_status != FftStatus::Stopping {
-            let fft_status = self.fft_status.clone();
+            let stop_flag = self.stop_flag.clone();
+            let (sender, receiver) = async_channel::unbounded::<FftStatus>();
             let fft_handle = gio::spawn_blocking(move || {
                 println!("Starting FIFO backend");
                 let settings = settings_manager();
@@ -41,6 +69,7 @@ impl FftBackend for FifoFftBackend {
                         let mut fft_buf_right: Vec<f32> = vec![0.0; n_samples];
                         let mut curr_step_left: Vec<f32> = vec![0.0; n_bins];
                         let mut curr_step_right: Vec<f32> = vec![0.0; n_bins];
+                        let mut was_reading: bool = false;
                         'outer: loop {
                             // These should be applied on-the-fly
                             let bin_mode =
@@ -111,9 +140,10 @@ impl FftBackend for FifoFftBackend {
                                 }
                                 Err(e) => match e.kind() {
                                     std::io::ErrorKind::UnexpectedEof
-                                    | std::io::ErrorKind::WouldBlock => {
-                                        *fft_status.write().unwrap() = FftStatus::ValidNotReading;
-                                    }
+                                        | std::io::ErrorKind::WouldBlock => {
+                                            was_reading = false;
+                                            sender.send_blocking(FftStatus::ValidNotReading);
+                                        }
                                     _ => {
                                         println!("FFT ERR: {:?}", &e);
                                         break 'outer;
@@ -122,12 +152,12 @@ impl FftBackend for FifoFftBackend {
                             }
                             // Placed here such that we can use the first iteration to verify
                             // that the settings are correct.
-                            let curr_status = *fft_status.read().unwrap();
-                            if curr_status == FftStatus::Stopping {
+                            if stop_flag.load(Ordering::Relaxed) {
                                 println!("Stopping thread...");
                                 return;
-                            } else if curr_status != FftStatus::Reading {
-                                *fft_status.write().unwrap() = FftStatus::Reading;
+                            } else if !was_reading {
+                                was_reading = true;
+                                sender.send_blocking(FftStatus::Reading);
                             }
                             thread::sleep(Duration::from_millis((1000.0 / fps).floor() as u64));
                         }
@@ -135,9 +165,27 @@ impl FftBackend for FifoFftBackend {
                 }
                 // All graceful thread shutdowns are inside the loop. If we've reached here then
                 // it's an error.
-                *fft_status.write().unwrap() = FftStatus::Invalid;
+                sender.send_blocking(FftStatus::Invalid);
             });
             self.fft_handle.replace(Some(fft_handle));
+
+            let player = self.player();
+            if let Some(old_handle) = self.fg_handle.replace(Some(glib::MainContext::default().spawn_local(clone!(
+                #[weak]
+                player,
+                async move {
+                    use futures::prelude::*;
+                    // Allow receiver to be mutated, but keep it at the same memory address.
+                    // See Receiver::next doc for why this is needed.
+                    let mut receiver = std::pin::pin!(receiver);
+                    while let Some(new_status) = receiver.next().await {
+                        player.set_fft_status(new_status);
+                    }
+                }
+            )))) {
+                old_handle.abort();
+            }
+
             return Ok(());
         }
         else {
@@ -147,20 +195,17 @@ impl FftBackend for FifoFftBackend {
     }
 
     fn stop(&self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
         if let Some(handle) = self.fft_handle.take() {
-            *self.fft_status.write().unwrap() = FftStatus::Stopping;
-            let stop_future = glib::MainContext::default().spawn_local(
-                async move {
-                    let _ = handle.await;
-                }
-            );
+            let stop_future = glib::MainContext::default().spawn_local(async move {
+                let _ = handle.await;
+            });
             let _ = glib::MainContext::default().block_on(stop_future);
-            // In case the thread is dead to begin with
-            *self.fft_status.write().unwrap() = FftStatus::ValidNotReading;
         }
-    }
-
-    fn status(&self) -> FftStatus {
-        *self.fft_status.read().unwrap()
+        // In case the thread is dead to begin with
+        self.player().set_fft_status(FftStatus::ValidNotReading);
+        if let Some(old_handle) = self.fg_handle.take() {
+            old_handle.abort();
+        }
     }
 }

--- a/src/player/fft_backends/fifo.rs
+++ b/src/player/fft_backends/fifo.rs
@@ -1,7 +1,7 @@
 use gio::{self, prelude::*};
 use glib::{subclass::prelude::*, clone};
 use std::{
-    cell::RefCell, str::FromStr, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration
+    cell::RefCell, rc::Rc, str::FromStr, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration
 };
 
 use mpd::status::AudioFormat;
@@ -29,6 +29,10 @@ impl FifoFftBackend {
 }
 
 impl FftBackendImpl for FifoFftBackend {
+    fn name(&self) -> &'static str {
+        "fifo"
+    }
+
     fn player(&self) -> &Player {
         &self.player
     }
@@ -41,7 +45,7 @@ impl FftBackendImpl for FifoFftBackend {
     /// FIFO backend does not make use of runtime configuration
     fn set_param(&self, _key: &str, _val: glib::Variant) {}
 
-    fn start(&self, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()> {
+    fn start(self: Rc<Self>, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()> {
         self.stop_flag.store(false, Ordering::Relaxed);
         let curr_status = self.status();
         println!("Current status: {:?}", curr_status);

--- a/src/player/fft_backends/mod.rs
+++ b/src/player/fft_backends/mod.rs
@@ -12,6 +12,6 @@ pub use pipewire::PipeWireFftBackend;
 #[duplicate_item(name; [FifoFftBackend]; [PipeWireFftBackend])]
 impl Drop for name {
     fn drop(&mut self) {
-        self.stop();
+        self.stop(true);
     }
 }

--- a/src/player/fft_backends/mod.rs
+++ b/src/player/fft_backends/mod.rs
@@ -1,4 +1,4 @@
-// use duplicate::duplicate_item;
+use duplicate::duplicate_item;
 
 pub mod fft;
 pub mod backend;
@@ -9,9 +9,9 @@ use backend::*;
 pub use fifo::FifoFftBackend;
 pub use pipewire::PipeWireFftBackend;
 
-// #[duplicate_item(name; [FifoFftBackend]; [PipeWireFftBackend])]
-// impl Drop for name {
-//     fn drop(&mut self) {
-//         self.stop();
-//     }
-// }
+#[duplicate_item(name; [FifoFftBackend]; [PipeWireFftBackend])]
+impl Drop for name {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/src/player/fft_backends/mod.rs
+++ b/src/player/fft_backends/mod.rs
@@ -1,4 +1,4 @@
-use duplicate::duplicate_item;
+// use duplicate::duplicate_item;
 
 pub mod fft;
 pub mod backend;
@@ -9,9 +9,9 @@ use backend::*;
 pub use fifo::FifoFftBackend;
 pub use pipewire::PipeWireFftBackend;
 
-#[duplicate_item(name; [FifoFftBackend]; [PipeWireFftBackend])]
-impl Drop for name {
-    fn drop(&mut self) {
-        self.stop();
-    }
-}
+// #[duplicate_item(name; [FifoFftBackend]; [PipeWireFftBackend])]
+// impl Drop for name {
+//     fn drop(&mut self) {
+//         self.stop();
+//     }
+// }

--- a/src/player/fft_backends/pipewire.rs
+++ b/src/player/fft_backends/pipewire.rs
@@ -1,5 +1,6 @@
-use std::{cell::RefCell, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration};
-use gio::prelude::SettingsExt;
+use std::{cell::{Cell, RefCell}, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration};
+use gio::{self, prelude::*};
+use glib::clone;
 use mpd::status::AudioFormat;
 use pipewire as pw;
 use pw::{properties::properties, spa};
@@ -10,7 +11,7 @@ use std::convert::TryInto;
 use std::mem;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 
-use crate::utils::settings_manager;
+use crate::{player::Player, utils::settings_manager};
 
 // Based on https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/raw/main/pipewire/examples/audio-capture.rs
 // Our PipeWire backend involves two threads:
@@ -19,39 +20,84 @@ use crate::utils::settings_manager;
 // The capture thread writes into ring buffers to decouple FPS and window size
 // from PipeWire configuration, similar to the FIFO backend, except that in
 // the FIFO backend, the ringbuffer is implemented internally by BufReader.
-use super::backend::{FftBackend, FftStatus};
+use super::backend::{FftBackendImpl, FftBackendExt, FftStatus};
+
+struct Terminate;
 
 struct UserData {
     format: spa::param::audio::AudioInfoRaw,
     cursor_move: bool,
 }
 
-// Our message to the pipewire loop, this tells it to terminate.
-struct Terminate;
-
 pub struct PipeWireFftBackend {
-    pw_sender: RefCell<Option<pw::channel::Sender<Terminate>>>,
     pw_handle: RefCell<Option<gio::JoinHandle<()>>>,
-    fft_stop: Arc<AtomicBool>,
+    pw_sender: RefCell<Option<pw::channel::Sender<Terminate>>>,
     fft_handle: RefCell<Option<gio::JoinHandle<()>>>,
-
+    fg_handle: RefCell<Option<glib::JoinHandle<()>>>,
+    devices: RefCell<Vec<String>>,
+    curr_device: Cell<i32>,
+    player: Player,
+    stop_flag: Arc<AtomicBool>,
 }
 
-impl Default for PipeWireFftBackend {
-    fn default() -> Self {
-        pw::init();
+impl PipeWireFftBackend {
+    pub fn new(player: Player) -> Self {
         Self {
-            pw_sender: RefCell::new(None),
-            pw_handle: RefCell::new(None),
-            fft_stop: Arc::new(AtomicBool::new(false)),
-            fft_handle: RefCell::new(None)
+            pw_handle: RefCell::default(),
+            pw_sender: RefCell::default(),
+            fft_handle: RefCell::default(),
+            fg_handle: RefCell::default(),
+            devices: RefCell::new(Vec::new()),
+            curr_device: Cell::new(0),
+            player,
+            stop_flag: Arc::new(AtomicBool::new(false))
         }
     }
 }
 
-impl FftBackend for PipeWireFftBackend {
+impl FftBackendImpl for PipeWireFftBackend {
+    fn player(&self) -> &Player {
+        &self.player
+    }
+
+    fn get_param(&self, key: &str) -> Option<glib::Variant> {
+        match key {
+            "devices" => Some(self.devices.borrow().to_variant()),
+            "current-device" => Some(self.curr_device.get().to_variant()),
+            _ => unimplemented!()
+        }
+    }
+
+    /// FIFO backend does not make use of runtime configuration
+    fn set_param(&self, key: &str, val: glib::Variant) {
+        match key {
+            "devices" => {
+                if let Some(devices) = val.get::<Vec<String>>() {
+                    let new_len = devices.len() as i32;
+                    self.devices.replace(devices);
+                    self.curr_device.set(0);
+                    self.emit_param_changed("devices", &val);
+                    if self.curr_device.get() >= new_len {
+                        let new_val = new_len - 1;
+                        self.curr_device.set(new_val);
+                        self.emit_param_changed("current-device", &new_val.to_variant());
+                    }
+                }
+            },
+            "current-device" => {
+                if let Some(new_idx) = val.get::<i32>() {
+                    let max_idx = self.devices.borrow().len() as i32 - 1;
+                    let final_val = max_idx.min(new_idx);
+                    self.curr_device.set(final_val);
+                    self.emit_param_changed("current-device", &final_val.to_variant());
+                }
+            },
+            _ => unimplemented!()
+        }
+    }
+
     fn start(&self, output: Arc<Mutex<(Vec<f32>, Vec<f32>)>>) -> Result<(), ()> {
-        let stop_flag = self.fft_stop.clone();
+        let stop_flag = self.stop_flag.clone();
         stop_flag.store(false, Ordering::Relaxed);
         let should_start = {
             self.pw_handle.borrow().is_none() && self.fft_handle.borrow().is_none()
@@ -61,6 +107,7 @@ impl FftBackend for PipeWireFftBackend {
             let player_settings = settings.child("player");
             let n_samples = player_settings.uint("visualizer-fft-samples") as usize;
             let n_bins = player_settings.uint("visualizer-spectrum-bins") as usize;
+            let (fg_sender, fg_receiver) = async_channel::unbounded::<FftStatus>();
             let (pw_sender, pw_receiver) = pw::channel::channel::<Terminate>();
             let samples = {
                 let mut samples: (AllocRingBuffer<f32>, AllocRingBuffer<f32>) = (
@@ -76,143 +123,172 @@ impl FftBackend for PipeWireFftBackend {
             let pw_format = format.clone();
             self.pw_sender.replace(Some(pw_sender));
             // Start the PipeWire capture thread
-            let pw_handle = gio::spawn_blocking(move || {
-                let pw_loop = pw::main_loop::MainLoop::new(None).expect("PipeWire FFT thread crashed");
-                let _receiver = pw_receiver.attach(pw_loop.loop_(), {
-                    let pw_loop = pw_loop.clone();
-                    move |_| pw_loop.quit()
-                });
+            let pw_handle = gio::spawn_blocking(clone!(
+                #[strong]
+                fg_sender,
+                move || {
+                    let Ok(pw_loop) = pw::main_loop::MainLoop::new(None) else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
+                    };
+                    let _receiver = pw_receiver.attach(pw_loop.loop_(), {
+                        let pw_loop = pw_loop.clone();
+                        move |_| pw_loop.quit()
+                    });
 
-                let context = pw::context::Context::new(&pw_loop).expect("PipeWire FFT thread crashed");
-                let core = context.connect(None).expect("PipeWire FFT thread crashed");
+                    let Ok(context) = pw::context::Context::new(&pw_loop) else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
+                    };
+                    let Ok(core) = context.connect(None) else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
+                    };
 
-                let data = UserData {
-                    format: Default::default(),
-                    cursor_move: false,
-                };
+                    let data = UserData {
+                        format: Default::default(),
+                        cursor_move: false,
+                    };
 
-                /* Create a simple stream, the simple stream manages the core and remote
-                 * objects for you if you don't need to deal with them.
-                 *
-                 * If you plan to autoconnect your stream, you need to provide at least
-                 * media, category and role properties.
-                 *
-                 * Pass your events and a user_data pointer as the last arguments. This
-                 * will inform you about the stream state. The most important event
-                 * you need to listen to is the process event where you need to produce
-                 * the data.
-                 */
-                let props = properties! {
-                    *pw::keys::MEDIA_TYPE => "Audio",
-                    *pw::keys::MEDIA_CATEGORY => "Capture",
-                    *pw::keys::MEDIA_ROLE => "Music",
-                };
+                    /* Create a simple stream, the simple stream manages the core and remote
+                     * objects for you if you don't need to deal with them.
+                     *
+                     * If you plan to autoconnect your stream, you need to provide at least
+                     * media, category and role properties.
+                     *
+                     * Pass your events and a user_data pointer as the last arguments. This
+                     * will inform you about the stream state. The most important event
+                     * you need to listen to is the process event where you need to produce
+                     * the data.
+                     */
+                    let props = properties! {
+                        *pw::keys::MEDIA_TYPE => "Audio",
+                        *pw::keys::MEDIA_CATEGORY => "Capture",
+                        *pw::keys::MEDIA_ROLE => "Music",
+                    };
 
-                let pw_stream = pw::stream::Stream::new(&core, "audio-capture", props).expect("PipeWire FFT thread crashed");
+                    let Ok(pw_stream) = pw::stream::Stream::new(&core, "audio-capture", props) else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
+                    };
 
-                let _listener = pw_stream
-                    .add_local_listener_with_user_data(data)
-                // After connecting the stream, the server will want to configure some parameters on the stream
-                    .param_changed(|_, user_data, id, param| {
-                        // NULL means to clear the format
-                        let Some(param) = param else {
-                            return;
-                        };
-                        if id != pw::spa::param::ParamType::Format.as_raw() {
-                            return;
-                        }
+                    let Ok(_listener) = pw_stream
+                        .add_local_listener_with_user_data(data)
+                    // After connecting the stream, the server will want to configure some parameters on the stream
+                        .param_changed(clone!(
+                            #[strong]
+                            fg_sender,
+                            move |_, user_data, id, param| {
+                                // NULL means to clear the format
+                                let Some(param) = param else {
+                                    return;
+                                };
+                                if id != pw::spa::param::ParamType::Format.as_raw() {
+                                    return;
+                                }
 
-                        let (media_type, media_subtype) = match format_utils::parse_format(param) {
-                            Ok(v) => v,
-                            Err(_) => return,
-                        };
+                                let (media_type, media_subtype) = match format_utils::parse_format(param) {
+                                    Ok(v) => v,
+                                    Err(_) => return,
+                                };
 
-                        if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
-                            return;
-                        }
+                                if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
+                                    return;
+                                }
 
-                        user_data
-                            .format
-                            .parse(param)
-                            .expect("Failed to parse param 'changed' to AudioInfoRaw");
-                    })
-                    .process(move |stream, user_data| match stream.dequeue_buffer() {
-                        None => {return;},
-                        Some(mut buffer) => {
-                            let buffer_data = buffer.datas_mut();
-                            if buffer_data.is_empty() {
-                                return;
-                            }
-
-                            let data = &mut buffer_data[0];
-                            let n_samples_avail = data.chunk().size() / (mem::size_of::<f32>() as u32);
-                            let n_channels = user_data.format.channels();
-                            if let Ok(mut format_lock) = pw_format.lock() {
-                                *format_lock = AudioFormat {
-                                    rate: user_data.format.rate(),
-                                    chans: n_channels as u8,
-                                    bits: match user_data.format.format() {
-                                        SpaAudioFormat::F32BE | SpaAudioFormat::F32LE => 32,
-                                        _ => unimplemented!()
-                                        // Might support these directly in the future but for now we're only
-                                        // taking in float32le.
-                                        // SpaAudioFormat::F64BE | SpaAudioFormat::F64LE => 64,
-                                        // SpaAudioFormat::S16 | SpaAudioFormat::S16BE | SpaAudioFormat::S16LE | SpaAudioFormat::U16 | SpaAudioFormat::U16BE | SpaAudioFormat::U16LE => 16,
-                                        // SpaAudioFormat::S24 | SpaAudioFormat::S24BE | SpaAudioFormat::S24LE | SpaAudioFormat::U24 | SpaAudioFormat::U24BE | SpaAudioFormat::U24LE => 24,
-                                    }
+                                let Ok(_) = user_data
+                                    .format
+                                    .parse(param)
+                                else {
+                                    let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                                    return;
                                 };
                             }
-                            if let Some(samples) = data.data() {
-                                // ASSUME THERE ARE AT LEAST TWO CHANNELS.
-                                // I'm not gatekeeping but audiophiles listen to at least stereo sound :)
-                                let mut locked_buffer = pw_samples.lock().unwrap();
-                                for n in (0..n_samples_avail).step_by(n_channels as usize) {
-                                    let l_start = n as usize * mem::size_of::<f32>();
-                                    let l_end = l_start + mem::size_of::<f32>();
-                                    let r_end = l_end + mem::size_of::<f32>();
-
-                                    locked_buffer.0.push(f32::from_le_bytes(samples[l_start..l_end].try_into().unwrap()));
-                                    locked_buffer.1.push(f32::from_le_bytes(samples[l_end..r_end].try_into().unwrap()));
+                        ))
+                        .process(move |stream, user_data| match stream.dequeue_buffer() {
+                            None => {return;},
+                            Some(mut buffer) => {
+                                println!("Incoming data");
+                                let buffer_data = buffer.datas_mut();
+                                if buffer_data.is_empty() {
+                                    return;
                                 }
-                                user_data.cursor_move = true;
+
+                                let data = &mut buffer_data[0];
+                                let n_samples_avail = data.chunk().size() / (mem::size_of::<f32>() as u32);
+                                let n_channels = user_data.format.channels();
+                                if let Ok(mut format_lock) = pw_format.lock() {
+                                    *format_lock = AudioFormat {
+                                        rate: user_data.format.rate(),
+                                        chans: n_channels as u8,
+                                        bits: match user_data.format.format() {
+                                            SpaAudioFormat::F32BE | SpaAudioFormat::F32LE => 32,
+                                            _ => unimplemented!()
+                                            // Might support these directly in the future but for now we're only
+                                            // taking in float32le.
+                                            // SpaAudioFormat::F64BE | SpaAudioFormat::F64LE => 64,
+                                            // SpaAudioFormat::S16 | SpaAudioFormat::S16BE | SpaAudioFormat::S16LE | SpaAudioFormat::U16 | SpaAudioFormat::U16BE | SpaAudioFormat::U16LE => 16,
+                                            // SpaAudioFormat::S24 | SpaAudioFormat::S24BE | SpaAudioFormat::S24LE | SpaAudioFormat::U24 | SpaAudioFormat::U24BE | SpaAudioFormat::U24LE => 24,
+                                        }
+                                    };
+                                }
+                                if let Some(samples) = data.data() {
+                                    // ASSUME THERE ARE AT LEAST TWO CHANNELS.
+                                    // I'm not gatekeeping but audiophiles listen to at least stereo sound :)
+                                    let mut locked_buffer = pw_samples.lock().unwrap();
+                                    for n in (0..n_samples_avail).step_by(n_channels as usize) {
+                                        let l_start = n as usize * mem::size_of::<f32>();
+                                        let l_end = l_start + mem::size_of::<f32>();
+                                        let r_end = l_end + mem::size_of::<f32>();
+
+                                        locked_buffer.0.push(f32::from_le_bytes(samples[l_start..l_end].try_into().unwrap()));
+                                        locked_buffer.1.push(f32::from_le_bytes(samples[l_end..r_end].try_into().unwrap()));
+                                    }
+                                    user_data.cursor_move = true;
+                                }
                             }
-                        }
-                    })
-                    .register().expect("PipeWire FFT thread crashed");
+                        })
+                        .register() else {
+                            let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                            return;
+                        };
 
-                /* Make one parameter with the supported formats. The SPA_PARAM_EnumFormat
-                 * id means that this is a format enumeration (of 1 value).
-                 * We leave the channels and rate empty to accept the native graph
-                 * rate and channels. */
-                let mut audio_info = spa::param::audio::AudioInfoRaw::new();
-                audio_info.set_format(spa::param::audio::AudioFormat::F32LE);
-                let obj = pw::spa::pod::Object {
-                    type_: pw::spa::utils::SpaTypes::ObjectParamFormat.as_raw(),
-                    id: pw::spa::param::ParamType::EnumFormat.as_raw(),
-                    properties: audio_info.into(),
-                };
-                let values: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
-                    std::io::Cursor::new(Vec::new()),
-                    &pw::spa::pod::Value::Object(obj),
-                )
-                    .unwrap()
-                    .0
-                    .into_inner();
+                    /* Make one parameter with the supported formats. The SPA_PARAM_EnumFormat
+                     * id means that this is a format enumeration (of 1 value).
+                     * We leave the channels and rate empty to accept the native graph
+                     * rate and channels. */
+                    let mut audio_info = spa::param::audio::AudioInfoRaw::new();
+                    audio_info.set_format(spa::param::audio::AudioFormat::F32LE);
+                    let obj = pw::spa::pod::Object {
+                        type_: pw::spa::utils::SpaTypes::ObjectParamFormat.as_raw(),
+                        id: pw::spa::param::ParamType::EnumFormat.as_raw(),
+                        properties: audio_info.into(),
+                    };
+                    let values: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
+                        std::io::Cursor::new(Vec::new()),
+                        &pw::spa::pod::Value::Object(obj),
+                    )
+                        .unwrap()
+                        .0
+                        .into_inner();
 
-                let mut params = [Pod::from_bytes(&values).unwrap()];
+                    let mut params = [Pod::from_bytes(&values).unwrap()];
 
-                /* Now connect this stream. We ask that our process function is
-                 * called in a realtime thread. */
-                pw_stream.connect(
-                    spa::utils::Direction::Input,
-                    None,
-                    pw::stream::StreamFlags::AUTOCONNECT
-                        | pw::stream::StreamFlags::MAP_BUFFERS
-                        | pw::stream::StreamFlags::RT_PROCESS,
-                    &mut params,
-                ).expect("PipeWire FFT thread crashed");
-                pw_loop.run();
-            });
+                    /* Now connect this stream. We ask that our process function is
+                     * called in a realtime thread. */
+                    let Ok(_) = pw_stream.connect(
+                        spa::utils::Direction::Input,
+                        None,
+                        pw::stream::StreamFlags::AUTOCONNECT
+                            | pw::stream::StreamFlags::MAP_BUFFERS
+                            | pw::stream::StreamFlags::RT_PROCESS,
+                        &mut params,
+                    ) else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
+                    };
+                    pw_loop.run();
+                }));
             self.pw_handle.replace(Some(pw_handle));
 
             // Run FFT thread
@@ -229,8 +305,9 @@ impl FftBackend for PipeWireFftBackend {
                         break 'outer;
                     }
                     // Just get our own copy to minimise blocking
-                    let format_lock = {
-                        format.lock().expect("Unable to read format of PipeWire stream from FFT thread").clone()
+                    let Ok(format_lock) = format.lock() else {
+                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
                     };
                     // Skip processing until format is nonzero
                     if format_lock.rate == 0 || format_lock.chans == 0 { continue; }
@@ -299,12 +376,32 @@ impl FftBackend for PipeWireFftBackend {
                         }
                         // println!("FFT L: {:?}\tR: {:?}", &output_lock.0, &output_lock.1);
                     } else {
-                        panic!("Unable to lock FFT data mutex");
+                         let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                        return;
                     }
                     thread::sleep(Duration::from_millis((1000.0 / fps).floor() as u64));
                 }
             });
             self.fft_handle.replace(Some(fft_handle));
+            self.set_status(FftStatus::Reading);
+
+            let player = self.player();
+            if let Some(old_handle) = self.fg_handle.replace(Some(glib::MainContext::default().spawn_local(clone!(
+                #[weak]
+                player,
+                async move {
+                    use futures::prelude::*;
+                    // Allow receiver to be mutated, but keep it at the same memory address.
+                    // See Receiver::next doc for why this is needed.
+                    let mut receiver = std::pin::pin!(fg_receiver);
+                    while let Some(new_status) = receiver.next().await {
+                        player.set_fft_status(new_status);
+                    }
+                }
+            )))) {
+                old_handle.abort();
+            }
+
             Ok(())
         }
         else {
@@ -313,7 +410,7 @@ impl FftBackend for PipeWireFftBackend {
     }
 
     fn stop(&self) {
-        let fft_stop = self.fft_stop.clone();
+        let fft_stop = self.stop_flag.clone();
         fft_stop.store(true, Ordering::Relaxed);
         if let Some(sender) = self.pw_sender.take() {
             if sender.send(Terminate).is_ok() {
@@ -325,14 +422,6 @@ impl FftBackend for PipeWireFftBackend {
                 }
             }
         }
-    }
-
-    fn status(&self) -> FftStatus {
-        if self.pw_handle.borrow().as_ref().is_some() {
-            FftStatus::Reading
-        }
-        else {
-            FftStatus::Invalid
-        }
+        self.set_status(FftStatus::ValidNotReading);
     }
 }

--- a/src/player/fft_backends/pipewire.rs
+++ b/src/player/fft_backends/pipewire.rs
@@ -103,6 +103,7 @@ impl FftBackendImpl for PipeWireFftBackend {
             self.pw_handle.borrow().is_none() && self.fft_handle.borrow().is_none()
         };
         if should_start {
+            // println!("Starting a new PipeWire listener...");
             let settings = settings_manager();
             let player_settings = settings.child("player");
             let n_samples = player_settings.uint("visualizer-fft-samples") as usize;
@@ -189,10 +190,13 @@ impl FftBackendImpl for PipeWireFftBackend {
 
                                 let (media_type, media_subtype) = match format_utils::parse_format(param) {
                                     Ok(v) => v,
-                                    Err(_) => return,
+                                    Err(_) => {
+                                        return
+                                    },
                                 };
 
                                 if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
+                                    println!("Not MediaType::Audio || MediaSubtype::Raw, skipping");
                                     return;
                                 }
 
@@ -200,6 +204,7 @@ impl FftBackendImpl for PipeWireFftBackend {
                                     .format
                                     .parse(param)
                                 else {
+                                    println!("Failed to parse format");
                                     let _ = fg_sender.send_blocking(FftStatus::Invalid);
                                     return;
                                 };
@@ -208,34 +213,43 @@ impl FftBackendImpl for PipeWireFftBackend {
                         .process(move |stream, user_data| match stream.dequeue_buffer() {
                             None => {return;},
                             Some(mut buffer) => {
-                                println!("Incoming data");
                                 let buffer_data = buffer.datas_mut();
                                 if buffer_data.is_empty() {
+                                    // println!("buffer_data is empty. Skipping");
                                     return;
                                 }
 
                                 let data = &mut buffer_data[0];
                                 let n_samples_avail = data.chunk().size() / (mem::size_of::<f32>() as u32);
                                 let n_channels = user_data.format.channels();
-                                if let Ok(mut format_lock) = pw_format.lock() {
-                                    *format_lock = AudioFormat {
-                                        rate: user_data.format.rate(),
-                                        chans: n_channels as u8,
-                                        bits: match user_data.format.format() {
-                                            SpaAudioFormat::F32BE | SpaAudioFormat::F32LE => 32,
-                                            _ => unimplemented!()
-                                            // Might support these directly in the future but for now we're only
-                                            // taking in float32le.
-                                            // SpaAudioFormat::F64BE | SpaAudioFormat::F64LE => 64,
-                                            // SpaAudioFormat::S16 | SpaAudioFormat::S16BE | SpaAudioFormat::S16LE | SpaAudioFormat::U16 | SpaAudioFormat::U16BE | SpaAudioFormat::U16LE => 16,
-                                            // SpaAudioFormat::S24 | SpaAudioFormat::S24BE | SpaAudioFormat::S24LE | SpaAudioFormat::U24 | SpaAudioFormat::U24BE | SpaAudioFormat::U24LE => 24,
-                                        }
-                                    };
+                                // println!("Locking pw_format...");
+                                {
+                                    if let Ok(mut format_lock) = pw_format.lock() {
+                                        // println!("Locked pw_format");
+                                        *format_lock = AudioFormat {
+                                            rate: user_data.format.rate(),
+                                            chans: n_channels as u8,
+                                            bits: match user_data.format.format() {
+                                                SpaAudioFormat::F32BE | SpaAudioFormat::F32LE => 32,
+                                                _ => unimplemented!()
+                                                // Might support these directly in the future but for now we're only
+                                                // taking in float32le.
+                                                // SpaAudioFormat::F64BE | SpaAudioFormat::F64LE => 64,
+                                                // SpaAudioFormat::S16 | SpaAudioFormat::S16BE | SpaAudioFormat::S16LE | SpaAudioFormat::U16 | SpaAudioFormat::U16BE | SpaAudioFormat::U16LE => 16,
+                                                // SpaAudioFormat::S24 | SpaAudioFormat::S24BE | SpaAudioFormat::S24LE | SpaAudioFormat::U24 | SpaAudioFormat::U24BE | SpaAudioFormat::U24LE => 24,
+                                            }
+                                        };
+                                    }
                                 }
+                                // println!("Unlocked pw_format");
+
                                 if let Some(samples) = data.data() {
+                                    // println!("Found samples");
                                     // ASSUME THERE ARE AT LEAST TWO CHANNELS.
                                     // I'm not gatekeeping but audiophiles listen to at least stereo sound :)
+                                    // println!("Locking buffer...");
                                     let mut locked_buffer = pw_samples.lock().unwrap();
+                                    // println!("Locked buffer");
                                     for n in (0..n_samples_avail).step_by(n_channels as usize) {
                                         let l_start = n as usize * mem::size_of::<f32>();
                                         let l_end = l_start + mem::size_of::<f32>();
@@ -246,6 +260,7 @@ impl FftBackendImpl for PipeWireFftBackend {
                                     }
                                     user_data.cursor_move = true;
                                 }
+                                // println!("Unlocked buffer");
                             }
                         })
                         .register() else {
@@ -284,6 +299,7 @@ impl FftBackendImpl for PipeWireFftBackend {
                             | pw::stream::StreamFlags::RT_PROCESS,
                         &mut params,
                     ) else {
+                        println!("Failed to connect PipeWire stream");
                         let _ = fg_sender.send_blocking(FftStatus::Invalid);
                         return;
                     };
@@ -304,81 +320,88 @@ impl FftBackendImpl for PipeWireFftBackend {
                     if stop_flag.load(Ordering::Relaxed) {
                         break 'outer;
                     }
-                    // Just get our own copy to minimise blocking
-                    let Ok(format_lock) = format.lock() else {
-                        let _ = fg_sender.send_blocking(FftStatus::Invalid);
-                        return;
-                    };
-                    // Skip processing until format is nonzero
-                    if format_lock.rate == 0 || format_lock.chans == 0 { continue; }
-                    // Copy ringbuffer to our static ones. Take care to read backward from the latest sample.
-                    if let Ok(ringbuffers) = samples.lock() {
-                        for pos in 0..n_samples {
-                            fft_buf_left[n_samples - pos - 1] = *ringbuffers.0.get_signed(-1 - pos as isize).unwrap_or(&(0.0 as f32));
-                            fft_buf_right[n_samples - pos - 1] = *ringbuffers.1.get_signed(-1 - pos as isize).unwrap_or(&(0.0 as f32));
-                        }
-                    }
-                    // These should be applied on-the-fly
-                    let bin_mode =
-                        if player_settings.boolean("visualizer-spectrum-use-log-bins") {
-                            super::fft::BinMode::Logarithmic
-                        } else {
-                            super::fft::BinMode::Linear
+                    // println!("FFT: locking format");
+                    {
+                        let Ok(format_lock) = format.lock() else {
+                            println!("PipeWire FFT: unable to lock format");
+                            let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                            return;
                         };
-                    let fps = player_settings.uint("visualizer-fps") as f32;
-                    let min_freq =
-                        player_settings.uint("visualizer-spectrum-min-hz") as f32;
-                    let max_freq =
-                        player_settings.uint("visualizer-spectrum-max-hz") as f32;
-                    let curr_step_weight = player_settings
-                        .double("visualizer-spectrum-curr-step-weight")
-                        as f32;
-                    // Compute outside of output mutex lock please
-
-                    super::fft::get_magnitudes(
-                        &format_lock,
-                        &mut fft_buf_left,
-                        &mut curr_step_left,
-                        n_bins as u32,
-                        bin_mode,
-                        min_freq,
-                        max_freq,
-                    );
-                    super::fft::get_magnitudes(
-                        &format_lock,
-                        &mut fft_buf_right,
-                        &mut curr_step_right,
-                        n_bins as u32,
-                        bin_mode,
-                        min_freq,
-                        max_freq,
-                    );
-                    // Replace last frame
-                    if let Ok(mut output_lock) = output.lock() {
-                        if output_lock.0.len() != n_bins
-                            || output_lock.1.len() != n_bins
-                        {
-                            output_lock.0.clear();
-                            output_lock.1.clear();
-                            for _ in 0..n_bins {
-                                output_lock.0.push(0.0);
-                                output_lock.1.push(0.0);
+                        // Skip processing until format is nonzero
+                        if format_lock.rate == 0 || format_lock.chans == 0 { continue; }
+                        // Copy ringbuffer to our static ones. Take care to read backward from the latest sample.
+                        if let Ok(ringbuffers) = samples.lock() {
+                            for pos in 0..n_samples {
+                                fft_buf_left[n_samples - pos - 1] = *ringbuffers.0.get_signed(-1 - pos as isize).unwrap_or(&(0.0 as f32));
+                                fft_buf_right[n_samples - pos - 1] = *ringbuffers.1.get_signed(-1 - pos as isize).unwrap_or(&(0.0 as f32));
                             }
                         }
-                        for i in 0..n_bins {
-                            // FIXME: To line up with FIFO backend we should scale this backend's magnitudes
-                            // up by 5x.
-                            output_lock.0[i] = curr_step_left[i] * curr_step_weight * 5.0
-                                + output_lock.0[i] * (1.0 - curr_step_weight);
-                            output_lock.1[i] = curr_step_right[i]
-                                * curr_step_weight * 5.0
-                                + output_lock.1[i] * (1.0 - curr_step_weight);
+                        // These should be applied on-the-fly
+                        let bin_mode =
+                            if player_settings.boolean("visualizer-spectrum-use-log-bins") {
+                                super::fft::BinMode::Logarithmic
+                            } else {
+                                super::fft::BinMode::Linear
+                            };
+                        let min_freq =
+                            player_settings.uint("visualizer-spectrum-min-hz") as f32;
+                        let max_freq =
+                            player_settings.uint("visualizer-spectrum-max-hz") as f32;
+                        let curr_step_weight = player_settings
+                            .double("visualizer-spectrum-curr-step-weight")
+                            as f32;
+                        // Compute outside of output mutex lock please
+
+                        super::fft::get_magnitudes(
+                            &format_lock,
+                            &mut fft_buf_left,
+                            &mut curr_step_left,
+                            n_bins as u32,
+                            bin_mode,
+                            min_freq,
+                            max_freq,
+                        );
+                        super::fft::get_magnitudes(
+                            &format_lock,
+                            &mut fft_buf_right,
+                            &mut curr_step_right,
+                            n_bins as u32,
+                            bin_mode,
+                            min_freq,
+                            max_freq,
+                        );
+                        // Replace last frame
+                        // println!("FFT: Locking output");
+                        if let Ok(mut output_lock) = output.lock() {
+                            // println!("Locked output");
+                            if output_lock.0.len() != n_bins
+                                || output_lock.1.len() != n_bins
+                            {
+                                output_lock.0.clear();
+                                output_lock.1.clear();
+                                for _ in 0..n_bins {
+                                    output_lock.0.push(0.0);
+                                    output_lock.1.push(0.0);
+                                }
+                            }
+                            for i in 0..n_bins {
+                                // FIXME: To line up with FIFO backend we should scale this backend's magnitudes
+                                // up by 5x.
+                                output_lock.0[i] = curr_step_left[i] * curr_step_weight * 5.0
+                                    + output_lock.0[i] * (1.0 - curr_step_weight);
+                                output_lock.1[i] = curr_step_right[i]
+                                    * curr_step_weight * 5.0
+                                    + output_lock.1[i] * (1.0 - curr_step_weight);
+                            }
+                            // println!("FFT L: {:?}\tR: {:?}", &output_lock.0, &output_lock.1);
+                        } else {
+                            println!("FFT: Failed to lock output for writing");
+                            let _ = fg_sender.send_blocking(FftStatus::Invalid);
+                            return;
                         }
-                        // println!("FFT L: {:?}\tR: {:?}", &output_lock.0, &output_lock.1);
-                    } else {
-                         let _ = fg_sender.send_blocking(FftStatus::Invalid);
-                        return;
                     }
+                    // println!("FFT: Unlocked output & format. Now sleeping...");
+                    let fps = player_settings.uint("visualizer-fps") as f32;
                     thread::sleep(Duration::from_millis((1000.0 / fps).floor() as u64));
                 }
             });
@@ -413,6 +436,7 @@ impl FftBackendImpl for PipeWireFftBackend {
         let fft_stop = self.stop_flag.clone();
         fft_stop.store(true, Ordering::Relaxed);
         if let Some(sender) = self.pw_sender.take() {
+            println!("Stopping PipeWire thread...");
             if sender.send(Terminate).is_ok() {
                 if let Some(handle) = self.pw_handle.take() {
                     let _ = glib::MainContext::default().block_on(handle);

--- a/src/player/seekbar.rs
+++ b/src/player/seekbar.rs
@@ -217,6 +217,6 @@ impl Seekbar {
             .sync_create()
             .build();
 
-        self.imp().player.set(player.clone());
+        let _ = self.imp().player.set(player.clone());
     }
 }

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -337,10 +337,6 @@ impl ClientPreferences {
         }
     }
 
-    fn on_fifo_changed(&self, state: FftStatus) {
-        self.imp().fifo_status.set_subtitle(state.get_description());
-    }
-
     fn on_playlists_status_changed(&self, cs: &ClientState) {
         // TODO: translatable
         let row = self.imp().playlists_status.get();
@@ -503,17 +499,16 @@ impl ClientPreferences {
             .build();
 
         // Visualiser
-        self.on_fifo_changed(player.fft_status());
-        player.connect_notify_local(
-            Some("fft-status"),
-            clone!(
-                #[weak(rename_to = this)]
-                self,
-                move |player, _| {
-                    this.on_fifo_changed(player.fft_status());
-                }
-            ),
-        );
+        player
+            .bind_property(
+                "fft-status",
+                &self.imp().fifo_status.get(),
+                "subtitle"
+            )
+            .transform_to(|_, status: FftStatus| Some(status.get_description()))
+            .sync_create()
+            .build();
+
         let player_settings = settings.child("player");
         imp.fifo_format
             .set_text(&conn_settings.string("mpd-fifo-format"));

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -115,6 +115,8 @@ mod imp {
         // PipeWire
         #[template_child]
         pub pipewire_devices: TemplateChild<adw::ComboRow>,
+        #[template_child]
+        pub pipewire_restart_between_songs: TemplateChild<adw::SwitchRow>,
         // FIFO
         #[template_child]
         pub fifo_path: TemplateChild<adw::ActionRow>,
@@ -189,6 +191,9 @@ mod imp {
                 .bind("mpd-fifo-path", &fifo_path_row, "subtitle")
                 .get_only()
                 .build();
+            viz_settings
+                .bind("pipewire-restart-between-songs", &self.pipewire_restart_between_songs.get(), "active")
+                .build();
             self.fifo_browse.connect_clicked(|_| {
                 utils::tokio_runtime().spawn(async move {
                     let maybe_files = SelectedFiles::open_file()
@@ -256,10 +261,14 @@ mod imp {
                     .build();
             }
             // Hide PipeWire-specific rows when FIFO is selected as data source
-            viz_source.bind_property("selected", &self.pipewire_devices.get(), "visible")
-                .transform_to(|_, val: u32| Some(val == 1))
-                .sync_create()
-                .build();
+            duplicate!{
+                [name; [pipewire_devices]; [pipewire_restart_between_songs];]
+                viz_source
+                    .bind_property("selected", &self.name.get(), "visible")
+                    .transform_to(|_, val: u32| Some(val == 1))
+                    .sync_create()
+                    .build();
+            }
         }
     }
     impl WidgetImpl for ClientPreferences {}


### PR DESCRIPTION
This PR fleshes out the FFT backends.

# Status reports

Previously backend status reports are static, updated only on connection/disconnection and not on actual audio stream or IO state changes. This means they couldn't really report errors that happen AFTER successful connections.

This PR moves all status reporting facilities to inside the Player controller. This being a GObject allows us to notify the UI whenever we want via glib signals.

# Backend trait improvements

I finally stopped procrastinating and learnt how to do trait autoimplementations the correct way. It should now be a bit easier and more Glib-idiomatic to implement new FFT backends.

# PipeWire improvements

The main focus of this PR is the PipeWire FFT backend.

- Euphonica now reports itself with more specific properties for better autoconnection results:
    - STREAM_MONITOR is now set to true to allow using faster resampling algos (we're just drawing a crude visualiser, why waste CPU cycles?)
    - STREAM_CAPTURE_SINK is also set to true now, to allow selecting any sink.
- **Monitor device is now selectable**. The PipeWire backend will now try to get a list of usable output nodes (sound cards, USB DACs, Bluetooth adapters, etc) and present to the user for selection. This should fix issues with autoconnection tripping Bluetooth headphones into headset mode (might fix #96 and #108).
- **Experimental automatic stream restart between tracks** have been added to allow PipeWire to match its output sample rate to each song, instead of being stuck to the one playing at the time Euphonica was launched. Basically allows bit-perfect playback with the right PipeWire configuration and supported hardware while still having the bouncy visualiser on screen. [Cava suffers from this too](https://askubuntu.com/questions/1550234/pipewire-switching-output-sample-rate-while-monitor-is-active).