### PR TITLE
Make queue updates asynchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "mpd",
  "mpris-server",
  "musicbrainz_rs",
+ "nohash-hasher",
  "once_cell",
  "open",
  "pipewire",
@@ -2835,6 +2836,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ urlencoding = "2.1.3"
 open = "5.3.2"
 resolve-path = "0.1.0"
 lru = "0.16.0"
+nohash-hasher = "0.2.0"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/src/application.rs
+++ b/src/application.rs
@@ -182,6 +182,7 @@ mod imp {
 
                 // If this is the main instance, respect the minimized flag
                 if !self.start_minimized.get() {
+                    self.player.get().unwrap().set_is_foreground(true);
                     self.obj().raise_window();
                 }
             }

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -14,7 +14,7 @@ extern crate bson;
 use lru::LruCache;
 use std::{num::NonZeroUsize, sync::Mutex};
 use async_channel::{Receiver, Sender};
-use image::io::Reader as ImageReader;
+use image::ImageReader;
 use gio::prelude::*;
 use glib::clone;
 use gtk::{gdk::{self, Texture}, gio, glib};
@@ -24,7 +24,7 @@ use std::{
     cell::OnceCell, fmt, fs::create_dir_all, path::PathBuf, rc::Rc, sync::{Arc, RwLock}
 };
 
-use crate::{common::SongInfo, meta_providers::{get_provider_with_priority, models::{ArtistMeta, Lyrics}}, utils::strip_filename_linux};
+use crate::{common::SongInfo, meta_providers::{get_provider, models::{ArtistMeta, Lyrics}}, utils::strip_filename_linux};
 use crate::{
     client::{BackgroundTask, MpdWrapper},
     common::{AlbumInfo, ArtistInfo},
@@ -102,14 +102,13 @@ impl fmt::Debug for Cache {
 }
 
 fn init_meta_provider_chain() -> MetadataChain {
-    let mut providers = MetadataChain::new(0);
+    let mut providers = MetadataChain::new();
     providers.providers = settings_manager()
         .child("metaprovider")
         .value("order")
         .array_iter_str()
         .unwrap()
-        .enumerate()
-        .map(|(prio, key)| get_provider_with_priority(key, prio as u32))
+        .map(|key| get_provider(key))
         .collect();
     providers
 }

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -323,12 +323,12 @@ pub fn find_album_meta(album: &AlbumInfo) -> Result<Option<AlbumMeta>, Error> {
     let conn = SQLITE_POOL.get().unwrap();
     if let Some(mbid) = album.mbid.as_deref() {
         query = conn
-            .prepare("select meta from albums where mbid = ?1")
+            .prepare("select data from albums where mbid = ?1")
             .unwrap()
             .query_row(params![mbid], |r| AlbumMetaRow::try_from(r));
     } else if let (title, Some(artist)) = (&album.title, album.get_artist_tag()) {
         query = conn
-            .prepare("select meta from albums where title = ?1 and artist = ?2")
+            .prepare("select data from albums where title = ?1 and artist = ?2")
             .unwrap()
             .query_row(params![title, artist], |r| AlbumMetaRow::try_from(r));
     } else {
@@ -353,12 +353,12 @@ pub fn find_artist_meta(artist: &ArtistInfo) -> Result<Option<ArtistMeta>, Error
     let conn = SQLITE_POOL.get().unwrap();
     if let Some(mbid) = artist.mbid.as_deref() {
         query = conn
-            .prepare("select meta from artists where mbid = ?1")
+            .prepare("select data from artists where mbid = ?1")
             .unwrap()
             .query_row(params![mbid], |r| ArtistMetaRow::try_from(r));
     } else {
         query = conn
-            .prepare("select meta from artists where name = ?1")
+            .prepare("select data from artists where name = ?1")
             .unwrap()
             .query_row(params![&artist.name], |r| ArtistMetaRow::try_from(r));
     }

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -225,11 +225,11 @@ pub enum Error {
 }
 
 pub struct AlbumMetaRow {
-    folder_uri: String,
-    mbid: Option<String>,
-    title: String,
-    artist: Option<String>,
-    last_modified: OffsetDateTime,
+    // folder_uri: String,
+    // mbid: Option<String>,
+    // title: String,
+    // artist: Option<String>,
+    // last_modified: OffsetDateTime,
     data: Vec<u8>, // BSON
 }
 
@@ -248,42 +248,20 @@ impl TryFrom<&Row<'_>> for AlbumMetaRow {
     type Error = SqliteError;
     fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
-            folder_uri: row.get(0)?,
-            mbid: row.get(1)?,
-            title: row.get(2)?,
-            artist: row.get(3)?,
-            last_modified: row.get(4)?,
-            data: row.get(5)?,
+            // folder_uri: row.get(0)?,
+            // mbid: row.get(1)?,
+            // title: row.get(2)?,
+            // artist: row.get(3)?,
+            // last_modified: row.get(4)?,
+            data: row.get(0)?,
         })
     }
 }
 
-impl AlbumMetaRow {
-    pub fn new(
-        folder_uri: String,
-        mbid: Option<String>,
-        title: String,
-        artist: Option<String>,
-        last_modified: OffsetDateTime,
-        meta: &AlbumMeta,
-    ) -> Result<Self, Error> {
-        let res = Self {
-            folder_uri,
-            mbid,
-            title,
-            artist,
-            last_modified,
-            data: bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?)
-                .map_err(|_| Error::DocToBytesError)?,
-        };
-        Ok(res)
-    }
-}
-
 pub struct ArtistMetaRow {
-    name: String,
-    mbid: Option<String>,
-    last_modified: OffsetDateTime,
+    // name: String,
+    // mbid: Option<String>,
+    // last_modified: OffsetDateTime,
     data: Vec<u8>, // BSON
 }
 
@@ -298,41 +276,23 @@ impl TryInto<ArtistMeta> for ArtistMetaRow {
     }
 }
 
-impl ArtistMetaRow {
-    pub fn new(
-        name: String,
-        mbid: Option<String>,
-        last_modified: OffsetDateTime,
-        meta: &ArtistMeta,
-    ) -> Result<Self, Error> {
-        let res = Self {
-            name,
-            mbid,
-            last_modified,
-            data: bson::to_vec(&bson::to_document(meta).map_err(|_| Error::MetaToDocError)?)
-                .map_err(|_| Error::DocToBytesError)?,
-        };
-        Ok(res)
-    }
-}
-
 impl TryFrom<&Row<'_>> for ArtistMetaRow {
     type Error = SqliteError;
     fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
-            name: row.get(0)?,
-            mbid: row.get(1)?,
-            last_modified: row.get(2)?,
-            data: row.get(3)?,
+            // name: row.get(0)?,
+            // mbid: row.get(1)?,
+            // last_modified: row.get(2)?,
+            data: row.get(0)?,
         })
     }
 }
 
 pub struct LyricsRow {
-    uri: String,
+    // uri: String,
     lyrics: String,
     synced: bool,
-    last_modified: OffsetDateTime,
+    // last_modified: OffsetDateTime,
 }
 
 impl TryInto<Lyrics> for LyricsRow {
@@ -350,10 +310,10 @@ impl TryFrom<&Row<'_>> for LyricsRow {
     type Error = SqliteError;
     fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
-            uri: row.get(0)?,
-            lyrics: row.get(1)?,
-            synced: row.get(2)?,
-            last_modified: row.get(3)?,
+            // uri: row.get(0)?,
+            lyrics: row.get(0)?,
+            synced: row.get(1)?,
+            // last_modified: row.get(3)?,
         })
     }
 }
@@ -363,12 +323,12 @@ pub fn find_album_meta(album: &AlbumInfo) -> Result<Option<AlbumMeta>, Error> {
     let conn = SQLITE_POOL.get().unwrap();
     if let Some(mbid) = album.mbid.as_deref() {
         query = conn
-            .prepare("select * from albums where mbid = ?1")
+            .prepare("select meta from albums where mbid = ?1")
             .unwrap()
             .query_row(params![mbid], |r| AlbumMetaRow::try_from(r));
     } else if let (title, Some(artist)) = (&album.title, album.get_artist_tag()) {
         query = conn
-            .prepare("select * from albums where title = ?1 and artist = ?2")
+            .prepare("select meta from albums where title = ?1 and artist = ?2")
             .unwrap()
             .query_row(params![title, artist], |r| AlbumMetaRow::try_from(r));
     } else {
@@ -393,12 +353,12 @@ pub fn find_artist_meta(artist: &ArtistInfo) -> Result<Option<ArtistMeta>, Error
     let conn = SQLITE_POOL.get().unwrap();
     if let Some(mbid) = artist.mbid.as_deref() {
         query = conn
-            .prepare("select * from artists where mbid = ?1")
+            .prepare("select meta from artists where mbid = ?1")
             .unwrap()
             .query_row(params![mbid], |r| ArtistMetaRow::try_from(r));
     } else {
         query = conn
-            .prepare("select * from artists where name = ?1")
+            .prepare("select meta from artists where name = ?1")
             .unwrap()
             .query_row(params![&artist.name], |r| ArtistMetaRow::try_from(r));
     }
@@ -476,7 +436,7 @@ pub fn find_lyrics(song: &SongInfo) -> Result<Option<Lyrics>, Error> {
     let query: Result<LyricsRow, SqliteError>;
     let conn = SQLITE_POOL.get().unwrap();
     query = conn
-        .prepare("select * from songs where uri = ?1")
+        .prepare("select lyrics, synced from songs where uri = ?1")
         .unwrap()
         .query_row(params![&song.uri], |r| LyricsRow::try_from(r));
     match query {

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -109,7 +109,7 @@ mod imp {
                         .build(),
                     Signal::builder("queue-changed")
                         .param_types([
-                            BoxedAnyObject::static_type(), // Vec<Song> (diff only)
+                            BoxedAnyObject::static_type(), // Vec<PosIdChange> (diff only)
                         ])
                         .build(),
                     Signal::builder("album-art-downloaded")
@@ -170,7 +170,12 @@ mod imp {
                         .param_types([
                             ClientError::static_type()
                         ])
-                        .build()
+                        .build(),
+                    Signal::builder("queue-songs-downloaded")
+                        .param_types([
+                            BoxedAnyObject::static_type(), // Vec<Song>
+                        ])
+                        .build(),
                 ]
             })
         }

--- a/src/common/artist.rs
+++ b/src/common/artist.rs
@@ -82,7 +82,7 @@ pub fn parse_mb_artist_tag<'a>(input: &'a str) -> Vec<&'a str> {
             }
             for i in 1..(matched_delims.len()) {
                 let between_range = matched_delims[i - 1].end()..matched_delims[i].start();
-                // println!("Between: `{between}`");
+                // println!("Between: `{between_range:?}`");
                 if buffer[between_range.clone()].trim().len() > 0 {
                     found_artists.push(input[between_range].trim());
                 }

--- a/src/common/artist.rs
+++ b/src/common/artist.rs
@@ -55,9 +55,11 @@ pub fn parse_mb_artist_tag<'a>(input: &'a str) -> Vec<&'a str> {
             // using any extra storage.
             let start = mat.start();
             let end = mat.end();
-            found_artists.push(&input[start..end]);
-            let len = end - start;
-            buffer.replace_range(start..end, &" ".repeat(len));
+            if let Some(name) = input.get(start..end) {
+                found_artists.push(name);
+                let len = end - start;
+                buffer.replace_range(start..end, &" ".repeat(len));
+            }
             // println!("Buffer is now: {buffer}");
         }
 
@@ -77,14 +79,18 @@ pub fn parse_mb_artist_tag<'a>(input: &'a str) -> Vec<&'a str> {
             // Take note to check for "blankness" using the buffer, but return slices
             // of input, since buffer will go out of scope after this function concludes.
             let first_range = 0..matched_delims[0].start();
-            if buffer[first_range.clone()].trim().len() > 0 {
-                found_artists.push(input[first_range].trim());
+            if buffer.get(first_range.clone()).is_some_and(|substr| substr.trim().len() > 0) {
+                if let Some(artist) = input.get(first_range).map(|name| name.trim()) {
+                    found_artists.push(artist);
+                }
             }
             for i in 1..(matched_delims.len()) {
                 let between_range = matched_delims[i - 1].end()..matched_delims[i].start();
                 // println!("Between: `{between_range:?}`");
-                if buffer[between_range.clone()].trim().len() > 0 {
-                    found_artists.push(input[between_range].trim());
+                if buffer.get(between_range.clone()).is_some_and(|substr| substr.trim().len() > 0) {
+                    if let Some(artist) = input.get(between_range).map(|name| name.trim()) {
+                        found_artists.push(artist);
+                    }
                 }
             }
             let last_range = matched_delims.last().unwrap().end().min(buffer.len())..;

--- a/src/common/rating.rs
+++ b/src/common/rating.rs
@@ -120,7 +120,7 @@ mod imp {
             click_ctl.connect_released(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |_, _, x, y| {
+                move |_, _, _, _| {
                     if this.editable.get() {
                         this.obj().set_value(this.preview_value.get());
                         // Further yell to let parent widgets know this change is user-initiated

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -624,7 +624,6 @@ impl From<mpd::song::Song> for SongInfo {
 
 impl From<mpd::song::Song> for Song {
     fn from(song: mpd::song::Song) -> Self {
-        let res = glib::Object::new::<Self>();
         let info = SongInfo::from(song);
         Self::from(info)
     }

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -85,6 +85,7 @@ pub struct SongInfo {
     pub artist_tag: Option<String>, // Original tag, with all the linkages and formatting
     pub duration: Option<Duration>, // Default to 0 if somehow the option in mpd's Song is None
     queue_id: Option<u32>,
+    original_queue_pos: Option<u32>,  // Only set once at creation. Subsequent updates are kept in the Song GObject.
     // range: Option<Range>,
     pub album: Option<AlbumInfo>,
     track: Cell<i64>,
@@ -124,6 +125,7 @@ impl Default for SongInfo {
             artist_tag: None,
             duration: None,
             queue_id: None,
+            original_queue_pos: None,
             album: None,
             track: Cell::new(-1), // negative values indicate no track index
             disc: Cell::new(-1),
@@ -344,10 +346,7 @@ impl Song {
     }
 
     pub fn get_queue_id(&self) -> u32 {
-        if let Some(id) = self.get_info().queue_id {
-            return id;
-        }
-        0
+        self.get_info().queue_id.unwrap_or(0)
     }
 
     pub fn get_queue_pos(&self) -> u32 {
@@ -490,6 +489,7 @@ impl From<mpd::song::Song> for SongInfo {
             artist_tag: song.artist,
             duration: song.duration,
             queue_id: None,
+            original_queue_pos: None,
             album: None,
             track: Cell::new(-1),
             disc: Cell::new(-1),
@@ -502,6 +502,7 @@ impl From<mpd::song::Song> for SongInfo {
 
         if let Some(place) = song.place {
             let _ = res.queue_id.replace(place.id.0);
+            let _ = res.original_queue_pos.replace(place.pos);
         }
 
         // Search tags vector for additional fields we can use.
@@ -624,9 +625,6 @@ impl From<mpd::song::Song> for SongInfo {
 impl From<mpd::song::Song> for Song {
     fn from(song: mpd::song::Song) -> Self {
         let res = glib::Object::new::<Self>();
-        if let Some(place) = song.place {
-            res.set_queue_pos(place.pos);
-        }
         let info = SongInfo::from(song);
         let _ = res.imp().info.set(info);
         res
@@ -636,6 +634,7 @@ impl From<mpd::song::Song> for Song {
 impl From<SongInfo> for Song {
     fn from(info: SongInfo) -> Self {
         let res = glib::Object::new::<Self>();
+        res.imp().pos.set(info.original_queue_pos.unwrap_or(0));
         let _ = res.imp().info.set(info);
         res
     }

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -626,8 +626,7 @@ impl From<mpd::song::Song> for Song {
     fn from(song: mpd::song::Song) -> Self {
         let res = glib::Object::new::<Self>();
         let info = SongInfo::from(song);
-        let _ = res.imp().info.set(info);
-        res
+        Self::from(info)
     }
 }
 

--- a/src/gtk/library/album-content-view.ui
+++ b/src/gtk/library/album-content-view.ui
@@ -30,7 +30,6 @@
                 <setter object="infobox_text" property="margin-start">12</setter>
                 <setter object="cover" property="pixel-size">128</setter>
                 <setter object="replace_queue_text" property="visible">false</setter>
-                <setter object="append_queue_text" property="visible">false</setter>
                 <setter object="add_to_playlist" property="collapsed">true</setter>
               </object>
             </child>

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -322,7 +322,7 @@ mod imp {
         pub fn on_selection_changed(&self) {
             let sel_model = &self.sel_model;
             // TODO: this can be slow, might consider redesigning
-            let n_sel = sel_model.selection().size(); println!("Selection changed. New size: {n_sel}");
+            let n_sel = sel_model.selection().size();
             if n_sel == 0 || (n_sel as u32) == sel_model.model().unwrap().n_items() {
                 self.selecting_all.replace(true);
                 self.replace_queue_text.set_label("Play all");

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -177,28 +177,7 @@ mod imp {
             self.sel_model.connect_selection_changed(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |sel_model, _, _| {
-                    // TODO: this can be slow, might consider redesigning
-                    let n_sel = sel_model.selection().size();
-                    if n_sel == 0 || (n_sel as u32) == sel_model.model().unwrap().n_items() {
-                        this.selecting_all.replace(true);
-                        this.replace_queue_text.set_label("Play all");
-                        this.queue_split_button_content.set_label("Queue all");
-                        let queue_split_menu = Menu::new();
-                        queue_split_menu.append(Some("Queue all next"), Some("album-content-view.insert-queue"));
-                        this.queue_split_button.set_menu_model(Some(&queue_split_menu));
-                    } else {
-                        // TODO: l10n
-                        this.selecting_all.replace(false);
-                        this.replace_queue_text
-                            .set_label(format!("Play {}", n_sel).as_str());
-                        this.queue_split_button_content
-                            .set_label(format!("Queue {}", n_sel).as_str());
-                        let queue_split_menu = Menu::new();
-                        queue_split_menu.append(Some(format!("Queue {} next", n_sel).as_str()), Some("album-content-view.insert-queue"));
-                        this.queue_split_button.set_menu_model(Some(&queue_split_menu));
-                    }
-                }
+                move |_, _, _| this.on_selection_changed()
             ));
 
             let sel_model = self.sel_model.clone();
@@ -338,6 +317,32 @@ mod imp {
     }
 
     impl WidgetImpl for AlbumContentView {}
+
+    impl AlbumContentView {
+        pub fn on_selection_changed(&self) {
+            let sel_model = &self.sel_model;
+            // TODO: this can be slow, might consider redesigning
+            let n_sel = sel_model.selection().size(); println!("Selection changed. New size: {n_sel}");
+            if n_sel == 0 || (n_sel as u32) == sel_model.model().unwrap().n_items() {
+                self.selecting_all.replace(true);
+                self.replace_queue_text.set_label("Play all");
+                self.queue_split_button_content.set_label("Queue all");
+                let queue_split_menu = Menu::new();
+                queue_split_menu.append(Some("Queue all next"), Some("album-content-view.insert-queue"));
+                self.queue_split_button.set_menu_model(Some(&queue_split_menu));
+            } else {
+                // TODO: l10n
+                self.selecting_all.replace(false);
+                self.replace_queue_text
+                    .set_label(format!("Play {}", n_sel).as_str());
+                self.queue_split_button_content
+                    .set_label(format!("Queue {}", n_sel).as_str());
+                let queue_split_menu = Menu::new();
+                queue_split_menu.append(Some(format!("Queue {} next", n_sel).as_str()), Some("album-content-view.insert-queue"));
+                self.queue_split_button.set_menu_model(Some(&queue_split_menu));
+            }
+        }
+    }
 }
 
 glib::wrapper! {
@@ -712,6 +717,7 @@ impl AlbumContentView {
     }
 
     pub fn bind(&self, album: Album) {
+        self.imp().on_selection_changed();
         let title_label = self.imp().title.get();
         let artists_box = self.imp().artists_box.get();
         let rating = self.imp().rating.get();

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -513,7 +513,9 @@ impl AlbumView {
             .get()
             .expect("AlbumView is incorrectly set up (no Library reference)")
             .init_album(album);
-        self.imp().nav_view.push_by_tag("content");
+        if self.imp().nav_view.visible_page_tag().is_none_or(|tag| tag.as_str() != "content") {
+            self.imp().nav_view.push_by_tag("content");
+        }
     }
 
     fn setup_gridview(&self, cache: Rc<Cache>) {

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -180,22 +180,7 @@ mod imp {
             self.song_sel_model.connect_selection_changed(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |sel_model, _, _| {
-                    // TODO: this can be slow, might consider redesigning
-                    let n_sel = sel_model.selection().size();
-                    if n_sel == 0 || (n_sel as u32) == sel_model.model().unwrap().n_items() {
-                        this.selecting_all.replace(true);
-                        this.replace_queue_text.set_label("Play all");
-                        this.append_queue_text.set_label("Queue all");
-                    } else {
-                        // TODO: l10n
-                        this.selecting_all.replace(false);
-                        this.replace_queue_text
-                            .set_label(format!("Play {}", n_sel).as_str());
-                        this.append_queue_text
-                            .set_label(format!("Queue {}", n_sel).as_str());
-                    }
-                }
+                move |_, _, _| this.on_song_selection_changed()
             ));
 
             let song_sel_model = self.song_sel_model.clone();
@@ -319,6 +304,26 @@ mod imp {
     }
 
     impl WidgetImpl for ArtistContentView {}
+
+    impl ArtistContentView {
+        pub fn on_song_selection_changed(&self) {
+            let sel_model = &self.song_sel_model;
+            // TODO: self can be slow, might consider redesigning
+            let n_sel = sel_model.selection().size();
+            if n_sel == 0 || (n_sel as u32) == sel_model.model().unwrap().n_items() {
+                self.selecting_all.replace(true);
+                self.replace_queue_text.set_label("Play all");
+                self.append_queue_text.set_label("Queue all");
+            } else {
+                // TODO: l10n
+                self.selecting_all.replace(false);
+                self.replace_queue_text
+                    .set_label(format!("Play {}", n_sel).as_str());
+                self.append_queue_text
+                    .set_label(format!("Queue {}", n_sel).as_str());
+            }
+        }
+    }
 }
 
 glib::wrapper! {
@@ -690,6 +695,7 @@ impl ArtistContentView {
     }
 
     pub fn bind(&self, artist: Artist) {
+        self.imp().on_song_selection_changed();
         self.update_meta(&artist);
         let info = artist.get_info();
         self.imp().avatar.set_text(Some(&info.name));

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -182,7 +182,7 @@ impl ArtistView {
         self.imp().library.set(library.clone()).expect("Unable to register library with Artist View");
         self.setup_sort();
         self.setup_search();
-        self.setup_gridview(client_state.clone(), cache.clone());
+        self.setup_gridview(cache.clone());
 
         let content_view = self.imp().content_view.get();
         content_view.setup(library, cache, client_state);
@@ -354,7 +354,7 @@ impl ArtistView {
         self.imp().library.get().unwrap().init_artist(artist);
     }
 
-    fn setup_gridview(&self, client_state: ClientState, cache: Rc<Cache>) {
+    fn setup_gridview(&self, cache: Rc<Cache>) {
         let settings = settings_manager().child("ui");
         // Refresh upon reconnection.
         // User-initiated refreshes will also trigger a reconnection, which will

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -350,7 +350,9 @@ impl ArtistView {
         let content_view = self.imp().content_view.get();
         content_view.unbind();
         content_view.bind(artist.clone());
-        self.imp().nav_view.push_by_tag("content");
+        if self.imp().nav_view.visible_page_tag().is_none_or(|tag| tag.as_str() != "content") {
+            self.imp().nav_view.push_by_tag("content");
+        }
         self.imp().library.get().unwrap().init_artist(artist);
     }
 

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -164,7 +164,6 @@ impl Library {
                 #[strong(rename_to = this)]
                 self,
                 move |_: ClientState, album: Album| {
-                    println!("{:?}", &album);
                     this.imp().albums.append(&album);
                 }
             ),
@@ -177,7 +176,6 @@ impl Library {
                 #[strong(rename_to = this)]
                 self,
                 move |_: ClientState, artist: Artist| {
-                    println!("{:?}", &artist);
                     this.imp().artists.append(&artist);
                 }
             ),

--- a/src/library/folder_view.rs
+++ b/src/library/folder_view.rs
@@ -497,7 +497,7 @@ impl FolderView {
         }
     }
 
-    fn setup_listview(&self, cache: Rc<Cache>, library: Library) {
+    fn setup_listview(&self, _cache: Rc<Cache>, library: Library) {
         // client_state.connect_closure(
         //     "inode-basic-info-downloaded",
         //     false,

--- a/src/library/playlist_view.rs
+++ b/src/library/playlist_view.rs
@@ -447,7 +447,9 @@ impl PlaylistView {
         let content_view = self.imp().content_view.get();
         content_view.unbind(true);
         content_view.bind(inode.clone());
-        self.imp().nav_view.push_by_tag("content");
+        if self.imp().nav_view.visible_page_tag().is_none_or(|tag| tag.as_str() != "content") {
+            self.imp().nav_view.push_by_tag("content");
+        }
         self.imp()
             .library
             .get()

--- a/src/library/playlist_view.rs
+++ b/src/library/playlist_view.rs
@@ -203,7 +203,7 @@ impl PlaylistView {
             .expect("Cannot init PlaylistView with Library");
         self.setup_sort();
         self.setup_search();
-        self.setup_listview(cache.clone());
+        self.setup_listview();
 
         client_state.connect_notify_local(
             Some("connection-state"),
@@ -455,7 +455,7 @@ impl PlaylistView {
             .init_playlist(inode.get_name().unwrap());
     }
 
-    fn setup_listview(&self, cache: Rc<Cache>) {
+    fn setup_listview(&self) {
         let library = self.imp().library.get().unwrap();
         // client_state.connect_closure(
         //     "inode-basic-info-downloaded",

--- a/src/meta_providers/base.rs
+++ b/src/meta_providers/base.rs
@@ -90,21 +90,10 @@ pub mod utils {
 }
 
 pub trait MetadataProvider: Send + Sync {
-    /// Create a new instance of this metadata provider with the given priority. A priority of 0 is the highest
-    /// & indicates the first provider to be called.
-    fn new(prio: u32) -> Self
+    /// Create a new instance of this metadata provider.
+    fn new() -> Self
     where
         Self: Sized;
-
-    /// Get an identifier of this metadata provider. This name must be unique & also used to name the corresponding
-    /// child GSettings schema. For this reason, it must be all lowercase alphabetical letters.
-    fn key(&self) -> &'static str;
-
-    /// Get priority of this provider.
-    fn priority(&self) -> u32;
-
-    /// Set priority of this provider.
-    fn set_priority(&self, prio: u32);
 
     /// Get textual metadata that wouldn't be available as song tags, such as wiki, producer name,
     /// etc. A new AlbumMeta object containing data from both the existing AlbumMeta and newly fetched data. New

--- a/src/meta_providers/chain.rs
+++ b/src/meta_providers/chain.rs
@@ -13,7 +13,7 @@ pub struct MetadataChain {
 
 impl MetadataProvider for MetadataChain {
     /// The priority argument exists only for compatibility and is always ignored.
-    fn new(_prio: u32) -> Self
+    fn new() -> Self
     where
         Self: Sized,
     {
@@ -21,18 +21,6 @@ impl MetadataProvider for MetadataChain {
             providers: Vec::new(),
         }
     }
-
-    fn key(&self) -> &'static str {
-        "chain"
-    }
-
-    /// Will always return 0, since MetadataChain is not meant to be nested in another chain.
-    fn priority(&self) -> u32 {
-        0
-    }
-
-    /// Does nothing, since MetadataChain is not meant to be nested in another chain.
-    fn set_priority(&self, _prio: u32) {}
 
     fn get_album_meta(
         self: &Self,
@@ -83,11 +71,11 @@ impl MetadataProvider for MetadataChain {
 
 /// Convenience method to construct a metadata provider instance by key with the given priority.
 /// When implementing a new provider, you must manually add it to this function too.
-pub fn get_provider_with_priority(key: &str, prio: u32) -> Box<dyn MetadataProvider> {
+pub fn get_provider(key: &str) -> Box<dyn MetadataProvider> {
     match key {
-        "musicbrainz" => Box::new(MusicBrainzWrapper::new(prio)),
-        "lastfm" => Box::new(LastfmWrapper::new(prio)),
-        "lrclib" => Box::new(LrcLibWrapper::new(prio)),
+        "musicbrainz" => Box::new(MusicBrainzWrapper::new()),
+        "lastfm" => Box::new(LastfmWrapper::new()),
+        "lrclib" => Box::new(LrcLibWrapper::new()),
         _ => unimplemented!(),
     }
 }

--- a/src/meta_providers/lastfm/controller.rs
+++ b/src/meta_providers/lastfm/controller.rs
@@ -1,7 +1,5 @@
 extern crate bson;
 
-use std::sync::RwLock;
-
 use gtk::prelude::*;
 use reqwest::{
     blocking::{Client, Response},
@@ -19,8 +17,7 @@ use super::{
 pub const API_ROOT: &str = "http://ws.audioscrobbler.com/2.0";
 
 pub struct LastfmWrapper {
-    client: Client,
-    priority: RwLock<u32>,
+    client: Client
 }
 
 impl LastfmWrapper {
@@ -51,24 +48,10 @@ impl LastfmWrapper {
 }
 
 impl MetadataProvider for LastfmWrapper {
-    fn new(prio: u32) -> Self {
+    fn new() -> Self {
         Self {
-            client: Client::new(),
-            priority: RwLock::new(prio),
+            client: Client::new()
         }
-    }
-
-    fn key(&self) -> &'static str {
-        PROVIDER_KEY
-    }
-
-    fn priority(&self) -> u32 {
-        *self.priority.read().expect("Poisoned RwLock")
-    }
-
-    fn set_priority(&self, prio: u32) {
-        let mut this_prio = self.priority.write().expect("Poisoned RwLock");
-        *this_prio = prio;
     }
 
     /// Schedule getting album metadata from Last.fm.

--- a/src/meta_providers/lrclib/controller.rs
+++ b/src/meta_providers/lrclib/controller.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use crate::{
     common::{AlbumInfo, ArtistInfo, SongInfo},
     config::APPLICATION_USER_AGENT,
@@ -20,8 +18,7 @@ use super::{
 pub const API_ROOT: &str = "https://lrclib.net/api/";
 
 pub struct LrcLibWrapper {
-    client: Client,
-    priority: RwLock<u32>,
+    client: Client
 }
 
 impl LrcLibWrapper {
@@ -40,24 +37,10 @@ impl LrcLibWrapper {
 }
 
 impl MetadataProvider for LrcLibWrapper {
-    fn new(prio: u32) -> Self {
+    fn new() -> Self {
         Self {
-            client: Client::new(),
-            priority: RwLock::new(prio),
+            client: Client::new()
         }
-    }
-
-    fn key(&self) -> &'static str {
-        "lrclib"
-    }
-
-    fn priority(&self) -> u32 {
-        *self.priority.read().expect("Poisoned RwLock")
-    }
-
-    fn set_priority(&self, prio: u32) {
-        let mut this_prio = self.priority.write().expect("Poisoned RwLock");
-        *this_prio = prio;
     }
 
     /// LRCLIB only provides song lyrics.

--- a/src/meta_providers/mod.rs
+++ b/src/meta_providers/mod.rs
@@ -6,7 +6,7 @@ pub mod musicbrainz;
 pub mod lrclib;
 
 pub use base::{utils, ProviderMessage, MetadataProvider};
-pub use chain::{get_provider_with_priority, MetadataChain};
+pub use chain::{get_provider, MetadataChain};
 
 pub mod prelude {
     pub use super::base::{sleep_after_request, MetadataProvider};

--- a/src/meta_providers/musicbrainz/controller.rs
+++ b/src/meta_providers/musicbrainz/controller.rs
@@ -1,8 +1,6 @@
 use gtk::prelude::*;
 extern crate bson;
 
-use std::sync::RwLock;
-
 use musicbrainz_rs::{
     entity::{artist::*, release::*},
     prelude::*,
@@ -15,28 +13,11 @@ use super::{
     PROVIDER_KEY,
 };
 
-pub struct MusicBrainzWrapper {
-    priority: RwLock<u32>,
-}
+pub struct MusicBrainzWrapper {}
 
 impl MetadataProvider for MusicBrainzWrapper {
-    fn new(prio: u32) -> Self {
-        Self {
-            priority: RwLock::new(prio),
-        }
-    }
-
-    fn key(&self) -> &'static str {
-        PROVIDER_KEY
-    }
-
-    fn priority(&self) -> u32 {
-        *self.priority.read().expect("Poisoned RwLock")
-    }
-
-    fn set_priority(&self, prio: u32) {
-        let mut this_prio = self.priority.write().expect("Poisoned RwLock");
-        *this_prio = prio;
+    fn new() -> Self {
+        Self {}
     }
 
     /// Schedule getting album metadata from MusicBrainz.
@@ -187,7 +168,7 @@ impl MetadataProvider for MusicBrainzWrapper {
     /// MusicBrainz does not provide lyrics.
     fn get_lyrics(
         &self,
-        key: &crate::common::SongInfo
+        _key: &crate::common::SongInfo
     ) -> Option<models::Lyrics> {
         None
     }

--- a/src/meta_providers/musicbrainz/models.rs
+++ b/src/meta_providers/musicbrainz/models.rs
@@ -12,7 +12,7 @@ use musicbrainz_rs::entity::{
 };
 
 use super::{
-    super::{models, prelude::*},
+    super::{models},
     PROVIDER_KEY,
 };
 

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -9,6 +9,7 @@ use crate::{
     utils::{prettify_audio_format, settings_manager, strip_filename_linux}
 };
 use async_lock::OnceCell as AsyncOnceCell;
+use ::glib::WeakRef;
 use mpris_server::{
     zbus::{self, fdo},
     LocalPlayerInterface, LocalRootInterface, LocalServer, LoopStatus, Metadata as MprisMetadata,
@@ -21,14 +22,15 @@ use glib::{clone, closure_local, subclass::Signal, BoxedAnyObject};
 use gtk::gdk::{self, Texture};
 use gtk::{gio, glib, prelude::*};
 use mpd::{
-    error::Error as MpdError,
-    status::{AudioFormat, State, Status},
-    ReplayGain, SaveMode, Subsystem,
+    error::Error as MpdError, song::PosIdChange, status::{AudioFormat, State, Status}, ReplayGain, SaveMode, Subsystem
 };
+use nohash_hasher::NoHashHasher;
 use std::{
+    collections::HashMap, hash::BuildHasherDefault,
     cell::{Cell, OnceCell, RefCell},
     ops::Deref, path::PathBuf,
-    rc::Rc, sync::{Arc, Mutex, OnceLock}, vec::Vec
+    rc::Rc, sync::{Arc, Mutex, OnceLock}, vec::Vec,
+
 };
 
 use super::fft_backends::{
@@ -168,6 +170,7 @@ fn get_replaygain_icon_name(mode: ReplayGain) -> &'static str {
 mod imp {
     use super::*;
     use crate::{application::EuphonicaApplication, common::CoverSource, meta_providers::models::Lyrics};
+    use ::glib::WeakRef;
     use glib::{
         ParamSpec, ParamSpecBoolean, ParamSpecDouble, ParamSpecEnum, ParamSpecFloat, ParamSpecInt,
         ParamSpecString, ParamSpecUInt, ParamSpecUInt64
@@ -179,6 +182,10 @@ mod imp {
         pub state: Cell<PlaybackState>,
         pub position: Cell<f64>,
         pub queue: gio::ListStore,
+        // Keep a mapping from song ID to their latest position in the queue.
+        // Song IDs are u32s anyway, and I don't think there's any risk of a HashDoS attack
+        // from a self-hosted music server so we'll just use identity hash for speed.
+        pub queue_map: RefCell<HashMap::<u32, WeakRef<Song>, BuildHasherDefault<NoHashHasher<u32>>>>,
         pub lyric_lines: gtk::StringList,  // Line by line for display. May be empty.
         pub lyrics: RefCell<Option<Lyrics>>,
         pub current_song: RefCell<Option<Song>>,
@@ -220,7 +227,8 @@ mod imp {
         // This enum is merely to help decide whether we should fire a notify signal
         // to the bar & pane.
         pub cover_source: Cell<CoverSource>,
-        pub saved_to_history: Cell<bool>
+        pub saved_to_history: Cell<bool>,
+        pub is_foreground: Cell<bool>
     }
 
     #[glib::object_subclass]
@@ -245,6 +253,7 @@ mod imp {
                 mixramp_db: Cell::new(0.0),
                 mixramp_delay: Cell::new(0.0),
                 queue: gio::ListStore::new::<Song>(),
+                queue_map: RefCell::new(HashMap::with_capacity_and_hasher(15, BuildHasherDefault::default())),
                 current_song: RefCell::new(None),
                 current_lyric_line: Cell::default(),
                 format: RefCell::new(None),
@@ -278,7 +287,8 @@ mod imp {
                 fft_backend_idx: Cell::new(0),
                 outputs: gio::ListStore::new::<BoxedAnyObject>(),
                 cover_source: Cell::default(),
-                saved_to_history: Cell::new(false)
+                saved_to_history: Cell::new(false),
+                is_foreground: Cell::new(false)
             };
             res
         }
@@ -393,7 +403,7 @@ mod imp {
                 "artist" => obj.artist().to_value(),
                 "album" => obj.album().to_value(),
                 "duration" => obj.duration().to_value(),
-                "queue-id" => obj.queue_id().to_value(),
+                "queue-id" => obj.queue_id().unwrap_or(u32::MAX).to_value(),
                 "quality-grade" => obj.quality_grade().to_value(),
                 "bitrate" => self.bitrate.get().to_value(),
                 "fft-status" => obj.fft_status().to_value(),
@@ -574,7 +584,12 @@ impl Player {
             .await
     }
 
+    pub fn is_foreground(&self) -> bool {
+        self.imp().is_foreground.get()
+    }
+
     pub fn set_is_foreground(&self, mode: bool) {
+        self.imp().is_foreground.set(mode);
         // If running in foreground mode, maybe start FFT thread and seekbar polling.
         if mode {
             println!("Player controller: entering foreground mode");
@@ -602,7 +617,7 @@ impl Player {
     // 2. Perform FFT & extrapolate to the marker frequencies.
     // 3. Send results back to main thread via the async channel.
     fn maybe_start_fft_thread(&self) {
-        if self.imp().use_visualizer.get() {
+        if self.imp().use_visualizer.get() && self.imp().is_foreground.get() {
             let output = self.imp().fft_data.clone();
             if let Some(backend) = self.imp().fft_backend.borrow().as_ref() {
                 let _ = backend.clone().start(output);
@@ -719,11 +734,7 @@ impl Player {
                 move |state, _| {
                     match state.get_connection_state() {
                         ConnectionState::Connected => {
-                            // Newly-connected? Get initial status
-                            // Remember to get queue before status so status parsing has something to read off.
-                            if let Some(songs) = this.client().get_current_queue() {
-                                this.update_queue(&songs, true);
-                            }
+                            // Newly-connected? Get initial status. This will also fetch the queue.
                             if let Some(status) = this.client().get_status() {
                                 this.update_status(&status);
                             }
@@ -733,6 +744,7 @@ impl Player {
                         }
                         ConnectionState::Connecting => {
                             this.imp().queue.remove_all();
+                            this.imp().queue_map.borrow_mut().clear();
                             this.imp().outputs.remove_all();
                             this.update_status(&mpd::Status::default());
                         }
@@ -741,6 +753,7 @@ impl Player {
                 }
             ),
         );
+
         client_state
             .bind_property("supports-playlists", self, "supports-playlists")
             .sync_create()
@@ -771,13 +784,31 @@ impl Player {
         );
 
         client_state.connect_closure(
+            "queue-songs-downloaded",
+            false,
+            closure_local!(
+                #[weak(rename_to = this)]
+                self,
+                move |_: ClientState, songs: glib::BoxedAnyObject| {
+                    let songs = songs.borrow::<Vec<Song>>();
+                    this.imp().queue.extend_from_slice(&songs);
+                    for song in songs.iter() {
+                        let weak_ref = WeakRef::new();
+                        weak_ref.set(Some(song));
+                        this.imp().queue_map.borrow_mut().insert(song.get_queue_id(), weak_ref);
+                    }
+                }
+            )
+        );
+
+        client_state.connect_closure(
             "queue-changed",
             false,
             closure_local!(
                 #[weak(rename_to = this)]
                 self,
-                move |_: ClientState, songs: BoxedAnyObject| {
-                    this.update_queue(songs.borrow::<Vec<Song>>().as_ref(), false);
+                move |_: ClientState, changes: BoxedAnyObject| {
+                    this.update_queue(changes.borrow::<Vec<PosIdChange>>().as_ref());
                 }
             ),
         );
@@ -862,10 +893,6 @@ impl Player {
     /// Main update function. MPD's protocol has a single "status" commands
     /// that returns everything at once. This update function will take what's
     /// relevant and update the GObject properties accordingly.
-    ///
-    /// This function must only be called AFTER updating the queue. MPD's idle
-    /// change notifier already follows this convention (by sending the queue change
-    /// notification before the player one).
     pub fn update_status(&self, status: &Status) {
         let mut mpris_changes: Vec<Property> = Vec::new();
         match status.state {
@@ -985,47 +1012,38 @@ impl Player {
 
         // Update playing status of songs in the queue
         if let Some(new_queue_place) = status.song {
-            let mut needs_refresh = true;
-            // There is now a playing song.
-            // Check if there was one and whether it is different from the one playing now.
-            // let new_id: u32 = new_queue_place.id.0;
-            let new_pos: u32 = new_queue_place.pos;
-            let new_song = self
-                .imp()
-                .queue
-                .item(new_pos)
-                .expect("Expected queue to have a song at new_pos")
-                .downcast::<Song>()
-                .expect("Queue has to contain common::Song objects");
-            // Set playing status
-            new_song.set_is_playing(true); // this whole thing would only run if playback state is not Stopped
-            // Always replace current song to ensure we're pointing at something on the queue.
-            // This is because a partial queue update may replace the current song with another instance of the
-            // same song (for example, when deleting a song before it from the queue).
-            let maybe_old_song = self.imp().current_song.replace(Some(new_song.clone()));
-            if let Some(old_song) = maybe_old_song {
-                if old_song.get_queue_id() != new_song.get_queue_id() {
-                    old_song.set_is_playing(false);
-                    // If using PipeWire visualiser, might need to restart it
-                    if self.imp().pipewire_restart_between_songs.get()
-                        && self.imp().fft_backend.borrow().as_ref().is_some_and(
-                            |backend| backend.name() == "pipewire"
-                        )
-                    {
-                        println!("Starting PipeWire backend again after song change...");
-                        self.maybe_start_fft_thread();
+            let mut needs_refresh: bool = false;
+            {
+                // There is now a playing song. Fetch if we haven't already.
+                let mut local_curr_song = self
+                    .imp()
+                    .current_song
+                    .borrow_mut();
+
+                if local_curr_song.as_ref().is_none_or(|song| song.get_queue_id() != new_queue_place.id.0) {
+                    needs_refresh = true;
+                    if let Some(new_song) = self.client().get_song_at_queue_id(new_queue_place.id.0) {
+                        // Always fetch as the queue might not have been populated yet
+                        local_curr_song.replace(new_song.clone());
+                        // If using PipeWire visualiser, might need to restart it
+                        if self.imp().pipewire_restart_between_songs.get()
+                            && self.imp().fft_backend.borrow().as_ref().is_some_and(
+                                |backend| backend.name() == "pipewire"
+                            )
+                        {
+                            println!("Starting PipeWire backend again after song change...");
+                            self.maybe_start_fft_thread();
+                        }
                     }
-                }
-                else {
+                } else if let Some(curr_song) = local_curr_song.as_ref() {
                     // Same old song
-                    needs_refresh = false;
                     // Record into playback history
                     if !settings_manager().child("library").boolean("pause-recent") {
-                        let dur = new_song.get_duration() as f32;
+                        let dur = curr_song.get_duration() as f32;
                         if dur >= 10.0 {
                             if let Some(new_position_dur) = status.elapsed {
                                 if !self.imp().saved_to_history.get() && new_position_dur.as_secs_f32() / dur >= 0.5 {
-                                    if let Ok(()) = sqlite::add_to_history(new_song.get_info()) {
+                                    if let Ok(()) = sqlite::add_to_history(curr_song.get_info()) {
                                         self.get_recent_songs();
                                         self.emit_by_name::<()>("history-changed", &[]);
                                     }
@@ -1037,47 +1055,50 @@ impl Player {
                 }
             }
             if needs_refresh {
-                self.imp().saved_to_history.set(false);
-                self.notify("title");
-                self.notify("artist");
-                self.notify("duration");
-                self.notify("quality-grade");
-                self.notify("format-desc");
-                self.notify("album");
-                // Get album art. Start with CoverSource::Unknown.
-                // We might also get an asynchronous reply later via a cache state signal.
-                if let Some((tex, is_fallback)) = self
-                    .imp()
-                    .cache
-                    .get()
-                    .unwrap()
-                    .clone()
-                    .load_cached_embedded_cover(new_song.get_info(), false, true)
-                {
-                    self.imp().cover_source.set(if is_fallback {CoverSource::Folder} else {CoverSource::Embedded});
-                    self.emit_by_name::<()>("cover-changed", &[&Some(tex)]);
-                }
-                else {
-                    self.imp().cover_source.set(CoverSource::Unknown);
-                    self.emit_by_name::<()>("cover-changed", &[&Option::<gdk::Texture>::None]);
-                }
-                // Get new lyrics
-                // First remove all current lines
-                self.imp().lyric_lines.splice(0, self.imp().lyric_lines.n_items(), &[]);
-                let _ = self.imp().lyrics.take();
-                // Fetch new lyrics
-                if let Some(lyrics) = self.imp().cache.get().unwrap().load_cached_lyrics(new_song.get_info()) {
-                    self.update_lyrics(lyrics);
-                }
-                else {
-                    // Schedule downloading
-                    self.imp().cache.get().unwrap().ensure_cached_lyrics(new_song.get_info());
-                }
-                // Update MPRIS side
-                if self.imp().mpris_enabled.get() {
-                    mpris_changes.push(Property::Metadata(
-                        new_song.get_mpris_metadata(),
-                    ));
+                if let Some(new_song) = self.imp().current_song.borrow().as_ref() {
+                    self.imp().saved_to_history.set(false);
+                    self.notify("title");
+                    self.notify("artist");
+                    self.notify("duration");
+                    self.notify("quality-grade");
+                    self.notify("format-desc");
+                    self.notify("album");
+                    self.notify("queue-id");
+                    // Get album art. Start with CoverSource::Unknown.
+                    // We might also get an asynchronous reply later via a cache state signal.
+                    if let Some((tex, is_fallback)) = self
+                        .imp()
+                        .cache
+                        .get()
+                        .unwrap()
+                        .clone()
+                        .load_cached_embedded_cover(new_song.get_info(), false, true)
+                    {
+                        self.imp().cover_source.set(if is_fallback {CoverSource::Folder} else {CoverSource::Embedded});
+                        self.emit_by_name::<()>("cover-changed", &[&Some(tex)]);
+                    }
+                    else {
+                        self.imp().cover_source.set(CoverSource::Unknown);
+                        self.emit_by_name::<()>("cover-changed", &[&Option::<gdk::Texture>::None]);
+                    }
+                    // Get new lyrics
+                    // First remove all current lines
+                    self.imp().lyric_lines.splice(0, self.imp().lyric_lines.n_items(), &[]);
+                    let _ = self.imp().lyrics.take();
+                    // Fetch new lyrics
+                    if let Some(lyrics) = self.imp().cache.get().unwrap().load_cached_lyrics(new_song.get_info()) {
+                        self.update_lyrics(lyrics);
+                    }
+                    else {
+                        // Schedule downloading
+                        self.imp().cache.get().unwrap().ensure_cached_lyrics(new_song.get_info());
+                    }
+                    // Update MPRIS side
+                    if self.imp().mpris_enabled.get() {
+                        mpris_changes.push(Property::Metadata(
+                            new_song.get_mpris_metadata(),
+                        ));
+                    }
                 }
             }
         } else {
@@ -1182,54 +1203,78 @@ impl Player {
     /// new queue length. The update_status() function will instead truncate the queue to the new
     /// length for us once called.
     /// If an MPRIS server is running, it will also emit property change signals.
-    pub fn update_queue(&self, songs: &[Song], replace: bool) {
+    pub fn update_queue(&self, changes: &[PosIdChange]) {
         let queue = &self.imp().queue;
-        if replace {
-            if songs.len() == 0 {
-                queue.remove_all();
-            } else {
-                // Replace overlapping portion.
-                // Only emit one changed signal for both removal and insertion. This avoids the brief visual
-                // blanking between queue versions.
-                // New songs should all have is_playing == false.
-                queue.splice(
-                    0,
-                    queue.n_items(),
-                    &songs[..(songs.len().min(queue.n_items() as usize))],
-                );
-                if songs.len() > queue.n_items() as usize {
-                    queue.extend_from_slice(&songs[(queue.n_items() as usize)..]);
+        if changes.len() > 0 {
+            // Find queue range covered by the changes vec
+            let mut max_pos: u32 = 0;
+            let mut min_pos: u32 = u32::MAX;
+            for change in changes.iter() {
+                if change.pos < min_pos {
+                    min_pos = change.pos;
+                }
+                if change.pos > max_pos {
+                    max_pos = change.pos;
                 }
             }
-        } else {
-            if songs.len() > 0 {
-                // Update overlapping portion
-                let curr_len = self.imp().queue.n_items() as usize;
-                let mut overlap: Vec<Song> = Vec::with_capacity(curr_len);
-                let mut new_pos: usize = 0;
-                for (i, maybe_old_song) in queue.iter::<Song>().enumerate() {
-                    if i >= curr_len {
-                        // Out of overlapping portion
-                        break;
-                    }
-                    // See if this position is changed
-                    if songs[new_pos].get_queue_pos() as usize == i {
-                        overlap.push(songs[new_pos].clone());
-                        if new_pos < songs.len() - 1 {
-                            new_pos += 1;
-                        }
-                    } else {
-                        let old_song = maybe_old_song.expect("Cannot read from old queue");
-                        overlap.push(old_song);
-                    }
-                }
-                // Only emit one changed signal for both removal and insertion
-                queue.splice(0, overlap.len() as u32, &overlap);
 
-                // Add songs beyond the length of the old queue
-                if new_pos < songs.len() {
-                    queue.extend_from_slice(&songs[new_pos..]);
+            // Reconstruct the queue within that range.
+            let mut new_segment: Vec<glib::Object> = Vec::with_capacity((max_pos - min_pos + 1) as usize);
+            let mut queue_map = self.imp().queue_map.borrow_mut();
+            let mut change_idx: usize = 0;
+            for pos in min_pos..=max_pos {
+                // If this position did not change, then simply use the current GObject.
+                // This only happens within the length of the current queue. Entries past its
+                // length will be included in the changes vec.
+                if changes[change_idx].pos != pos {
+                    if let Some(old_song) = queue.item(pos as u32) {
+                        new_segment.push(old_song);
+                    } else {
+                        // Exceeded current queue (new queue is longer)
+                        panic!("New queue is longer than current queue, but no corresponding diff info was received");
+                    }
+                } else {
+                    // This position changed. Check if it's now occupied by a song that's also
+                    // in the current queue. If yes, reuse the GObject.
+                    let mut found_existing: bool = false;
+                    let id = changes[change_idx].id.0;
+                    if let Some(weak_ref) = queue_map.get(&id) {
+                        if let Some(obj) = weak_ref.upgrade() {
+                            // Update its position in the queue.
+                            obj.downcast_ref::<Song>().unwrap().set_queue_pos(pos);
+                            found_existing = true;
+                            new_segment.push(obj.into());
+                        }
+                         else {
+                             queue_map.remove(&id);
+                         }
+                    }
+                    if !found_existing {
+                        // New song. Fetch info.
+                        // On very slow connections this might be called after the queue has changed
+                        // once more, potentially removing the song with this ID from the server-side
+                        // queue. In that case, push a default Song GObject as padding. More update
+                        // calls are guaranteed to be triggered and will fix this.
+                        let song = self.client()
+                                .get_song_at_queue_id(id)
+                                .unwrap_or_default();
+                        let weak_ref = WeakRef::new();
+                        weak_ref.set(Some(&song));
+                        queue_map.insert(id, weak_ref);
+                        new_segment.push(song.into());
+                    }
+                    change_idx += 1;
                 }
+            }
+            if queue.n_items() > 0 && min_pos < queue.n_items() {
+                // Overwrite current queue with the above updated segment
+                queue.splice(
+                    min_pos,
+                    max_pos.min(queue.n_items() - 1) - min_pos + 1,
+                    &new_segment
+                );
+            } else {
+                queue.extend_from_slice(&new_segment);
             }
         }
     }
@@ -1373,19 +1418,12 @@ impl Player {
         self.imp().volume.get()
     }
 
-    pub fn queue_id(&self) -> u32 {
-        if let Some(song) = &*self.imp().current_song.borrow() {
-            return song.get_queue_id();
-        }
-        // Should never match a real song.
-        u32::MAX
+    pub fn queue_id(&self) -> Option<u32> {
+        self.imp().current_song.borrow().as_ref().map(|s| s.get_queue_id())
     }
 
     pub fn queue_pos(&self) -> Option<u32> {
-        if let Some(song) = &*self.imp().current_song.borrow() {
-            return Some(song.get_queue_pos());
-        }
-        return None;
+        self.imp().current_song.borrow().as_ref().map(|s| s.get_queue_pos())
     }
 
     pub fn position(&self) -> f64 {
@@ -1496,77 +1534,51 @@ impl Player {
         self.client().play_at(song.get_queue_id(), true);
     }
 
-    fn pos_of_id(&self, id: u32) -> Option<u32> {
-        for (i, song_obj) in self.imp().queue.iter::<Song>().enumerate() {
-            let song: Song = song_obj.unwrap().downcast::<Song>().unwrap();
-            if song.get_queue_id() == id {
-                return Some(i as u32);
-            }
-        }
-        None
-    }
-
-    pub fn remove_song_id(&self, id: u32) {
-        if let Some(pos) = self.pos_of_id(id) {
+    pub fn remove_song_pos(&self, delete_pos: u32) {
+        {
+            let id = self.imp().queue.item(delete_pos).and_downcast_ref::<Song>().unwrap().get_queue_pos();
+            self.imp().queue_map.borrow_mut().remove(&id);
+            self.imp().queue.remove(delete_pos);
             self.client().register_local_queue_changes(1);
-            self.imp().queue.remove(pos);
-            if let Some(current_song) = self.imp().current_song.borrow().as_ref() {
-                let curr_pos = current_song.get_queue_pos();
-                if curr_pos > pos {
-                    current_song.set_queue_pos(curr_pos - 1);
-                }
-            }
-            self.client().delete_at(id, true);
-        }
-    }
-
-    pub fn swap_dir(&self, id: u32, direction: SwapDirection) {
-        // Find position of given queue_id
-        if let Some(pos) = self.pos_of_id(id) {
-            self.client().register_local_queue_changes(1);
-            let current_song = self.imp().current_song.borrow();
-            match direction {
-                SwapDirection::Up => {
-                    if pos > 0 {
-                        let target = self.imp().queue.item(pos).unwrap().downcast::<Song>().unwrap();
-                        let upper = self.imp().queue.item(pos - 1).unwrap().downcast::<Song>().unwrap();
-                        // As of right now we only need to keep the current song's queue pos updated for the Queue Next function.
-                        // Other songs' queue positions are not used.
-                        if let Some(current_song) = current_song.as_ref() {
-                            if current_song.get_queue_id() == target.get_queue_id() {
-                                current_song.set_queue_pos(current_song.get_queue_pos() - 1);
-                            }
-                            else if current_song.get_queue_id() == upper.get_queue_id() {
-                                current_song.set_queue_pos(current_song.get_queue_pos() + 1);
-                            }
-                        }
-                        self.imp().queue.splice(pos - 1, 2, &[
-                            target.upcast::<glib::Object>(),
-                            upper.upcast::<glib::Object>()
-                        ]);
-                        self.client().swap(pos, pos - 1, false);
+            for (_, song) in self.imp().queue_map.borrow().iter() {
+                if let Some(song) = song.upgrade() {
+                    let curr_pos = song.get_queue_pos();
+                    if curr_pos > delete_pos {
+                        song.set_queue_pos(curr_pos - 1);
                     }
                 }
-                SwapDirection::Down => {
-                    if pos < self.imp().queue.n_items() - 1 {
-                        let target = self.imp().queue.item(pos).unwrap().downcast::<Song>().unwrap();
-                        let lower = self.imp().queue.item(pos + 1).unwrap().downcast::<Song>().unwrap();
-                        // As of right now we only need to keep the current song's queue pos updated for the Queue Next function.
-                        // Other songs' queue positions are not used.
-                        if let Some(current_song) = current_song.as_ref() {
-                            if current_song.get_queue_id() == target.get_queue_id() {
-                                current_song.set_queue_pos(current_song.get_queue_pos() + 1);
-                            }
-                            else if current_song.get_queue_id() == lower.get_queue_id() {
-                                current_song.set_queue_pos(current_song.get_queue_pos() - 1);
-                            }
-                        }
-                        self.imp().queue.splice(pos, 2, &[
-                            lower.upcast::<glib::Object>(),
-                            target.upcast::<glib::Object>()
-                        ]);
-                        self.client().swap(pos, pos + 1, false);
-                    }
+            }
+        }
+        self.client().delete_at(delete_pos, false);
+    }
+
+    pub fn swap_dir(&self, pos: u32, direction: SwapDirection) {
+        self.client().register_local_queue_changes(1);
+        match direction {
+            SwapDirection::Up => {
+                if pos > 0 {
+                    let target = self.imp().queue.item(pos).unwrap().downcast::<Song>().unwrap();
+                    let upper = self.imp().queue.item(pos - 1).unwrap().downcast::<Song>().unwrap();
+                    target.set_queue_pos(pos - 1);
+                    upper.set_queue_pos(pos);
+                    self.imp().queue.splice(pos - 1, 2, &[
+                        target.upcast::<glib::Object>(),
+                        upper.upcast::<glib::Object>()
+                    ]);
+                    self.client().swap(pos, pos - 1, false);
+                }
+            }
+            SwapDirection::Down => {
+                if pos < self.imp().queue.n_items() - 1 {
+                    let target = self.imp().queue.item(pos).unwrap().downcast::<Song>().unwrap();
+                    let lower = self.imp().queue.item(pos + 1).unwrap().downcast::<Song>().unwrap();
+                    target.set_queue_pos(pos + 1);
+                    lower.set_queue_pos(pos);
+                    self.imp().queue.splice(pos, 2, &[
+                        lower.upcast::<glib::Object>(),
+                        target.upcast::<glib::Object>()
+                    ]);
+                    self.client().swap(pos, pos + 1, false);
                 }
             }
         }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1103,16 +1103,19 @@ impl Player {
                     }
                 }
             }
-        } else {
+        }
+        // status responses after a "stop" command will still come with the ID of the last-played
+        // song, which is not what we want.
+        if status.song.is_none() || status.state == State::Stop {
+            println!("No song playing right now");
             // No song is playing. Update state accordingly.
-            let was_playing = self.imp().current_song.borrow().as_ref().is_some(); // end borrow
-            if was_playing {
+            if let Some(_) = self.imp().current_song.take() {
                 self.imp().saved_to_history.set(false);
-                let _ = self.imp().current_song.take();
                 self.notify("title");
                 self.notify("artist");
                 self.notify("album");
                 self.notify("duration");
+                self.notify("queue-id");
                 self.imp().cover_source.set(CoverSource::Unknown);
                 self.emit_by_name::<()>("cover-changed", &[&Option::<gdk::Texture>::None]);
                 // Update MPRIS side
@@ -1478,26 +1481,26 @@ impl Player {
         }
     }
 
-    pub fn prev_song(&self) {
+    pub fn prev_song(&self, block: bool) {
         if self.imp().pipewire_restart_between_songs.get()
             && self.imp().fft_backend.borrow().as_ref().is_some_and(
                 |backend| backend.name() == "pipewire" && backend.status() != FftStatus::ValidNotReading
             )
         {
             println!("Stopping PipeWire backend to allow samplerate change...");
-            self.maybe_stop_fft_thread(true);
+            self.maybe_stop_fft_thread(block);
         }
         self.client().prev();
     }
 
-    pub fn next_song(&self) {
+    pub fn next_song(&self, block: bool) {
         if self.imp().pipewire_restart_between_songs.get()
             && self.imp().fft_backend.borrow().as_ref().is_some_and(
                 |backend| backend.name() == "pipewire" && backend.status() != FftStatus::ValidNotReading
             )
         {
             println!("Stopping PipeWire backend to allow samplerate change...");
-            self.maybe_stop_fft_thread(true);
+            self.maybe_stop_fft_thread(block);
         }
         self.client().next();
     }
@@ -1680,12 +1683,12 @@ impl LocalRootInterface for Player {
 
 impl LocalPlayerInterface for Player {
     async fn next(&self) -> fdo::Result<()> {
-        self.next_song();
+        self.next_song(false);
         Ok(())
     }
 
     async fn previous(&self) -> fdo::Result<()> {
-        self.prev_song();
+        self.prev_song(false);
         Ok(())
     }
 

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1038,7 +1038,6 @@ impl Player {
                     }
                 } else if let Some(curr_song) = local_curr_song.as_ref() {
                     // Same old song. Just update its queue position.
-                    println!("Updating queue pos of current song");
                     curr_song.set_queue_pos(new_queue_place.pos);
                     // Record into playback history
                     if !settings_manager().child("library").boolean("pause-recent") {

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -9,7 +9,6 @@ use crate::{
     utils::{prettify_audio_format, settings_manager, strip_filename_linux}
 };
 use async_lock::OnceCell as AsyncOnceCell;
-use ::glib::WeakRef;
 use mpris_server::{
     zbus::{self, fdo},
     LocalPlayerInterface, LocalRootInterface, LocalServer, LoopStatus, Metadata as MprisMetadata,
@@ -173,7 +172,6 @@ mod imp {
 
     use super::*;
     use crate::{application::EuphonicaApplication, common::CoverSource, meta_providers::models::Lyrics};
-    use ::glib::WeakRef;
     use glib::{
         ParamSpec, ParamSpecBoolean, ParamSpecDouble, ParamSpecEnum, ParamSpecFloat, ParamSpecInt,
         ParamSpecString, ParamSpecUInt, ParamSpecUInt64
@@ -799,24 +797,6 @@ impl Player {
                     let mut song_cache = this.imp().song_cache.borrow_mut();
                     for song in songs.iter() {
                         song_cache.push(song.get_queue_id(), song.clone());
-                    }
-                }
-            )
-        );
-
-        client_state.connect_closure(
-            "queue-songs-downloaded",
-            false,
-            closure_local!(
-                #[weak(rename_to = this)]
-                self,
-                move |_: ClientState, songs: glib::BoxedAnyObject| {
-                    let songs = songs.borrow::<Vec<Song>>();
-                    this.imp().queue.extend_from_slice(&songs);
-                    for song in songs.iter() {
-                        let weak_ref = WeakRef::new();
-                        weak_ref.set(Some(song));
-                        this.imp().queue_map.borrow_mut().insert(song.get_queue_id(), weak_ref);
                     }
                 }
             )

--- a/src/player/fft_backends/fifo.rs
+++ b/src/player/fft_backends/fifo.rs
@@ -1,5 +1,5 @@
 use gio::{self, prelude::*};
-use glib::{subclass::prelude::*, clone};
+use glib::{clone};
 use std::{
     cell::RefCell, rc::Rc, str::FromStr, sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex}, thread, time::Duration
 };
@@ -146,7 +146,7 @@ impl FftBackendImpl for FifoFftBackend {
                                     std::io::ErrorKind::UnexpectedEof
                                         | std::io::ErrorKind::WouldBlock => {
                                             was_reading = false;
-                                            sender.send_blocking(FftStatus::ValidNotReading);
+                                            let _ = sender.send_blocking(FftStatus::ValidNotReading);
                                         }
                                     _ => {
                                         println!("FFT ERR: {:?}", &e);
@@ -161,7 +161,7 @@ impl FftBackendImpl for FifoFftBackend {
                                 return;
                             } else if !was_reading {
                                 was_reading = true;
-                                sender.send_blocking(FftStatus::Reading);
+                                let _ = sender.send_blocking(FftStatus::Reading);
                             }
                             thread::sleep(Duration::from_millis((1000.0 / fps).floor() as u64));
                         }
@@ -169,7 +169,7 @@ impl FftBackendImpl for FifoFftBackend {
                 }
                 // All graceful thread shutdowns are inside the loop. If we've reached here then
                 // it's an error.
-                sender.send_blocking(FftStatus::Invalid);
+                let _ = sender.send_blocking(FftStatus::Invalid);
             });
             self.fft_handle.replace(Some(fft_handle));
 

--- a/src/player/playback_controls.rs
+++ b/src/player/playback_controls.rs
@@ -118,7 +118,7 @@ impl PlaybackControls {
         self.imp().prev_btn.connect_clicked(clone!(
             #[strong]
             player,
-            move |_| player.prev_song()
+            move |_| player.prev_song(true)
         ));
         self.imp().play_pause_btn.connect_clicked(clone!(
             #[weak]
@@ -128,7 +128,7 @@ impl PlaybackControls {
         self.imp().next_btn.connect_clicked(clone!(
             #[strong]
             player,
-            move |_| player.next_song()
+            move |_| player.next_song(true)
         ));
         let shuffle_btn = imp.random_btn.get();
         shuffle_btn

--- a/src/player/queue_row.rs
+++ b/src/player/queue_row.rs
@@ -43,9 +43,9 @@ mod imp {
         pub quality_grade: TemplateChild<gtk::Image>,
         #[template_child]
         pub remove: TemplateChild<Button>,
-        pub queue_id: Cell<u32>,
-        pub thumbnail_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
+        pub signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId, SignalHandlerId)>>,
         pub song: RefCell<Option<Song>>,
+        pub player: OnceCell<Player>,
         pub cache: OnceCell<Rc<Cache>>,
         pub thumbnail_source: Cell<CoverSource>,
     }
@@ -76,7 +76,6 @@ mod imp {
                     ParamSpecString::builder("artist").build(),
                     ParamSpecString::builder("album").build(),
                     ParamSpecBoolean::builder("is-playing").build(),
-                    ParamSpecUInt::builder("queue-id").build(),
                     // ParamSpecString::builder("duration").build(),
                     ParamSpecString::builder("quality-grade").build(),
                 ]
@@ -90,7 +89,6 @@ mod imp {
                 "artist" => self.artist_name.label().to_value(),
                 "album" => self.album_name.label().to_value(),
                 "is-playing" => self.playing_indicator.is_child_revealed().to_value(),
-                "queue-id" => self.queue_id.get().to_value(),
                 // "duration" => self.duration.label().to_value(),
                 "quality-grade" => self.quality_grade.icon_name().to_value(),
                 _ => unimplemented!(),
@@ -124,11 +122,6 @@ mod imp {
                         self.playing_indicator.set_reveal_child(p);
                     }
                 }
-                "queue-id" => {
-                    if let Ok(id) = value.get::<u32>() {
-                        self.queue_id.replace(id);
-                    }
-                }
                 // "duration" => {
                 //     // Pre-formatted please
                 //     if let Ok(dur) = value.get::<&str>() {
@@ -149,7 +142,8 @@ mod imp {
         }
 
         fn dispose(&self) {
-            if let Some((set_id, clear_id)) = self.thumbnail_signal_ids.take() {
+            if let Some((playing_id, set_id, clear_id)) = self.signal_ids.take() {
+                self.player.get().unwrap().disconnect(playing_id);
                 let cache_state = self.cache.get().unwrap().get_cache_state();
                 cache_state.disconnect(set_id);
                 cache_state.disconnect(clear_id);
@@ -177,10 +171,22 @@ impl QueueRow {
         res
     }
 
+    fn update_playing_status(&self, maybe_queue_id: Option<u32>) {
+        if let (Some(id), Some(own_id)) = (
+            maybe_queue_id,
+            self.imp().song.borrow().as_ref().map(|s| s.get_queue_id())
+        ) {
+            self.imp().playing_indicator.set_reveal_child(id == own_id);
+        } else {
+            self.imp().playing_indicator.set_reveal_child(false);
+        }
+    }
+
     #[inline(always)]
     pub fn setup(&self, item: &gtk::ListItem, player: Player, cache: Rc<Cache>) {
         let cache_state = cache.get_cache_state();
         let _ = self.imp().cache.set(cache.clone());
+        let _ = self.imp().player.set(player.clone());
         // Bind controls
         self.imp().remove.connect_clicked(clone!(
             #[weak(rename_to = this)]
@@ -188,7 +194,9 @@ impl QueueRow {
             #[weak]
             player,
             move |_| {
-                player.remove_song_id(this.imp().queue_id.get());
+                if let Some(song) = this.imp().song.borrow().as_ref() {
+                    player.remove_song_pos(song.get_queue_pos());
+                }
             }
         ));
 
@@ -198,7 +206,9 @@ impl QueueRow {
             #[weak]
             player,
             move |_| {
-                player.swap_dir(this.imp().queue_id.get(), SwapDirection::Up);
+                if let Some(song) = this.imp().song.borrow().as_ref() {
+                    player.swap_dir(song.get_queue_pos(), SwapDirection::Up);
+                }
             }
         ));
 
@@ -208,7 +218,9 @@ impl QueueRow {
             #[weak]
             player,
             move |_| {
-                player.swap_dir(this.imp().queue_id.get(), SwapDirection::Down);
+                if let Some(song) = this.imp().song.borrow().as_ref() {
+                    player.swap_dir(song.get_queue_pos(), SwapDirection::Down);
+                }
             }
         ));
 
@@ -240,11 +252,17 @@ impl QueueRow {
             .chain_property::<Song>("is-playing")
             .bind(self, "is-playing", gtk::Widget::NONE);
 
-        item.property_expression("item")
-            .chain_property::<Song>("queue-id")
-            .bind(self, "queue-id", gtk::Widget::NONE);
-
-        let _ = self.imp().thumbnail_signal_ids.replace(Some((
+        let _ = self.imp().signal_ids.replace(Some((
+            player.connect_notify_local(
+                Some("queue-id"),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |player, _| {
+                        this.update_playing_status(player.queue_id());
+                    }
+                )
+            ),
             cache_state.connect_closure(
                 "album-art-downloaded",
                 false,
@@ -351,6 +369,7 @@ impl QueueRow {
         // Here we only need to manually bind to the cache controller to fetch album art.
         // No need to fetch here as QueueView has already done once for us.
         self.imp().song.replace(Some(song.clone()));
+        self.update_playing_status(self.imp().player.get().unwrap().queue_id());
         self.schedule_thumbnail(song.get_info());
     }
 

--- a/src/player/queue_row.rs
+++ b/src/player/queue_row.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{controller::SwapDirection, Player};
 
 mod imp {
-    use glib::{ParamSpec, ParamSpecBoolean, ParamSpecString, ParamSpecUInt};
+    use glib::{ParamSpec, ParamSpecBoolean, ParamSpecString};
     use gtk::{Button, Revealer};
     use once_cell::sync::Lazy;
     use std::cell::{Cell, OnceCell};
@@ -195,7 +195,7 @@ impl QueueRow {
             player,
             move |_| {
                 if let Some(song) = this.imp().song.borrow().as_ref() {
-                    player.remove_song_pos(song.get_queue_pos());
+                    player.remove_song(song);
                 }
             }
         ));
@@ -207,7 +207,7 @@ impl QueueRow {
             player,
             move |_| {
                 if let Some(song) = this.imp().song.borrow().as_ref() {
-                    player.swap_dir(song.get_queue_pos(), SwapDirection::Up);
+                    player.swap_dir(song, SwapDirection::Up);
                 }
             }
         ));
@@ -219,7 +219,7 @@ impl QueueRow {
             player,
             move |_| {
                 if let Some(song) = this.imp().song.borrow().as_ref() {
-                    player.swap_dir(song.get_queue_pos(), SwapDirection::Down);
+                    player.swap_dir(song, SwapDirection::Down);
                 }
             }
         ));

--- a/src/player/queue_view.rs
+++ b/src/player/queue_view.rs
@@ -182,7 +182,7 @@ impl QueueView {
         // Enable/disable clear queue button depending on whether the queue is empty or not
         // Set selection mode
         // TODO: Allow click to jump to song
-        let queue_model = player.queue();
+        let queue_model = player.queue().clone();
         let stack = self.imp().content_stack.get();
         queue_model
             .bind_property("n-items", &stack, "visible-child-name")

--- a/src/player/queue_view.rs
+++ b/src/player/queue_view.rs
@@ -216,26 +216,32 @@ impl QueueView {
             }
         ));
         // Tell factory how to bind `QueueRow` to one of our Song GObjects
-        factory.connect_bind(move |_, list_item| {
-            // Get `Song` from `ListItem` (that is, the data side)
-            let item: Song = list_item
-                .downcast_ref::<ListItem>()
-                .expect("Needs to be ListItem")
-                .item()
-                .and_downcast::<Song>()
-                .expect("The item has to be a common::Song.");
+        factory.connect_bind(clone!(
+            #[weak(rename_to = this)]
+            self,
+            move |_, list_item| {
+                // Get `Song` from `ListItem` (that is, the data side)
+                let item: Song = list_item
+                    .downcast_ref::<ListItem>()
+                    .expect("Needs to be ListItem")
+                    .item()
+                    .and_downcast::<Song>()
+                    .expect("The item has to be a common::Song.");
 
-            // Get `QueueRow` from `ListItem` (the UI widget)
-            let child: QueueRow = list_item
-                .downcast_ref::<ListItem>()
-                .expect("Needs to be ListItem")
-                .child()
-                .and_downcast::<QueueRow>()
-                .expect("The child has to be a `QueueRow`.");
+                // Get `QueueRow` from `ListItem` (the UI widget)
+                let child: QueueRow = list_item
+                    .downcast_ref::<ListItem>()
+                    .expect("Needs to be ListItem")
+                    .child()
+                    .and_downcast::<QueueRow>()
+                    .expect("The child has to be a `QueueRow`.");
 
-            // Within this binding fn is where the cached album art texture gets used.
-            child.bind(&item);
-        });
+                // Within this binding fn is where the cached album art texture gets used.
+                child.bind(&item);
+
+                this.imp().last_scroll_pos.set(this.imp().scrolled_window.vadjustment().value());
+                this.imp().restore_last_pos.set(2);
+            }));
 
         // When row goes out of sight, unbind from item to allow reuse with another.
         // Remember to also unset the thumbnail widget's texture to potentially free it from memory.
@@ -254,7 +260,7 @@ impl QueueView {
             #[weak(rename_to = this)]
             self,
             move |_, _| {
-                // The above scroll bug only manifests after this, so now is the best time to set
+                // The above scroll bug also manifests after this, so now is the best time to set
                 // the corresponding values.
                 this.imp().last_scroll_pos.set(this.imp().scrolled_window.vadjustment().value());
                 this.imp().restore_last_pos.set(2);

--- a/src/player/seekbar.rs
+++ b/src/player/seekbar.rs
@@ -1,4 +1,4 @@
-use glib::{clone, closure_local, Object};
+use glib::{clone, Object};
 use gtk::{glib, prelude::*, subclass::prelude::*, CompositeTemplate};
 use std::cell::Cell;
 
@@ -7,10 +7,10 @@ use crate::{common::QualityGrade, utils};
 use super::Player;
 
 mod imp {
-    use std::{cell::OnceCell, sync::OnceLock};
+    use std::{cell::OnceCell};
 
     use crate::utils::format_secs_as_duration;
-    use glib::{subclass::Signal, ParamSpec, ParamSpecDouble};
+    use glib::{ParamSpec, ParamSpecDouble};
     use once_cell::sync::Lazy;
 
     use super::*;

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -206,7 +206,9 @@ impl Sidebar {
                         move |btn| {
                             if btn.is_active() {
                                 playlist_view.on_playlist_clicked(&playlist);
-                                stack.set_visible_child_name("playlists");
+                                if stack.visible_child_name().is_none_or(|name| name.as_str() != "playlists") {
+                                    stack.set_visible_child_name("playlists");
+                                }
                                 split_view.set_show_sidebar(!split_view.is_collapsed());
                             }
                         }
@@ -239,7 +241,9 @@ impl Sidebar {
             move |btn| {
                 if btn.is_active() {
                     playlist_view.pop();
-                    stack.set_visible_child_name("playlists");
+                    if stack.visible_child_name().is_none_or(|name| name.as_str() != "playlists") {
+                        stack.set_visible_child_name("playlists");
+                    }
                 }
             }
         ));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use aho_corasick::AhoCorasick;
 use gio::prelude::*;
 use gtk::gio;
 use gtk::Ordering;
-use image::{imageops::FilterType, io::Reader as ImageReader, DynamicImage, RgbImage};
+use image::{imageops::FilterType, ImageReader, DynamicImage, RgbImage};
 use mpd::status::AudioFormat;
 use once_cell::sync::Lazy;
 use std::sync::OnceLock;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1052,7 +1052,7 @@ impl EuphonicaWindow {
             ClientError::Queuing => {
                 self.send_simple_toast("Some songs could not be queued", 3);
             }
-            _ => {}
+            // _ => {}
         }
     }
 


### PR DESCRIPTION
Batch-based queue fetch and update code. There's now an additional LRU cache to facilitate the more complicated update logic. All song objects in the queue now have their queue positions kept up to date efficiently and asynchronously (i.e. deletions from extremely long queues should no longer block UI).

Should fix the last instances of UI freezing & fix #110.

- [x] Make all remaining O(n) operations async
- [x] Make playlist content loading async when connected to MPD 0.24+
- [x] Fix playing indicator not disappearing after player goes into stopped state
- [x] Fix selection-related labels not updating after switching to a new album/artist in their respective content views