### PR TITLE
More queue & playlist view performance improvements

### DIFF
--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -31,14 +31,6 @@ pub struct HistoryStep {
 }
 
 impl HistoryStep {
-    fn update_queue_pos(&self, list: &gio::ListStore, from: u32, to: u32) {
-        for i in from..=to {
-            list.item(i)
-                .and_downcast_ref::<Song>()
-                .unwrap()
-                .set_queue_pos(i);
-        }
-    }
     fn shift(&self, list: &gio::ListStore, old: u32, backward: bool) {
         // Use splice to only emit one update signal, reducing visual jitter
         let src = if backward { old - 1 } else { old };
@@ -46,7 +38,6 @@ impl HistoryStep {
         let src_song = list.item(src).unwrap();
         let des_song = list.item(des).unwrap();
         list.splice(src, 2, &[des_song, src_song]);
-        self.update_queue_pos(list, src, des);
     }
 
     pub fn forward(&self, list: &gio::ListStore) {
@@ -73,10 +64,6 @@ impl HistoryStep {
             }
             InternalEditAction::Remove(idx) => {
                 list.insert(idx, self.song.as_ref().unwrap());
-                let len = list.n_items();
-                if len > 0 && idx <= len - 1 {
-                    self.update_queue_pos(list, idx, len - 1);
-                }
             }
         }
     }
@@ -841,17 +828,7 @@ impl PlaylistContentView {
     fn add_songs(&self, songs: &[Song]) {
         // To facilitate editing, each song needs to keep its own position within the playlist.
         // TODO: find a less fragile algo for this
-        let curr_len = self.imp().song_list.n_items();
         self.imp().song_list.extend_from_slice(songs);
-        for i in curr_len..self.imp().song_list.n_items() {
-            self.imp()
-                .song_list
-                .item(i)
-                .unwrap()
-                .downcast_ref::<Song>()
-                .unwrap()
-                .set_queue_pos(curr_len + i);
-        }
         self.imp()
             .track_count
             .set_label(&self.imp().song_list.n_items().to_string());

--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -59,10 +59,6 @@ impl HistoryStep {
             }
             InternalEditAction::Remove(idx) => {
                 list.remove(idx);
-                let len = list.n_items();
-                if len > 0 && idx <= len - 1 {
-                    self.update_queue_pos(list, idx, len - 1);
-                }
             }
         }
     }
@@ -717,23 +713,18 @@ impl PlaylistContentView {
         [&factory, &editing_factory].iter().for_each(move |f| {
             f.connect_bind(|_, list_item| {
                 // Get `Song` from `ListItem` (that is, the data side)
-                let item: Song = list_item
+                let item: &ListItem = list_item
                     .downcast_ref::<ListItem>()
-                    .expect("Needs to be ListItem")
-                    .item()
-                    .and_downcast::<Song>()
-                    .expect("The item has to be a common::Song.");
+                    .expect("Needs to be ListItem");
 
                 // Get `PlaylistSongRow` from `ListItem` (the UI widget)
-                let child: PlaylistSongRow = list_item
-                    .downcast_ref::<ListItem>()
-                    .expect("Needs to be ListItem")
+                let child: PlaylistSongRow = item
                     .child()
                     .and_downcast::<PlaylistSongRow>()
                     .expect("The child has to be an `PlaylistSongRow`.");
 
                 // Within this binding fn is where the cached album art texture gets used.
-                child.bind(&item);
+                child.bind(item);
             });
 
             // When row goes out of sight, unbind from item to allow reuse with another.

--- a/src/library/playlist_song_row.rs
+++ b/src/library/playlist_song_row.rs
@@ -1,4 +1,4 @@
-use glib::{clone, closure_local, Object, SignalHandlerId};
+use glib::{clone, closure_local, Object, SignalHandlerId, WeakRef};
 use gtk::{gdk, glib, prelude::*, subclass::prelude::*, CompositeTemplate};
 use std::{
     cell::{OnceCell, RefCell},
@@ -57,7 +57,7 @@ mod imp {
         pub lower_signal_id: RefCell<Option<SignalHandlerId>>,
         pub remove_signal_id: RefCell<Option<SignalHandlerId>>,
         pub library: OnceCell<Library>,
-        pub song: RefCell<Option<Song>>,
+        pub item: WeakRef<gtk::ListItem>,
         pub cache: OnceCell<Rc<Cache>>,
         pub content_view: OnceCell<PlaylistContentView>,
         pub queue_controls_visible: Cell<bool>,
@@ -271,7 +271,7 @@ impl PlaylistSongRow {
                         }
                         // Match song URI first then folder URI. Only try to match by folder URI
                         // if we don't have a current thumbnail.
-                        if let Some(song) = this.imp().song.borrow().as_ref() {
+                        if let Some(song) = this.song() {
                             if uri.as_str() == song.get_uri() {
                                 // Force update since we might have been using a folder cover
                                 // temporarily
@@ -292,7 +292,7 @@ impl PlaylistSongRow {
                     #[weak(rename_to = this)]
                     self,
                     move |_: CacheState, uri: String| {
-                        if let Some(song) = this.imp().song.borrow().as_ref() {
+                        if let Some(song) = this.song() {
                             match this.imp().thumbnail_source.get() {
                                 CoverSource::Folder => {
                                     if strip_filename_linux(song.get_uri()) == uri {
@@ -316,7 +316,7 @@ impl PlaylistSongRow {
             #[strong(rename_to = this)]
             self,
             move |_| {
-                if let (Some(library), Some(song)) = (this.imp().library.get(), this.imp().song.borrow().as_ref()) {
+                if let (Some(library), Some(song)) = (this.imp().library.get(), this.song()) {
                     library.queue_uri(song.get_uri(), true, true, false);
                 }
             }
@@ -326,7 +326,7 @@ impl PlaylistSongRow {
             #[strong(rename_to = this)]
             self,
             move |_| {
-                if let (Some(library), Some(song)) = (this.imp().library.get(), this.imp().song.borrow().as_ref()) {
+                if let (Some(library), Some(song)) = (this.imp().library.get(), this.song()) {
                     library.queue_uri(song.get_uri(), false, false, false);
                 }
             }
@@ -336,8 +336,8 @@ impl PlaylistSongRow {
             #[strong(rename_to = this)]
             self,
             move |_| {
-                if let Some(song) = this.imp().song.borrow().as_ref() {
-                    this.imp().content_view.get().unwrap().shift_backward(song.get_queue_pos());
+                if let Some(item) = this.imp().item.upgrade() {
+                    this.imp().content_view.get().unwrap().shift_backward(item.position());
                 }
             }
         ));
@@ -346,8 +346,8 @@ impl PlaylistSongRow {
             #[strong(rename_to = this)]
             self,
             move |_| {
-                if let Some(song) = this.imp().song.borrow().as_ref() {
-                    this.imp().content_view.get().unwrap().shift_forward(song.get_queue_pos());
+                if let Some(item) = this.imp().item.upgrade() {
+                    this.imp().content_view.get().unwrap().shift_forward(item.position());
                 }
             }
         ));
@@ -356,8 +356,8 @@ impl PlaylistSongRow {
             #[strong(rename_to = this)]
             self,
             move |_| {
-                if let Some(song) = this.imp().song.borrow().as_ref() {
-                    this.imp().content_view.get().unwrap().remove(song.get_queue_pos());
+                if let Some(item) = this.imp().item.upgrade() {
+                    this.imp().content_view.get().unwrap().remove(item.position());
                 }
             }
         ));
@@ -390,15 +390,22 @@ impl PlaylistSongRow {
         self.imp().thumbnail_source.set(src);
     }
 
-    pub fn bind(&self, song: &Song) {
-        self.imp().song.replace(Some(song.clone()));
+    fn song(&self) -> Option<Song> {
+        self.imp().item.upgrade().map(|item| item
+            .item()
+            .and_downcast::<Song>()
+            .expect("The item has to be a common::Song."))
+    }
+
+    pub fn bind(&self, item: &gtk::ListItem) {
+        self.imp().item.set(Some(item));
+        let song = self.song().unwrap();
         self.schedule_thumbnail(song.get_info());
     }
 
     pub fn unbind(&self) {
-        if let Some(_) = self.imp().song.take() {
-            self.clear_thumbnail();
-        }
+        self.imp().item.set(Option::<&gtk::ListItem>::None);
+        self.clear_thumbnail();
     }
 
     pub fn get_queue_controls_visible(&self) -> bool {

--- a/src/library/playlist_song_row.rs
+++ b/src/library/playlist_song_row.rs
@@ -229,8 +229,7 @@ impl PlaylistSongRow {
            .expect("ArtistSongRow cannot bind to cache");
         let _ = self.imp().library.set(library);
         let _ = self.imp().content_view.set(view);
-        item.property_expression("item")
-            .chain_property::<Song>("queue-pos")
+        item.property_expression("position")
             .chain_closure::<String>(closure_local!(|_: Option<Object>, val: u32| {
                 val.to_string()
             }))

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1037,9 +1037,7 @@ impl Player {
                         }
                     }
                 } else if let Some(curr_song) = local_curr_song.as_ref() {
-                    // Same old song. Just update its queue position.
-                    curr_song.set_queue_pos(new_queue_place.pos);
-                    // Record into playback history
+                    // Same old song. Might want to record into playback history.
                     if !settings_manager().child("library").boolean("pause-recent") {
                         let dur = curr_song.get_duration() as f32;
                         if dur >= 10.0 {
@@ -1242,7 +1240,6 @@ impl Player {
                     // This position changed. Check if it's a song we already have locally.
                     let id = changes[change_idx].id.0;
                     if let Some(existing) = song_cache.get(&id) {
-                        existing.set_queue_pos(changes[change_idx].pos);
                         new_segment.push(existing.clone().into());
                     } else {
                         println!("update_queue(): Song cache miss");
@@ -1542,8 +1539,6 @@ impl Player {
             SwapDirection::Up => {
                 if pos > 0 {
                     let upper = self.imp().queue.item(pos - 1).and_downcast::<Song>().unwrap();
-                    target.set_queue_pos(pos - 1);
-                    upper.set_queue_pos(pos);
                     self.imp().queue.splice(pos - 1, 2, &[
                         target.clone().upcast::<glib::Object>(),
                         upper.upcast::<glib::Object>()
@@ -1554,8 +1549,6 @@ impl Player {
             SwapDirection::Down => {
                 if pos < self.imp().queue.n_items() - 1 {
                     let lower = self.imp().queue.item(pos + 1).and_downcast::<Song>().unwrap();
-                    target.set_queue_pos(pos + 1);
-                    lower.set_queue_pos(pos);
                     self.imp().queue.splice(pos, 2, &[
                         lower.upcast::<glib::Object>(),
                         target.clone().upcast::<glib::Object>()

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1528,15 +1528,16 @@ impl Player {
         self.client().play_at(song.get_queue_id(), true);
     }
 
-    /// Remove given song from queue. Will cause an asynchronous server-side sync
-    /// to update all subsequent songs' queue positions.
-    pub fn remove_song(&self, song: &Song) {
-        self.client().delete_at(song.get_queue_id(), true);
+    /// Remove given song from queue.
+    pub fn remove_pos(&self, pos: u32) {
+        self.client().register_local_queue_changes(1);
+        self.queue().remove(pos);
+        self.client().delete_at(pos, false);
     }
 
-    pub fn swap_dir(&self, target: &Song, direction: SwapDirection) {
+    pub fn swap_dir(&self, pos: u32, direction: SwapDirection) {
         self.client().register_local_queue_changes(1);
-        let pos = target.get_queue_pos();
+        let target = self.imp().queue.item(pos).and_downcast::<Song>().unwrap();
         match direction {
             SwapDirection::Up => {
                 if pos > 0 {

--- a/src/player/queue_view.rs
+++ b/src/player/queue_view.rs
@@ -221,17 +221,13 @@ impl QueueView {
             self,
             move |_, list_item| {
                 // Get `Song` from `ListItem` (that is, the data side)
-                let item: Song = list_item
+                let item: &ListItem = list_item
                     .downcast_ref::<ListItem>()
-                    .expect("Needs to be ListItem")
-                    .item()
-                    .and_downcast::<Song>()
-                    .expect("The item has to be a common::Song.");
+                    .expect("Needs to be ListItem");
+
 
                 // Get `QueueRow` from `ListItem` (the UI widget)
-                let child: QueueRow = list_item
-                    .downcast_ref::<ListItem>()
-                    .expect("Needs to be ListItem")
+                let child: QueueRow = item
                     .child()
                     .and_downcast::<QueueRow>()
                     .expect("The child has to be a `QueueRow`.");


### PR DESCRIPTION
## Use list store position for deletion & swaps

This avoids a full queue update after a deletion.

Using liststore positions also saves us the trouble of having to keep every queued song's queue positions internally up to date. This is the way to go (I didn't know we could extract the list model position from a given list item before).

## Use list store position for playlist editor operations

Playlist editor operations now also make use of ListItem positions & no longer need to spend O(n) updating positions of songs after deleted ones. In other words, all operations should now be O(log(n)).