### PR TITLE
Change MPRIS play behaviour & implement remote volume change UI update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "mpd"
 version = "0.1.0"
-source = "git+https://github.com/htkhiem/rust-mpd.git#037d9a213b4a8dc2ead74b3f44d53351ddff67a2"
+source = "git+https://github.com/htkhiem/rust-mpd.git?rev=3eedd021a0c46d22f1b31729e37a56a8f9bd99b0#3eedd021a0c46d22f1b31729e37a56a8f9bd99b0"
 dependencies = [
  "bufstream",
  "fxhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.30"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 image = "0.25.1"
 librsvg = "2.58.1"
-mpd = { git = "https://github.com/htkhiem/rust-mpd.git" }
+mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "3eedd021a0c46d22f1b31729e37a56a8f9bd99b0" }
 once_cell = "1.19.0"
 time = { version = "0.3.36", features = ["formatting"] }
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1103,6 +1103,15 @@ impl MpdWrapper {
         }
     }
 
+    pub fn get_volume(&self) -> Option<i8> {
+        if let Some(client) = self.main_client.borrow_mut().as_mut() {
+            client.getvol().ok()
+        }
+        else {
+            None
+        }
+    }
+
     pub fn add(&self, uri: String, recursive: bool) {
         if let Some(client) = self.main_client.borrow_mut().as_mut() {
             if recursive {

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -778,6 +778,11 @@ impl Player {
                                 this.update_outputs(outs);
                             }
                         }
+                        Subsystem::Mixer => {
+                            if let Some(vol) = this.client().get_volume() {
+                                this.emit_by_name::<()>("volume-changed", &[&vol]);
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -1696,7 +1701,7 @@ impl LocalPlayerInterface for Player {
     }
 
     async fn play(&self) -> fdo::Result<()> {
-        self.send_play();
+        self.toggle_playback();
         Ok(())
     }
 

--- a/src/player/knob.rs
+++ b/src/player/knob.rs
@@ -275,6 +275,7 @@ impl VolumeKnob {
         if old_rounded != new_rounded {
             let _ = self.imp().value.replace(new_rounded as f64);
             self.notify("value");
+            self.imp().draw_area.queue_draw();
             // Will not emit a signal (doing so would result in an infinite loop
             // between parent widget and this one).
         }


### PR DESCRIPTION
Fixes #138. Turns out I forgot to implement the prerequisites for remote volume updates.

Requires some changes on the `rust-mpd` fork, but now that it's a Git crate dependency it shouldn't be problematic any more.