### PR TITLE
v0.97.0: Switch to libsecret, better connection error handling, lazy init & more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,30 +816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
-dependencies = [
- "dbus",
- "futures-util",
- "num",
- "once_cell",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,11 +1017,11 @@ dependencies = [
  "idna",
  "image",
  "itertools 0.13.0",
- "keyring",
  "libadwaita",
  "libblur",
  "libc",
  "librsvg",
+ "libsecret",
  "lru",
  "mpd",
  "mpris-server",
@@ -2308,17 +2284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1961983669d57bdfe6c0f3ef8e4c229b5ef751afcc7d87e4271d2f71f6ccfa8b"
-dependencies = [
- "dbus-secret-service",
- "linux-keyutils",
- "log",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,15 +2359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "pkg-config",
-]
-
-[[package]]
 name = "libfuzzer-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2431,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsecret"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed48c3c2b757067b21f693e8de3dd6ad4ba37508c8cc2c2bc8d0c2f16b5896b9"
+dependencies = [
+ "gio 0.20.12",
+ "glib 0.20.12",
+ "libc",
+ "libsecret-sys",
+]
+
+[[package]]
+name = "libsecret-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b2ed075a9bb4deae8110ba9a2cf5a05fafa9ba588a3c2148eee56040ac5a302"
+dependencies = [
+ "gio-sys 0.20.10",
+ "glib-sys 0.20.10",
+ "gobject-sys 0.20.10",
+ "libc",
+ "pkg-config",
+ "system-deps 7.0.5",
+]
+
+[[package]]
 name = "libspa"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,16 +2492,6 @@ checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
 ]
 
 [[package]]
@@ -2860,20 +2832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,17 +2873,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.96.5"
+version = "0.97.0"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.96.4"
+version = "0.96.5"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.96.5"
+version = "0.97.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ musicbrainz_rs = { version = "0.5.0", features = ["blocking"], default-features 
 mpris-server = "0.8.1"
 async-lock = "3.4.0"
 libblur = "0.14.4"
-keyring = { version = "3", features = ["linux-native-sync-persistent"] }
 gio = { version = "0.21.0", features = ["v2_80"] }
 rustls = "0.23.18" # GHSA ID GHSA-qg5g-gv98-5ffh
 glib = { version = "0.21.0", features = ["v2_80"] }  # GHSA ID GHSA-wrw7-89jp-8q8g
@@ -52,6 +51,7 @@ open = "5.3.2"
 resolve-path = "0.1.0"
 lru = "0.16.0"
 nohash-hasher = "0.2.0"
+libsecret = "0.7.0"
 
 [dependencies.gtk]
 package = "gtk4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.96.4"
+version = "0.96.5"
 edition = "2024"
 
 [dev-dependencies]

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -78,7 +78,7 @@
   </screenshots>
 
   <releases>
-    <release version="0.97.0-beta" date="2025-09-06">
+    <release version="0.97.0-beta" date="2025-09-07">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.97.0-beta</url>
       <description>
         <p>New: Global background task counter and spinner.</p>

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -78,6 +78,17 @@
   </screenshots>
 
   <releases>
+    <release version="0.97.0-beta" date="2025-09-06">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.97.0-beta</url>
+      <description>
+        <p>New: Global background task counter and spinner.</p>
+        <p>Refactor: Lazy init for all views, should markedly improve startup smoothness.</p>
+        <p>Refactor: Switched to libsecret to manage MPD password. Will require reentering your password if you use one.</p>
+        <p>Refactor: Add more padding to Recent View row separators.</p>
+        <p>Fix: Many timeout-related crashes. Euphonica will now automatically attempt a reconnection instead.</p>
+        <p>Fix: Playlist editor apply button remaining disabled after one edit.</p>
+      </description>
+    </release>
     <release version="0.96.4-beta" date="2025-09-02">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.96.4-beta</url>
       <description>

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -53,21 +53,27 @@
   <screenshots>
     <screenshot type="default">
       <image>https://i.ibb.co/ZztBGwWp/Screenshot-From-2025-07-23-20-36-09.png</image>
+      <caption>Recent View</caption>
     </screenshot>
     <screenshot>
       <image>https://i.ibb.co/27g2D2Ph/Screenshot-From-2025-07-23-20-49-49.png</image>
+      <caption>Album View</caption>
     </screenshot>
     <screenshot>
       <image>https://i.ibb.co/DHtsRQB9/Screenshot-From-2025-07-23-20-46-02.png</image>
+      <caption>Album Content View</caption>
     </screenshot>
     <screenshot>
       <image>https://i.ibb.co/zTSZhPMp/Screenshot-From-2025-07-23-20-42-43.png</image>
+      <caption>Playlist Content View</caption>
     </screenshot>
     <screenshot>
       <image>https://i.ibb.co/fGxfq60N/Screenshot-From-2025-07-23-20-40-22.png</image>
+      <caption>Artist Content View</caption>
     </screenshot>
     <screenshot>
       <image>https://i.ibb.co/84bYWgJF/Screenshot-From-2025-06-21-20-15-05.png</image>
+      <caption>Queue View</caption>
     </screenshot>
   </screenshots>
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.96.4',
+          version: '0.96.5',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.96.5',
+          version: '0.97.0',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,7 @@
 mod stream;
 pub mod state;
 pub mod wrapper;
+pub mod password;
 
 pub use state::{ClientState, ConnectionState, ClientError};
 pub use wrapper::{BackgroundTask, MpdWrapper};

--- a/src/client/password.rs
+++ b/src/client/password.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use libsecret::*;
+
+use crate::config::APPLICATION_ID;
+
+pub fn get_mpd_password_schema() -> Schema {
+    let mut attributes = HashMap::new();
+    attributes.insert("type", SchemaAttributeType::String);
+
+    Schema::new(APPLICATION_ID, SchemaFlags::NONE, attributes)
+}
+
+pub async fn get_mpd_password() -> Result<Option<String>, String> {
+    let schema = get_mpd_password_schema();
+    let mut attributes = HashMap::new();
+    attributes.insert("type", "mpd");
+
+    libsecret::password_lookup_future(
+        Some(&schema),
+        attributes
+    )
+        .await
+        .map(|op| op.map(|gs| gs.as_str().to_owned()))
+        .map_err(|ge| format!("{:?}", ge))
+}
+
+pub async fn set_mpd_password(maybe_password: Option<&str>) -> Result<(), String> {
+    let schema = get_mpd_password_schema();
+    let mut attributes = HashMap::new();
+    attributes.insert("type", "mpd");
+
+    if let Some(password) = maybe_password {
+        libsecret::password_store_future(
+            Some(&schema),
+            attributes,
+            None,
+            "Euphonica MPD password",
+            password
+        )
+            .await
+            .map_err(|ge| format!("{:?}", ge))
+    } else {
+        libsecret::password_clear_future(
+            Some(&schema),
+            attributes
+        )
+            .await
+            .map_err(|ge| format!("{:?}", ge))
+    }
+}

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -16,8 +16,9 @@ pub enum ConnectionState {
     ConnectionRefused,
     SocketNotFound,
     Connecting,
-    Unauthenticated, // Either no password is provided or the one provided is insufficiently privileged
-    CredentialStoreError, // Cannot access underlying credential store to fetch or save password
+    Unauthenticated, // The provided password is incorrect or insufficiently privileged
+    PasswordNotAvailable, // No password was provided but we need one
+    CredentialStoreError, // Internal error
     WrongPassword,   // The provided password does not match any of the configured passwords
     Connected,
 }

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -125,6 +125,9 @@ mod imp {
                     Signal::builder("album-basic-info-downloaded")
                         .param_types([Album::static_type()])
                         .build(),
+                    Signal::builder("recent-album-downloaded")
+                        .param_types([Album::static_type()])
+                        .build(),
                     // A chunk of an album's songs have been retrieved. Emit this
                     // to make AlbumContentView append this chunk.
                     Signal::builder("album-songs-downloaded")
@@ -135,6 +138,9 @@ mod imp {
                         .build(),
                     // ArtistInfo downloaded. Should probably queue metadata retrieval.
                     Signal::builder("artist-basic-info-downloaded")
+                        .param_types([Artist::static_type()])
+                        .build(),
+                    Signal::builder("recent-artist-downloaded")
                         .param_types([Artist::static_type()])
                         .build(),
                     // A chunk of an artist's songs have been retrieved. Emit this

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -40,7 +40,7 @@ pub enum ClientError {
 }
 
 mod imp {
-    use glib::{ParamSpec, ParamSpecBoolean, ParamSpecEnum};
+    use glib::{ParamSpec, ParamSpecBoolean, ParamSpecEnum, ParamSpecUInt64};
 
     use super::*;
     use once_cell::sync::Lazy;
@@ -49,7 +49,7 @@ mod imp {
     pub struct ClientState {
         pub connection_state: Cell<ConnectionState>,
         // Used to indicate that the background client is busy.
-        pub busy: Cell<bool>,
+        pub n_tasks: Cell<u64>,
         pub supports_playlists: Cell<bool>,
         pub stickers_support_level: Cell<StickersSupportLevel>,
     }
@@ -62,7 +62,7 @@ mod imp {
         fn new() -> Self {
             Self {
                 connection_state: Cell::default(),
-                busy: Cell::new(false),
+                n_tasks: Cell::new(0),
                 stickers_support_level: Cell::default(),
                 supports_playlists: Cell::new(true),
             }
@@ -73,7 +73,7 @@ mod imp {
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
                 vec![
-                    ParamSpecBoolean::builder("busy").read_only().build(),
+                    ParamSpecUInt64::builder("n-background-tasks").read_only().build(),
                     ParamSpecEnum::builder::<StickersSupportLevel>("stickers-support-level")
                         .read_only()
                         .build(),
@@ -92,7 +92,7 @@ mod imp {
             let obj = self.obj();
             match pspec.name() {
                 "connection-state" => obj.get_connection_state().to_value(),
-                "busy" => obj.is_busy().to_value(),
+                "n-background-tasks" => self.n_tasks.get().to_value(),
                 "stickers-support-level" => obj.get_stickers_support_level().to_value(),
                 "supports-playlists" => obj.supports_playlists().to_value(),
                 _ => unimplemented!(),
@@ -198,21 +198,10 @@ impl ClientState {
         self.imp().connection_state.get()
     }
 
-    pub fn is_busy(&self) -> bool {
-        self.imp().busy.get()
-    }
-
     pub fn set_connection_state(&self, new_state: ConnectionState) {
         let old_state = self.imp().connection_state.replace(new_state);
         if old_state != new_state {
             self.notify("connection-state");
-        }
-    }
-
-    pub fn set_busy(&self, new_busy: bool) {
-        let old_busy = self.imp().busy.replace(new_busy);
-        if old_busy != new_busy {
-            self.notify("busy");
         }
     }
 
@@ -249,6 +238,17 @@ impl ClientState {
         let old = self.imp().supports_playlists.replace(state);
         if old != state {
             self.notify("supports-playlists");
+        }
+    }
+
+    pub fn get_n_background_tasks(&self) -> u64 {
+        self.imp().n_tasks.get()
+    }
+
+    pub fn set_n_background_tasks(&self, n: u64) {
+        let old = self.imp().n_tasks.replace(n);
+        if old != n {
+            self.notify("n-background-tasks");
         }
     }
 }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1195,6 +1195,8 @@ impl MpdWrapper {
     pub async fn connect_async(&self) {
         // Close current clients
         self.disconnect_async().await;
+        self.queue_version.set(0);
+        self.expected_queue_version.set(0);
 
         let conn = utils::settings_manager().child("client");
 

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1041,11 +1041,13 @@ impl MpdWrapper {
                                 }
                             }
                             None => {
+                                // We'll also reach here if denied keyring access.
                                 client_password = None;
                             }
                         }
                     }
                     Err(e) => {
+                        // Only reachable by glib async runner errors
                         client_password = None;
                         println!("{:?}", &e);
                         password_access_failed = true;
@@ -1057,6 +1059,8 @@ impl MpdWrapper {
                         self.state.set_connection_state(
                             if password_access_failed {
                                 ConnectionState::CredentialStoreError
+                            } else if client_password.is_none() {
+                                ConnectionState::PasswordNotAvailable
                             } else {
                                 ConnectionState::Unauthenticated
                             }

--- a/src/gtk/library/recent-view.ui
+++ b/src/gtk/library/recent-view.ui
@@ -146,6 +146,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkSeparator">
+                                    <property name="margin-top">6px</property>
                                     <property name="margin-bottom">6px</property>
                                   </object>
                                 </child>
@@ -238,6 +239,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkSeparator">
+                                    <property name="margin-top">6px</property>
                                     <property name="margin-bottom">6px</property>
                                   </object>
                                 </child>

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -337,7 +337,8 @@
                     <property name="propagate-natural-height">false</property>
                     <property name="has-frame">false</property>
                     <property name="hexpand">true</property>
-                    <property name="height-request">96</property>
+                    <property name="height-request">32</property>
+                    <property name="vexpand">true</property>
                     <property name="child">
                       <object class="GtkListBox" id="lyrics_box">
                         <property name="selection-mode">0</property>

--- a/src/gtk/preferences/client.ui
+++ b/src/gtk/preferences/client.ui
@@ -40,6 +40,7 @@
         <child>
           <object class="AdwSwitchRow" id="mpd_download_album_art">
             <property name="title" translatable="true">Download album arts</property>
+            <property name="subtitle" translatable="true">Fetch album art files (named "cover.png/jpg/webp") and embedded covers in song files.</property>
           </object>
         </child>
         <child>

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -222,6 +222,9 @@ impl Library {
         self.imp().folder_inodes.remove_all();
         let _ = self.imp().folder_history.replace(Vec::new());
         let _ = self.imp().folder_curr_idx.replace(0);
+        self.notify("folder-path");
+        self.notify("folder-his-len");
+        self.notify("folder-curr-idx");
     }
 
     fn client(&self) -> &Rc<MpdWrapper> {

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -126,37 +126,6 @@ impl Library {
         let _ = self.imp().client.set(client);
         let _ = self.imp().player.set(player);
 
-        // Refresh upon reconnection.
-        // User-initiated refreshes will also trigger a reconnection, which will
-        // in turn trigger this.
-        client_state.connect_notify_local(
-            Some("connection-state"),
-            clone!(
-                #[weak(rename_to = this)]
-                self,
-                move |state, _| {
-                    match state.get_connection_state() {
-                        ConnectionState::Connected => {
-                            this.get_recent_songs();
-                            this.init_albums();
-                            this.init_artists(false);
-                            this.get_folder_contents("");
-                        }
-                        ConnectionState::Connecting => {
-                            this.imp().recent_songs.remove_all();
-                            this.imp().albums.remove_all();
-                            this.imp().artists.remove_all();
-                            this.imp().playlists.remove_all();
-                            this.imp().folder_inodes.remove_all();
-                            let _ = this.imp().folder_history.replace(Vec::new());
-                            let _ = this.imp().folder_curr_idx.replace(0);
-                        }
-                        _ => {}
-                    }
-                }
-            ),
-        );
-
         client_state.connect_closure(
             "album-basic-info-downloaded",
             false,
@@ -213,6 +182,16 @@ impl Library {
                 }
             ),
         );
+    }
+
+    pub fn clear(&self) {
+        self.imp().recent_songs.remove_all();
+        self.imp().albums.remove_all();
+        self.imp().artists.remove_all();
+        self.imp().playlists.remove_all();
+        self.imp().folder_inodes.remove_all();
+        let _ = self.imp().folder_history.replace(Vec::new());
+        let _ = self.imp().folder_curr_idx.replace(0);
     }
 
     fn client(&self) -> &Rc<MpdWrapper> {

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -1,11 +1,11 @@
 use crate::{
     cache::{sqlite, Cache},
-    client::{BackgroundTask, ClientState, ConnectionState, MpdWrapper},
+    client::{BackgroundTask, ClientState, MpdWrapper},
     common::{Album, Artist, INode, Song, Stickers}, 
     utils::settings_manager,
     player::Player,
 };
-use glib::{clone, closure_local, subclass::Signal};
+use glib::{closure_local, subclass::Signal};
 use gtk::{gio, glib, prelude::*};
 use std::{borrow::Cow, cell::OnceCell, rc::Rc, sync::OnceLock, vec::Vec};
 
@@ -36,7 +36,9 @@ mod imp {
         // append to the list store.
         pub playlists: gio::ListStore,
         pub albums: gio::ListStore,
+        pub recent_albums: gio::ListStore,
         pub artists: gio::ListStore,
+        pub recent_artists: gio::ListStore,
 
         // Folder view
         // Files and folders
@@ -58,7 +60,9 @@ mod imp {
                 recent_songs: gio::ListStore::new::<Song>(),
                 playlists: gio::ListStore::new::<INode>(),
                 albums: gio::ListStore::new::<Album>(),
+                recent_albums: gio::ListStore::new::<Album>(),
                 artists: gio::ListStore::new::<Artist>(),
+                recent_artists: gio::ListStore::new::<Artist>(),
                 client: OnceCell::new(),
                 cache: OnceCell::new(),
                 player: OnceCell::new(),
@@ -139,6 +143,18 @@ impl Library {
         );
 
         client_state.connect_closure(
+            "recent-album-downloaded",
+            false,
+            closure_local!(
+                #[strong(rename_to = this)]
+                self,
+                move |_: ClientState, album: Album| {
+                    this.imp().recent_albums.append(&album);
+                }
+            ),
+        );
+
+        client_state.connect_closure(
             "artist-basic-info-downloaded",
             false,
             closure_local!(
@@ -146,6 +162,18 @@ impl Library {
                 self,
                 move |_: ClientState, artist: Artist| {
                     this.imp().artists.append(&artist);
+                }
+            ),
+        );
+
+        client_state.connect_closure(
+            "recent-artist-downloaded",
+            false,
+            closure_local!(
+                #[strong(rename_to = this)]
+                self,
+                move |_: ClientState, artist: Artist| {
+                    this.imp().recent_artists.append(&artist);
                 }
             ),
         );
@@ -187,7 +215,9 @@ impl Library {
     pub fn clear(&self) {
         self.imp().recent_songs.remove_all();
         self.imp().albums.remove_all();
+        self.imp().recent_albums.remove_all();
         self.imp().artists.remove_all();
+        self.imp().recent_artists.remove_all();
         self.imp().playlists.remove_all();
         self.imp().folder_inodes.remove_all();
         let _ = self.imp().folder_history.replace(Vec::new());
@@ -405,9 +435,19 @@ impl Library {
         self.imp().albums.clone()
     }
 
+    /// Get a reference to the local recent albums store
+    pub fn recent_albums(&self) -> gio::ListStore {
+        self.imp().recent_albums.clone()
+    }
+
     /// Get a reference to the local artists store
     pub fn artists(&self) -> gio::ListStore {
         self.imp().artists.clone()
+    }
+
+    /// Get a reference to the local recent artists store
+    pub fn recent_artists(&self) -> gio::ListStore {
+        self.imp().recent_artists.clone()
     }
 
     /// Retrieve songs in a playlist
@@ -463,10 +503,26 @@ impl Library {
     pub fn init_albums(&self) {
         self.client().queue_background(BackgroundTask::FetchAlbums, false);
     }
+
+    pub fn fetch_recent_albums(&self) {
+        println!("fetch_recent_albums() called");
+        // High-priority as this is lightweight (only a few will be fetched)
+        // and is triggered by the user navigating to the Recent view
+        self.imp().recent_albums.remove_all();
+        self.client().queue_background(BackgroundTask::FetchRecentAlbums, true);
+    }
  
     pub fn init_artists(&self, use_albumartists: bool) {
         self.client()
             .queue_background(BackgroundTask::FetchArtists(use_albumartists), false);
+    }
+
+    pub fn fetch_recent_artists(&self) {
+        println!("fetch_recent_artists() called");
+        // High-priority as this is lightweight (only a few will be fetched)
+        // and is triggered by the user navigating to the Recent view
+        self.imp().recent_artists.remove_all();
+        self.client().queue_background(BackgroundTask::FetchRecentArtists, true);
     }
 
     pub fn set_cover(&self, folder_uri: &str, path: &str) {

--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -332,11 +332,12 @@ mod imp {
     impl WidgetImpl for PlaylistContentView {}
 
     impl PlaylistContentView {
-        fn update_undo_redo_sensitivity(&self) {
+        fn update_btn_sensitivity(&self) {
             let curr_idx = self.history_idx.get();
             self.edit_undo.set_sensitive(curr_idx > 0);
             self.edit_redo
                 .set_sensitive(curr_idx < self.history.borrow().len());
+            self.edit_apply.set_sensitive(curr_idx > 0);
         }
 
         pub fn enter_edit_mode(&self) {
@@ -361,6 +362,7 @@ mod imp {
             // Everything is now in place; start fading
             self.action_row.set_visible_child_name("edit-mode");
             self.content_stack.set_visible_child_name("edit-mode");
+            self.edit_apply.set_sensitive(false);
         }
 
         pub fn exit_edit_mode(&self, apply: bool) {
@@ -390,7 +392,6 @@ mod imp {
                 self.history.borrow_mut().clear();
                 self.edit_undo.set_sensitive(false);
                 self.edit_redo.set_sensitive(false);
-                self.edit_apply.set_sensitive(false);
             }
             // Just fade back, no need to clear the list (won't lag us
             // since we're not rendering it)
@@ -408,7 +409,7 @@ mod imp {
                 let step = &history[curr_idx - 1];
                 step.backward(&self.editing_song_list);
                 self.history_idx.replace(curr_idx - 1);
-                self.update_undo_redo_sensitivity();
+                self.update_btn_sensitivity();
             }
         }
 
@@ -424,7 +425,7 @@ mod imp {
                 let step = &history[curr_idx];
                 step.forward(&self.editing_song_list);
                 self.history_idx.replace(curr_idx + 1);
-                self.update_undo_redo_sensitivity();
+                self.update_btn_sensitivity();
             }
         }
 
@@ -440,7 +441,7 @@ mod imp {
                 history.push(step);
                 self.history_idx.replace(history.len());
             }
-            self.update_undo_redo_sensitivity();
+            self.update_btn_sensitivity();
         }
     }
 }

--- a/src/library/recent_view.rs
+++ b/src/library/recent_view.rs
@@ -1,23 +1,26 @@
+use std::rc::Rc;
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
-use futures::TryFutureExt;
 use gtk::{
     glib::{self},
-    CompositeTemplate, ListItem, Ordering, SignalListItemFactory, SingleSelection,
+    CompositeTemplate, ListItem, SignalListItemFactory, SingleSelection,
 };
-use rustc_hash::FxHashMap;
-use std::{cell::Cell, rc::Rc};
 
 use glib::{clone, closure_local, Properties};
 
 use super::{AlbumCell, ArtistCell, Library};
 use crate::{
     utils::LazyInit,
-    cache::{sqlite, Cache}, common::{marquee::MarqueeWrapMode, Album, Artist, Song}, library::recent_song_row::RecentSongRow, player::Player, utils::settings_manager, window::EuphonicaWindow
+    cache::Cache,
+    common::{marquee::MarqueeWrapMode, Album, Artist, Song},
+    library::recent_song_row::RecentSongRow,
+    player::Player,
+    window::EuphonicaWindow
 };
 
 mod imp {
-    use std::{cell::OnceCell, sync::OnceLock};
+    use std::{cell::{Cell, OnceCell}, sync::OnceLock};
 
     use glib::subclass::Signal;
 
@@ -68,13 +71,6 @@ mod imp {
 
         #[property(get, set)]
         pub collapsed: Cell<bool>,
-
-        // Search & filter models
-        pub album_filter: gtk::CustomFilter,
-        pub album_sorter: gtk::CustomSorter,
-
-        pub artist_filter: gtk::CustomFilter,
-        pub artist_sorter: gtk::CustomSorter,
 
         pub initialized: Cell<bool>  // Only start fetching content when navigated to for the first time
     }
@@ -242,150 +238,34 @@ impl RecentView {
     }
 
     pub fn on_history_changed(&self) {
-        self.imp().album_row_stack.set_visible_child_name("loading");
-        self.imp().artist_row_stack.set_visible_child_name("loading");
-        // Runs on another thread to avoid stuttering on startup
-        glib::spawn_future_local(clone!(
-            #[weak(rename_to = this)]
-            self,
-            async move {
-                // Albums
-                let _ = gio::spawn_blocking(|| {
-                    let settings = settings_manager().child("library");
-                    return sqlite::get_last_n_albums(settings.uint("n-recent-albums")).expect("Sqlite DB error");
-                }).map_ok(clone!(
-                    #[weak]
-                    this,
-                    move |recent_albums| {
-                        this.imp().album_row_stack.set_visible_child_name("content");
-                        if recent_albums.len() > 0 {
-                            let mut albums_map: FxHashMap<String, usize> = FxHashMap::default();
-                            for tup in recent_albums.iter().enumerate() {
-                                albums_map.insert(tup.1.clone(), tup.0);
-                            }
-                            let albums_map_cloned = albums_map.clone();
-                            this.imp().album_filter.set_filter_func(move |obj| {
-                                let album = obj
-                                    .downcast_ref::<Album>()
-                                    .expect("Search obj has to be a common::Album.");
-
-                                albums_map_cloned.contains_key(album.get_title())
-                            });
-                            this.imp()
-                                .album_filter
-                                .changed(gtk::FilterChange::Different);
-
-                            this.imp().album_sorter.set_sort_func(
-                                move |obj1: &glib::Object, obj2: &glib::Object| -> Ordering {
-                                    let album1 = obj1
-                                        .downcast_ref::<Album>()
-                                        .expect("Sort obj has to be a common::Album.");
-
-                                    let album2 = obj2
-                                        .downcast_ref::<Album>()
-                                        .expect("Sort obj has to be a common::Album.");
-
-                                    if let (Some(order1), Some(order2)) = (
-                                        albums_map.get(album1.get_title()),
-                                        albums_map.get(album2.get_title()),
-                                    ) {
-                                        Ordering::from(order1.cmp(order2))
-                                    } else {
-                                        Ordering::Equal
-                                    }
-                                },
-                            );
-                            this.imp()
-                                .album_sorter
-                                .changed(gtk::SorterChange::Different);
-                        } else {
-                            // Don't show anything.
-                            this.imp().album_filter.set_filter_func(|_| false);
-                            this.imp()
-                                .album_filter
-                                .changed(gtk::FilterChange::Different);
-                        }
-                    }
-                )).await;
-
-                // Artists
-                let _ = gio::spawn_blocking(|| {
-                    let settings = settings_manager().child("library");
-                    return sqlite::get_last_n_artists(settings.uint("n-recent-artists")).expect("Sqlite DB error");
-                }).map_ok(clone!(
-                    #[weak]
-                    this,
-                    move |recent_artists| {
-                        this.imp().artist_row_stack.set_visible_child_name("content");
-                        if recent_artists.len() > 0 {
-                            let mut artists_map: FxHashMap<String, usize> = FxHashMap::default();
-                            for tup in recent_artists.iter().enumerate() {
-                                artists_map.insert(tup.1.clone(), tup.0);
-                            }
-                            let artists_map_cloned = artists_map.clone();
-                            this.imp().artist_filter.set_filter_func(move |obj| {
-                                let artist = obj
-                                    .downcast_ref::<Artist>()
-                                    .expect("Search obj has to be a common::Artist.");
-
-                                artists_map_cloned.contains_key(artist.get_name())
-                            });
-                            this.imp()
-                                .artist_filter
-                                .changed(gtk::FilterChange::Different);
-
-                            this.imp().artist_sorter.set_sort_func(
-                                move |obj1: &glib::Object, obj2: &glib::Object| -> Ordering {
-                                    let artist1 = obj1
-                                        .downcast_ref::<Artist>()
-                                        .expect("Sort obj has to be a common::Artist.");
-
-                                    let artist2 = obj2
-                                        .downcast_ref::<Artist>()
-                                        .expect("Sort obj has to be a common::Artist.");
-
-                                    if let (Some(order1), Some(order2)) = (
-                                        artists_map.get(artist1.get_name()),
-                                        artists_map.get(artist2.get_name()),
-                                    ) {
-                                        Ordering::from(order1.cmp(order2))
-                                    } else {
-                                        Ordering::Equal
-                                    }
-                                },
-                            );
-                            this.imp()
-                                .artist_sorter
-                                .changed(gtk::SorterChange::Different);
-                        } else {
-                            // Don't show anything.
-                            this.imp().artist_filter.set_filter_func(|_| false);
-                            this.imp()
-                                .artist_filter
-                                .changed(gtk::FilterChange::Different);
-                        }
-                    }
-                )).await;
-            }
-        ));
-        // Songs are fetched by either the library (upon startup) or player (upon song change)
+        if self.imp().initialized.get() {
+            let library = self.imp().library.get().unwrap();
+            library.fetch_recent_albums();
+            library.fetch_recent_artists();
+            // Songs are fetched by either the library (upon startup) or player (upon song change)
+        }
     }
 
     fn setup_album_row(&self, window: &EuphonicaWindow, cache: Rc<Cache>) {
-        let album_list = self.imp().library.get().unwrap().albums();
+        let album_list = self.imp().library.get().unwrap().recent_albums();
 
-        // Chain search & sort. Put sort after search to reduce number of sort items.
-        let search_model = gtk::FilterListModel::new(
-            Some(album_list.clone()),
-            Some(self.imp().album_filter.clone()),
-        );
-        search_model.set_incremental(true);
+        album_list
+            .bind_property(
+                "n-items",
+                &self.imp().album_row_stack.get(),
+                "visible-child-name"
+            )
+            .transform_to(|_, n: u32| {
+                if n > 0 {
+                    Some("content".to_value())
+                } else {
+                    Some("loading".to_value())
+                }
+            })
+            .sync_create()
+            .build();
 
-        let sort_model =
-            gtk::SortListModel::new(Some(search_model), Some(self.imp().album_sorter.clone()));
-        sort_model.set_incremental(true);
-        let sel_model = SingleSelection::new(Some(sort_model));
-
+        let sel_model = SingleSelection::new(Some(album_list));
         self.imp().album_row.set_model(Some(&sel_model));
 
         // Set up factory
@@ -470,20 +350,25 @@ impl RecentView {
     }
 
     fn setup_artist_row(&self, window: &EuphonicaWindow, cache: Rc<Cache>) {
-        let artist_list = self.imp().library.get().unwrap().artists();
+        let artist_list = self.imp().library.get().unwrap().recent_artists();
 
-        // Chain search & sort. Put sort after search to reduce number of sort items.
-        let search_model = gtk::FilterListModel::new(
-            Some(artist_list.clone()),
-            Some(self.imp().artist_filter.clone()),
-        );
-        search_model.set_incremental(true);
+        artist_list
+            .bind_property(
+                "n-items",
+                &self.imp().artist_row_stack.get(),
+                "visible-child-name"
+            )
+            .transform_to(|_, n: u32| {
+                if n > 0 {
+                    Some("content".to_value())
+                } else {
+                    Some("loading".to_value())
+                }
+            })
+            .sync_create()
+            .build();
 
-        let sort_model =
-            gtk::SortListModel::new(Some(search_model), Some(self.imp().artist_sorter.clone()));
-        sort_model.set_incremental(true);
-        let sel_model = SingleSelection::new(Some(sort_model));
-
+        let sel_model = SingleSelection::new(Some(artist_list));
         self.imp().artist_row.set_model(Some(&sel_model));
 
         // Set up factory

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -189,6 +189,7 @@ mod imp {
         pub song_cache: RefCell<LruCache::<u32, Song, BuildHasherDefault<NoHashHasher<u32>>>>,
         pub lyric_lines: gtk::StringList,  // Line by line for display. May be empty.
         pub lyrics: RefCell<Option<Lyrics>>,
+        pub queue_len: Cell<u32>,
         pub current_song: RefCell<Option<Song>>,
         pub current_lyric_line: Cell<u32>,
         pub format: RefCell<Option<AudioFormat>>,
@@ -255,6 +256,7 @@ mod imp {
                 mixramp_delay: Cell::new(0.0),
                 queue: gio::ListStore::new::<Song>(),
                 song_cache: RefCell::new(LruCache::with_hasher(NonZero::new(1024).unwrap(), BuildHasherDefault::default())),
+                queue_len: Cell::new(0),
                 current_song: RefCell::new(None),
                 current_lyric_line: Cell::default(),
                 format: RefCell::new(None),
@@ -367,6 +369,7 @@ mod imp {
                     ParamSpecString::builder("album").read_only().build(),
                     ParamSpecUInt64::builder("duration").read_only().build(),
                     ParamSpecUInt::builder("queue-id").read_only().build(),
+                    ParamSpecUInt::builder("queue-len").read_only().build(),  // Always available, even when queue hasn't been fetched yet
                     ParamSpecEnum::builder::<QualityGrade>("quality-grade")
                         .read_only()
                         .build(),
@@ -404,6 +407,7 @@ mod imp {
                 "artist" => obj.artist().to_value(),
                 "album" => obj.album().to_value(),
                 "duration" => obj.duration().to_value(),
+                "queue-len" => self.queue_len.get().to_value(),
                 "queue-id" => obj.queue_id().unwrap_or(u32::MAX).to_value(),
                 "quality-grade" => obj.quality_grade().to_value(),
                 "bitrate" => self.bitrate.get().to_value(),
@@ -1174,11 +1178,17 @@ impl Player {
             }
         }
 
+        // We need to separately keep track of queue length here as the queue list model might
+        // not have been initialised yet.
+        let new_len = status.queue_len;
+        let old_len = self.imp().queue_len.replace(new_len);
+        if old_len != new_len {
+            self.notify("queue-len");
+        }
         // If new queue is shorter, truncate current queue.
         // This is because update_queue would be called before update_status, which means
         // the new length was not available to update_queue.
         let old_len = self.imp().queue.n_items();
-        let new_len = status.queue_len;
         if old_len > new_len {
             self.imp()
                 .queue

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -303,7 +303,7 @@ impl ClientPreferences {
                 set_status_icon(&self.imp().mpd_status_icon.get(), StatusIconState::Loading);
                 self.imp().reconnect.set_sensitive(false);
             }
-            ConnectionState::Unauthenticated => {
+            ConnectionState::Unauthenticated | ConnectionState::PasswordNotAvailable => {
                 self.imp().mpd_status.set_subtitle("Authentication failed");
                 self.imp().mpd_status.set_enable_expansion(false);
                 set_status_icon(&self.imp().mpd_status_icon.get(), StatusIconState::Disabled);
@@ -399,7 +399,6 @@ impl ClientPreferences {
         imp.mpd_port
             .set_text(&conn_settings.uint("mpd-port").to_string());
         let password_field = imp.mpd_password.get();
-        reconnect_btn.set_sensitive(false);
         glib::spawn_future_local(async move {
             match get_mpd_password().await {
                 Ok(maybe_password) => {

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -1,6 +1,5 @@
 use duplicate::duplicate;
 use ::glib::closure_local;
-use keyring::{Entry, Error as KeyringError};
 use std::{rc::Rc, str::FromStr};
 
 use adw::prelude::*;
@@ -12,7 +11,7 @@ use glib::clone;
 use mpd::status::AudioFormat;
 
 use crate::{
-    client::{state::StickersSupportLevel, ClientState, ConnectionState, MpdWrapper},
+    client::{password::{get_mpd_password, set_mpd_password}, state::StickersSupportLevel, ClientState, ConnectionState, MpdWrapper},
     player::{FftStatus, Player},
     utils,
 };
@@ -399,19 +398,25 @@ impl ClientPreferences {
         imp.mpd_unix_socket.set_text(&conn_settings.string("mpd-unix-socket"));
         imp.mpd_port
             .set_text(&conn_settings.uint("mpd-port").to_string());
-        let maybe_keyring_entry = Entry::new("euphonica", "mpd-password");
-        if let Ok(ref keyring_entry) = maybe_keyring_entry {
-            // At startup the password entry is disabled with a tooltip stating that
-            // the credential store is not available.
-            imp.mpd_password.set_sensitive(true);
-            imp.mpd_password.set_tooltip_text(None);
-            match keyring_entry.get_password() {
-                Ok(password) => {
-                    imp.mpd_password.set_text(&password);
+        let password_field = imp.mpd_password.get();
+        reconnect_btn.set_sensitive(false);
+        glib::spawn_future_local(async move {
+            match get_mpd_password().await {
+                Ok(maybe_password) => {
+                    // At startup the password entry is disabled with a tooltip stating that
+                    // the credential store is not available.
+                    password_field.set_sensitive(true);
+                    password_field.set_tooltip_text(None);
+                    if let Some(password) = maybe_password {
+                        password_field.set_text(&password);
+                    }
                 }
-                _ => {}
+                Err(e) => {
+                    println!("{:?}", e);
+                }
             }
-        }
+        });
+
 
         // TODO: more input validation
         // Prevent entering anything other than digits into the port entry row
@@ -494,21 +499,20 @@ impl ClientPreferences {
                     );
                 }
 
-                if let Ok(ref keyring_entry) = maybe_keyring_entry {
-                    let password = this.imp().mpd_password.text();
-                    if password.is_empty() {
-                        let res = keyring_entry.delete_credential();
-                        match res {
-                            Ok(()) | Err(KeyringError::NoEntry) => {}
-                            e => {println!("{:?}", e)}
+                let password_val = this.imp().mpd_password.text();
+                glib::spawn_future_local(clone!(
+                    #[weak]
+                    client,
+                    async move {
+                        let password: Option<&str> = if password_val.is_empty() { None } else { Some(password_val.as_str()) };
+                        match set_mpd_password(password).await {
+                            Ok(()) => {
+                                client.connect_async().await;
+                            }
+                            Err(msg) => {println!("{}", msg);}
                         }
-                    } else {
-                        keyring_entry
-                            .set_password(password.as_str())
-                            .expect("Unable to save MPD password to keyring");
                     }
-                }
-                let _ = client.queue_connect();
+                ));
             }
         ));
         let mpd_download_album_art = imp.mpd_download_album_art.get();

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -33,7 +33,7 @@ mod imp {
         #[template_child]
         pub queue_len: TemplateChild<gtk::Label>,
         #[property(get, set)]
-        pub showing_queue_view: Cell<bool>,
+        pub showing_queue_view: Cell<bool>
     }
 
     #[glib::object_subclass]

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -292,8 +292,7 @@ impl Sidebar {
         }
 
         player
-            .queue()
-            .bind_property("n-items", &self.imp().queue_len.get(), "label")
+            .bind_property("queue-len", &self.imp().queue_len.get(), "label")
             .transform_to(|_, size: u32| Some(size.to_string()))
             .sync_create()
             .build();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,3 +262,8 @@ pub fn rebuild_artist_delim_exception_automaton() {
         *automaton = new;
     }
 }
+
+pub trait LazyInit {
+    fn clear(&self);
+    fn populate(&self);
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -144,7 +144,7 @@ mod imp {
         // Sidebar
         // TODO: Replace with Libadwaita spinner when v1.6 hits stable
         #[template_child]
-        pub busy_spinner: TemplateChild<gtk::Spinner>,
+        pub busy_spinner: TemplateChild<adw::Spinner>,
         #[template_child]
         pub title: TemplateChild<adw::WindowTitle>,
         #[template_child]
@@ -1186,7 +1186,14 @@ impl EuphonicaWindow {
             .build();
 
         state
-            .bind_property("busy", &spinner, "visible")
+            .bind_property("n-background-tasks", &spinner, "visible")
+            .transform_to(|_, val: u64| Some((val > 0).to_value()))
+            .sync_create()
+            .build();
+
+        state
+            .bind_property("n-background-tasks", &spinner, "tooltip-text")
+            .transform_to(|_, val: u64| Some(format!("Background task(s): {val}").to_value()))
             .sync_create()
             .build();
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1032,7 +1032,14 @@ impl EuphonicaWindow {
             ConnectionState::Unauthenticated => {
                 self.show_error_dialog(
                     "Authentication Failed",
-                    "Your MPD instance requires a password, which was either not provided or lacks the necessary privileges for Euphonica to function correctly.",
+                    "The current password lacks the necessary privileges for Euphonica to function.",
+                    true
+                );
+            }
+            ConnectionState::PasswordNotAvailable => {
+                self.show_error_dialog(
+                    "No password available",
+                    "Your MPD instance requires a password, but Euphonica could not find one from the default keyring. If the keyring is still locked, please unlock it first.",
                     true
                 );
             }
@@ -1170,6 +1177,7 @@ impl EuphonicaWindow {
                 ConnectionState::Connecting => Some("Connecting"),
                 ConnectionState::Unauthenticated
                 | ConnectionState::WrongPassword
+                | ConnectionState::PasswordNotAvailable
                 | ConnectionState::CredentialStoreError => Some("Unauthenticated"),
                 ConnectionState::Connected => Some("Connected"),
                 _ => Some("Not connected")

--- a/src/window.ui
+++ b/src/window.ui
@@ -48,7 +48,8 @@
                         <child type="top">
                           <object class="AdwHeaderBar">
                             <child type="start">
-                              <object class="GtkSpinner" id="busy_spinner">
+                              <object class="AdwSpinner" id="busy_spinner">
+                                <property name="margin-start">12</property>
                                 <property name="visible">false</property>
                               </object>
                             </child>


### PR DESCRIPTION
# Libsecret

**NOTE:**  This update will change how Euphonica store passwords, necessitating entering your password again. The old password entry is still there in your default keyring and can be safely deleted afterwards.

Previously Euphonica was using `keyring` to communicate with the host system's secrets store backend (on Linux that'll be `secret_service`). Over time it's become pretty much Linux-only and so there's no point using this heavyweight crate anymore. Switching to `libsecret` also gives us native Flatpak compatibility without having to specify a DBus talk-name fixed permission.

# Global busy spinner

Add a spinner to the top left of the window to indicate presence of running background tasks. Hovering over it will show the number of remaining tasks. This isn't a progress bar as background tasks get added all the time.

This should help clarify what Euphonica is doing behind the scenes especially for slower MPD server hardware, slow connections, large libraries or mass album art downloads on cold starts. Related to #145.

<img width="372" height="240" alt="image" src="https://github.com/user-attachments/assets/17dd1124-0c33-4502-b203-bf31a24ba3e4" />

# Lazy init

Views are now initialised only upon the first time they're navigated to. This spreads the startup init workload over a longer period of time, reducing stutter and reducing costs of repeated reconnections. Testing shows this to provide a pretty nice improvement in overall smoothness on startup.

# Better connection error handling

The MPD-facing code has been significantly revamped to handle errors more gracefully. Connection errors will now trigger reconnection attempts. Most of the `panic!()` and `expect()` have been replaced with proper error handling now, so Euphonica should crash frequently.

Should fix #146.

# Other changes

- Lyrics box now expands to the remaining available space after the album art has grown to its maximum size in the player pane. It'll also shrink down to 32px to fit in the minimum window height. This fixes the player bar overflowing when lyrics are enabled.
- Fixed playlist editor's Apply button remaining disabled after one save.