### PR TITLE
Fix metadata fetching issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.97.0"
+version = "0.97.1"
 dependencies = [
  "aho-corasick",
  "ashpd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,9 +1178,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2108,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3123,9 +3123,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -4660,9 +4660,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.97.0"
+version = "0.97.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -78,6 +78,16 @@
   </screenshots>
 
   <releases>
+    <release version="0.97.1-beta" date="2025-09-14">
+      <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.97.1-beta</url>
+      <description>
+        <p>New: Option to re-fetch metadata. Will also re-attempt artist avatar fetching.</p>
+        <p>Refactor: Basic album/artist info is now shown early instead of being hidden until external wiki loads.</p>
+        <p>Fix: Repeated inits causing duplicate albums and artists after exiting background mode.</p>
+        <p>Fix: Album wiki text and artist avatars not loading.</p>
+        <p>Fix: Consume mode resetting on new window opens.</p>
+      </description>
+    </release>
     <release version="0.97.0-beta" date="2025-09-07">
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.97.0-beta</url>
       <description>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.97.0',
+          version: '0.97.1',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -376,7 +376,7 @@ pub fn find_artist_meta(artist: &ArtistInfo) -> Result<Option<ArtistMeta>, Error
     }
 }
 
-pub async fn write_album_meta(album: &AlbumInfo, meta: &AlbumMeta) -> Result<(), Error> {
+pub fn write_album_meta(album: &AlbumInfo, meta: &AlbumMeta) -> Result<(), Error> {
     let mut conn = SQLITE_POOL.get().unwrap();
     let tx = conn.transaction().map_err(|e| Error::DbError(e))?;
     if let Some(mbid) = album.mbid.as_deref() {

--- a/src/gtk/library/album-content-view.ui
+++ b/src/gtk/library/album-content-view.ui
@@ -67,137 +67,140 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkStack" id="infobox_spinner">
+                          <object class="GtkBox" id="infobox_text">
+                            <property name="orientation">1</property>
+                            <property name="spacing">6</property>
+                            <property name="hexpand">true</property>
                             <child>
-                              <object class="GtkStackPage">
-                                <property name="name">spinner</property>
-                                <property name="child">
-                                  <object class="AdwSpinner"/>
-                                </property>
+                              <object class="GtkLabel" id="title">
+                                <property name="halign">start</property>
+                                <property name="wrap">true</property>
+                                <property name="justify">left</property>
+                                <property name="label">Untitled Album</property>
+                                <style>
+                                  <class name="title-2"/>
+                                </style>
                               </object>
                             </child>
                             <child>
-                              <object class="GtkStackPage">
-                                <property name="name">content</property>
-                                <property name="child">
-                                  <object class="GtkBox" id="infobox_text">
+                              <object class="AdwWrapBox" id="artists_box">
+                                <property name="child-spacing">3</property>
+                                <property name="line-spacing">3</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="EuphonicaRating" id="rating">
+                                    <property name="dim-inactive">true</property>
+                                    <property name="editable">true</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="rating_readout">
+                                    <property name="label">Unrated</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <style>
+                                  <class name="spacer"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkBox">
                                     <property name="orientation">1</property>
-                                    <property name="spacing">6</property>
-                                    <property name="hexpand">true</property>
                                     <child>
-                                      <object class="GtkLabel" id="title">
-                                        <property name="halign">start</property>
-                                        <property name="wrap">true</property>
-                                        <property name="justify">left</property>
-                                        <property name="label">Untitled Album</property>
+                                      <object class="GtkLabel">
+                                        <property name="label" translatable="true">Originally released</property>
                                         <style>
-                                          <class name="title-2"/>
+                                          <class name="caption-heading"/>
                                         </style>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="AdwWrapBox" id="artists_box">
-                                        <property name="child-spacing">3</property>
-                                        <property name="line-spacing">3</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="spacing">6</property>
-                                        <child>
-                                          <object class="EuphonicaRating" id="rating">
-                                            <property name="dim-inactive">true</property>
-                                            <property name="editable">true</property>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="rating_readout">
-                                            <property name="label">Unrated</property>
-                                            <style>
-                                              <class name="dim-label"/>
-                                            </style>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSeparator">
+                                      <object class="GtkLabel" id="release_date">
+                                        <property name="label">-</property>
                                         <style>
-                                          <class name="spacer"/>
+                                          <class name="caption"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="orientation">1</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="label" translatable="true">Tracks</property>
+                                        <style>
+                                          <class name="caption-heading"/>
                                         </style>
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkBox">
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkBox">
-                                            <property name="orientation">1</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="label" translatable="true">Originally released</property>
-                                                <style>
-                                                  <class name="caption-heading"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="release_date">
-                                                <property name="label">-</property>
-                                                <style>
-                                                  <class name="caption"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
+                                      <object class="GtkLabel" id="track_count">
+                                        <property name="label">-</property>
+                                        <style>
+                                          <class name="caption"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
 
-                                        <child>
-                                          <object class="GtkBox">
-                                            <property name="orientation">1</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="label" translatable="true">Tracks</property>
-                                                <style>
-                                                  <class name="caption-heading"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="track_count">
-                                                <property name="label">-</property>
-                                                <style>
-                                                  <class name="caption"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
-
-                                        <child>
-                                          <object class="GtkBox">
-                                            <property name="orientation">1</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="label" translatable="true">Runtime</property>
-                                                <style>
-                                                  <class name="caption-heading"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="runtime">
-                                                <property name="label">-</property>
-                                                <style>
-                                                  <class name="caption"/>
-                                                </style>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="orientation">1</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="label" translatable="true">Runtime</property>
+                                        <style>
+                                          <class name="caption-heading"/>
+                                        </style>
                                       </object>
                                     </child>
                                     <child>
+                                      <object class="GtkLabel" id="runtime">
+                                        <property name="label">-</property>
+                                        <style>
+                                          <class name="caption"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+
+                            <child>
+                              <object class="GtkStack" id="infobox_spinner">
+                                <child>
+                                  <object class="GtkStackPage">
+                                    <property name="name">spinner</property>
+                                    <property name="child">
+                                      <object class="AdwSpinner">
+                                        <property name="vexpand">true</property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkStackPage">
+                                    <property name="name">content</property>
+                                    <property name="child">
                                       <object class="GtkScrolledWindow" id="wiki_box">
                                         <property name="hscrollbar-policy">never</property>
                                         <property name="vexpand">true</property>
@@ -245,9 +248,9 @@
                                           </object>
                                         </property>
                                       </object>
-                                    </child>
+                                    </property>
                                   </object>
-                                </property>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/gtk/library/album-content-view.ui
+++ b/src/gtk/library/album-content-view.ui
@@ -394,6 +394,10 @@
           <attribute name="label" translatable="true">Clear album art</attribute>
           <attribute name="action">album-content-view.clear-album-art</attribute>
         </item>
+        <item>
+          <attribute name="label" translatable="true">Re-fetch metadata</attribute>
+          <attribute name="action">album-content-view.refetch-metadata</attribute>
+        </item>
       </section>
     </menu>
     <menu id="queue_menu_model">

--- a/src/gtk/library/artist-content-view.ui
+++ b/src/gtk/library/artist-content-view.ui
@@ -54,21 +54,9 @@
                             <property name="size">128</property>>
                           </object>
                         </child>
+
                         <child>
-                          <object class="GtkStack" id="infobox_spinner">
-                            <child>
-                              <object class="GtkStackPage">
-                                <property name="name">spinner</property>
-                                <property name="child">
-                                  <object class="AdwSpinner"/>
-                                </property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkStackPage">
-                                <property name="name">content</property>
-                                <property name="child">
-                                  <object class="GtkBox" id="infobox_text">
+                          <object class="GtkBox" id="infobox_text">
                             <property name="orientation">1</property>
                             <property name="spacing">6</property>
                             <property name="hexpand">true</property>
@@ -129,60 +117,74 @@
                                     </child>
                                   </object>
                                 </child>
-
                               </object>
                             </child>
                             <child>
-                              <object class="GtkScrolledWindow" id="bio_box">
-                                <property name="hscrollbar-policy">never</property>
-                                <property name="vexpand">true</property>
-                                <property name="child">
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <property name="valign">start</property>
-                                    <child>
-                                      <object class="GtkLabel" id="bio_text">
-                                        <property name="halign">start</property>
-                                        <property name="margin-end">12</property>
-                                        <property name="wrap">true</property>
-                                        <property name="justify">fill</property>
-                                        <style>
-                                          <class name="caption"/>
-                                        </style>
+                              <object class="GtkStack" id="infobox_spinner">
+                                <child>
+                                  <object class="GtkStackPage">
+                                    <property name="name">spinner</property>
+                                    <property name="child">
+                                      <object class="AdwSpinner">
+                                        <property name="vexpand">true</property>
                                       </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLinkButton" id="bio_link">
-                                        <style>
-                                          <class name="padding-0"/>
-                                        </style>
-                                        <property name="halign">start</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <style>
-                                              <class name="caption"/>
-                                            </style>
-                                            <property name="label" translatable="true">Read more</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="bio_attrib">
-                                        <property name="wrap">true</property>
-                                        <property name="halign">start</property>
-                                        <style>
-                                          <class name="caption"/>
-                                          <class name="dim-label"/>
-                                        </style>
-                                      </object>
-                                    </child>
+                                    </property>
                                   </object>
-                                </property>
-                              </object>
-                            </child>
-                          </object>
-                                </property>
+                                </child>
+                                <child>
+                                  <object class="GtkStackPage">
+                                    <property name="name">content</property>
+                                    <property name="child">
+                                      <object class="GtkScrolledWindow" id="bio_box">
+                                        <property name="hscrollbar-policy">never</property>
+                                        <property name="vexpand">true</property>
+                                        <property name="child">
+                                          <object class="GtkBox">
+                                            <property name="orientation">1</property>
+                                            <property name="valign">start</property>
+                                            <child>
+                                              <object class="GtkLabel" id="bio_text">
+                                                <property name="halign">start</property>
+                                                <property name="margin-end">12</property>
+                                                <property name="wrap">true</property>
+                                                <property name="justify">fill</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLinkButton" id="bio_link">
+                                                <style>
+                                                  <class name="padding-0"/>
+                                                </style>
+                                                <property name="halign">start</property>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <style>
+                                                      <class name="caption"/>
+                                                    </style>
+                                                    <property name="label" translatable="true">Read more</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="bio_attrib">
+                                                <property name="wrap">true</property>
+                                                <property name="halign">start</property>
+                                                <style>
+                                                  <class name="caption"/>
+                                                  <class name="dim-label"/>
+                                                </style>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </property>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/gtk/library/artist-content-view.ui
+++ b/src/gtk/library/artist-content-view.ui
@@ -454,6 +454,10 @@
         <attribute name="label" translatable="true">Clear avatar</attribute>
         <attribute name="action">artist-content-view.clear-avatar</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="true">Re-fetch metadata</attribute>
+        <attribute name="action">artist-content-view.refetch-metadata</attribute>
+      </item>
     </menu>
   </template>
 </interface>

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -269,6 +269,26 @@ mod imp {
                 ))
                 .build();
 
+            let action_refetch_metadata = ActionEntry::builder("refetch-metadata")
+                .activate(clone!(
+                    #[strong]
+                    obj,
+                    move |_, _, _| {
+                        if let (Some(album), Some(library)) = (
+                            obj.imp().album.borrow().as_ref(),
+                            obj.imp().library.get()
+                        ) {
+                            let spinner = obj.imp().infobox_spinner.get();
+                            if spinner.visible_child_name().unwrap() != "spinner" {
+                                spinner.set_visible_child_name("spinner");
+                            }
+                            library.clear_cover(album.get_folder_uri());
+                            library.refetch_album_metadata(&album);
+                        }
+                    }
+                ))
+                .build();
+
             let action_insert_queue = ActionEntry::builder("insert-queue")
                 .activate(clone!(
                     #[strong]
@@ -306,6 +326,7 @@ mod imp {
             actions.add_action_entries([
                 action_clear_rating,
                 action_set_album_art,
+                action_refetch_metadata,
                 action_clear_album_art,
                 action_insert_queue,
             ]);

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -53,8 +53,6 @@ mod imp {
         pub rating_readout: TemplateChild<gtk::Label>,
 
         #[template_child]
-        pub wiki_box: TemplateChild<gtk::ScrolledWindow>,
-        #[template_child]
         pub wiki_text: TemplateChild<gtk::Label>,
         #[template_child]
         pub wiki_link: TemplateChild<gtk::LinkButton>,
@@ -111,7 +109,6 @@ mod imp {
                 infobox_spinner: TemplateChild::default(),
                 infobox_revealer: TemplateChild::default(),
                 collapse_infobox: TemplateChild::default(),
-                wiki_box: TemplateChild::default(),
                 wiki_text: TemplateChild::default(),
                 wiki_link: TemplateChild::default(),
                 wiki_attrib: TemplateChild::default(),
@@ -386,7 +383,6 @@ impl AlbumContentView {
                     }
                     wiki_attrib.set_label(&wiki.attribution);
                 }
-                println!("infobox_spinner child: {}", infobox_spinner.visible_child_name().unwrap());
                 if infobox_spinner.visible_child_name().unwrap() != "content" {
                     infobox_spinner.set_visible_child_name("content");
                 }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -363,12 +363,10 @@ impl AlbumContentView {
     }
 
     fn update_meta(&self, album: &Album) {
-        let wiki_box = self.imp().wiki_box.get();
         let infobox_spinner = self.imp().infobox_spinner.get();
         // If the current album is the "untitled" one (i.e. for songs without an album tag),
         // don't attempt to update metadata.
         if album.get_title().is_empty() {
-            wiki_box.set_visible(false);
             if infobox_spinner.visible_child_name().unwrap() != "content" {
                 infobox_spinner.set_visible_child_name("content");
             }
@@ -379,7 +377,6 @@ impl AlbumContentView {
             let wiki_attrib = self.imp().wiki_attrib.get();
             if let Some(meta) = cache.load_cached_album_meta(album.get_info()) {
                 if let Some(wiki) = meta.wiki {
-                    wiki_box.set_visible(true);
                     wiki_text.set_label(&wiki.content);
                     if let Some(url) = wiki.url.as_ref() {
                         wiki_link.set_visible(true);
@@ -388,14 +385,11 @@ impl AlbumContentView {
                         wiki_link.set_visible(false);
                     }
                     wiki_attrib.set_label(&wiki.attribution);
-                } else {
-                    wiki_box.set_visible(false);
                 }
+                println!("infobox_spinner child: {}", infobox_spinner.visible_child_name().unwrap());
                 if infobox_spinner.visible_child_name().unwrap() != "content" {
                     infobox_spinner.set_visible_child_name("content");
                 }
-            } else {
-                wiki_box.set_visible(false);
             }
         }
     }
@@ -815,7 +809,6 @@ impl AlbumContentView {
 
         
         // Unset metadata widgets
-        self.imp().wiki_box.set_visible(false);
         self.imp().song_list.remove_all();
         let content_spinner = self.imp().content_spinner.get();
         if content_spinner.visible_child_name().unwrap() != "spinner" {

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -46,8 +46,6 @@ mod imp {
         pub collapse_infobox: TemplateChild<gtk::ToggleButton>,
 
         #[template_child]
-        pub bio_box: TemplateChild<gtk::ScrolledWindow>,
-        #[template_child]
         pub bio_text: TemplateChild<gtk::Label>,
         #[template_child]
         pub bio_link: TemplateChild<gtk::LinkButton>,
@@ -109,7 +107,6 @@ mod imp {
                 infobox_spinner: TemplateChild::default(),
                 infobox_revealer: TemplateChild::default(),
                 collapse_infobox: TemplateChild::default(),
-                bio_box: TemplateChild::default(),
                 bio_text: TemplateChild::default(),
                 bio_link: TemplateChild::default(),
                 bio_attrib: TemplateChild::default(),
@@ -340,13 +337,11 @@ impl Default for ArtistContentView {
 
 impl ArtistContentView {
     fn update_meta(&self, artist: &Artist) {
-        let bio_box = self.imp().bio_box.get();
         let stack = self.imp().infobox_spinner.get();
         // If the current album is the "untitled" one (i.e. for songs without an album tag),
         // don't attempt to update metadata.
         let cache = self.imp().cache.get().unwrap().clone();
         if artist.get_name().is_empty() {
-            bio_box.set_visible(false);
             if stack.visible_child_name().unwrap() != "content" {
                 stack.set_visible_child_name("content");
             }
@@ -356,7 +351,6 @@ impl ArtistContentView {
             let bio_attrib = self.imp().bio_attrib.get();
             if let Some(meta) = cache.load_cached_artist_meta(artist.get_info()) {
                 if let Some(bio) = meta.bio {
-                    bio_box.set_visible(true);
                     bio_text.set_label(&bio.content);
                     if let Some(url) = bio.url.as_ref() {
                         bio_link.set_visible(true);
@@ -365,14 +359,10 @@ impl ArtistContentView {
                         bio_link.set_visible(false);
                     }
                     bio_attrib.set_label(&bio.attribution);
-                } else {
-                    bio_box.set_visible(false);
                 }
                 if stack.visible_child_name().unwrap() != "content" {
                     stack.set_visible_child_name("content");
                 }
-            } else {
-                bio_box.set_visible(false);
             }
         }
     }
@@ -741,7 +731,6 @@ impl ArtistContentView {
             }
         }
         // Unset metadata widgets
-        self.imp().bio_box.set_visible(false);
         self.imp().avatar.set_text(None);
         self.clear_content();
         duplicate!{

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -281,11 +281,32 @@ mod imp {
                 ))
                 .build();
 
+            let action_refetch_metadata = ActionEntry::builder("refetch-metadata")
+                .activate(clone!(
+                    #[strong]
+                    obj,
+                    move |_, _, _| {
+                        if let (Some(artist), Some(library)) = (
+                            obj.imp().artist.borrow().as_ref(),
+                            obj.imp().library.get()
+                        ) {
+                            let spinner = obj.imp().infobox_spinner.get();
+                            if spinner.visible_child_name().unwrap() != "spinner" {
+                                spinner.set_visible_child_name("spinner");
+                            }
+                            library.clear_artist_avatar(artist.get_name());
+                            library.refetch_artist_metadata(&artist);
+                        }
+                    }
+                ))
+                .build();
+
             // Create a new action group and add actions to it
             let actions = SimpleActionGroup::new();
             actions.add_action_entries([
                 action_set_avatar,
-                action_clear_avatar
+                action_clear_avatar,
+                action_refetch_metadata
             ]);
             self.obj().insert_action_group("artist-content-view", Some(&actions));
         }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -253,15 +253,20 @@ impl Library {
 
     /// Get all the information available about an album & its contents (won't block;
     /// UI will get notified of result later if one does arrive late).
-    /// TODO: implement provider daisy-chaining on the cache side
     pub fn init_album(&self, album: &Album) {
         if let Some(cache) = self.imp().cache.get() {
-            cache.ensure_cached_album_meta(album.get_info());
+            cache.fetch_album_meta(album.get_info(), false);
         }
         self.client()
             .queue_background(BackgroundTask::FetchAlbumSongs(
                 album.get_title().to_owned(),
             ), true);
+    }
+
+    pub fn refetch_album_metadata(&self, album: &Album) {
+        if let Some(cache) = self.imp().cache.get() {
+            cache.fetch_album_meta(album.get_info(), true);
+        }
     }
 
     /// Queue specific songs
@@ -346,13 +351,18 @@ impl Library {
 
     /// Get all the information available about an artist (won't block;
     /// UI will get notified of result later via signals).
-    /// TODO: implement provider daisy-chaining on the cache side
     pub fn init_artist(&self, artist: &Artist) {
         if let Some(cache) = self.imp().cache.get() {
-            cache.ensure_cached_artist_meta(artist.get_info());
+            cache.fetch_artist_meta(artist.get_info(), false);
         }
         self.client()
             .get_artist_content(artist.get_name().to_owned());
+    }
+
+    pub fn refetch_artist_metadata(&self, artist: &Artist) {
+        if let Some(cache) = self.imp().cache.get() {
+            cache.fetch_artist_meta(artist.get_info(), true);
+        }
     }
 
     pub fn folder_inodes(&self) -> gio::ListStore {

--- a/src/library/recent_view.rs
+++ b/src/library/recent_view.rs
@@ -242,7 +242,7 @@ impl RecentView {
             let library = self.imp().library.get().unwrap();
             library.fetch_recent_albums();
             library.fetch_recent_artists();
-            // Songs are fetched by either the library (upon startup) or player (upon song change)
+            library.fetch_recent_songs();
         }
     }
 
@@ -484,7 +484,6 @@ impl LazyInit for RecentView {
             let was_populated = self.imp().initialized.replace(true);
             if !was_populated {
                 println!("Initialising recents");
-                library.get_recent_songs();
                 self.on_history_changed();
             }
         }

--- a/src/meta_providers/base.rs
+++ b/src/meta_providers/base.rs
@@ -25,14 +25,14 @@ pub enum ProviderMessage {
     FallbackToFolderCover(AlbumInfo),
     FallbackToEmbeddedCover(AlbumInfo),
     FetchFolderCoverExternally(AlbumInfo), // Pass through the fallback parameter
-    AlbumMeta(AlbumInfo),
+    AlbumMeta(AlbumInfo, bool), // if true, skip check (for overwriting)
     AlbumMetaAvailable(String), // Only return URI
     ArtistAvatarCleared(String), // Only need name
     /// Both request and positive response
     ArtistAvatar(ArtistInfo), // With cache basepath
     ArtistAvatarAvailable(String, bool, gdk::Texture), // Name, is_thumbnail, the texture itself
     /// Both request and positive response. Includes downloading artist avatar.
-    ArtistMeta(ArtistInfo), // With cache basepath (for passthrough to artist avatar)
+    ArtistMeta(ArtistInfo, bool), // If bool is true, skip check (for overwriting)
     ArtistMetaAvailable(String), // Only return name
     Lyrics(SongInfo),
     LyricsAvailable(String) // Only return full URI

--- a/src/meta_providers/base.rs
+++ b/src/meta_providers/base.rs
@@ -1,7 +1,7 @@
 extern crate bson;
 use gtk::{prelude::*, gdk};
 use std::{thread, time::Duration};
-
+use reqwest::blocking::Client;
 use crate::{common::{AlbumInfo, ArtistInfo, SongInfo}, utils::settings_manager};
 
 use super::models;
@@ -41,25 +41,37 @@ pub enum ProviderMessage {
 /// Common provider-agnostic utilities.
 pub mod utils {
     use super::*;
-    use crate::utils;
+    use crate::{config::APPLICATION_USER_AGENT, utils};
     use image::DynamicImage;
+    use reqwest::header::USER_AGENT;
 
     /// Get a file from the given URL as bytes. Useful for downloading images.
     fn get_file(url: &str) -> Option<Vec<u8>> {
-        let response = reqwest::blocking::get(url);
+        let client = Client::default();
         // This empty check comes in handy for certain metadata providers who, instead of
         // skipping the URL fields, opt to return an empty string instead.
         if !url.is_empty() {
-            if let Ok(res) = response {
-                if let Ok(bytes) = res.bytes() {
-                    return Some(bytes.to_vec());
-                } else {
-                    println!("get_file: Failed to read response as bytes!");
-                    return None;
+            match client
+                .get(url)
+                .header(USER_AGENT, APPLICATION_USER_AGENT)
+                .send()
+            {
+                Ok(res) => {
+                    if let Ok(bytes) = res.bytes() {
+                        if let Ok(s) = str::from_utf8(&bytes) {
+                            println!("Received UTF8 instead: {}", s);
+                        }
+                        Some(bytes.to_vec())
+                    } else {
+                        println!("get_file: Failed to read response as bytes!");
+                        None
+                    }
+                },
+                Err(e) => {
+                    println!("get_file: {:?}", e);
+                    None
                 }
             }
-            println!("get_file: {:?}", response.err());
-            None
         } else {
             None
         }
@@ -75,9 +87,9 @@ pub mod utils {
             ));
         }
         images.sort_by_key(|img| img.size);
-        for image in images.iter().rev() {
-            if let Some(bytes) = get_file(image.url.as_ref()) {
-                println!("Downloaded image from: {:?}", &image.url);
+        for image_meta in images.iter().rev() {
+            if let Some(bytes) = get_file(image_meta.url.as_ref()) {
+                println!("Downloaded image from: {:?}", &image_meta.url);
                 if let Some(image) = utils::read_image_from_bytes(bytes) {
                     return Ok(image);
                 }

--- a/src/meta_providers/lastfm/controller.rs
+++ b/src/meta_providers/lastfm/controller.rs
@@ -26,7 +26,7 @@ impl LastfmWrapper {
         let key = settings.string("api-key").to_string();
         // Return None if there is no API key specified.
         if !key.is_empty() {
-            println!("Last.fm: calling `{}` with query {:?}", method, params);
+            println!("[Last.fm] Calling `{}` with query {:?}", method, params);
             let resp = self
                 .client
                 .get(API_ROOT)
@@ -38,10 +38,15 @@ impl LastfmWrapper {
                 .query(params)
                 .header(USER_AGENT, APPLICATION_USER_AGENT)
                 .send();
-            if let Ok(res) = resp {
-                return Some(res);
+            match resp {
+                Ok(res) => {
+                    return Some(res);
+                }
+                Err(e) => {
+                    println!("{e:?}");
+                    return None;
+                }
             }
-            return None;
         }
         None
     }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -908,12 +908,6 @@ impl Player {
     // Signals will be sent for properties whose values have changed, even though
     // we will be receiving updates for many properties at once.
 
-    pub fn get_recent_songs(&self) {
-        let settings = settings_manager().child("library");
-        self.client()
-            .queue_background(BackgroundTask::FetchRecentSongs(settings.uint("n-recent-songs")), true);
-    }
-
     /// Main update function. MPD's protocol has a single "status" commands
     /// that returns everything at once. This update function will take what's
     /// relevant and update the GObject properties accordingly.
@@ -1067,7 +1061,6 @@ impl Player {
                             if let Some(new_position_dur) = status.elapsed {
                                 if !self.imp().saved_to_history.get() && new_position_dur.as_secs_f32() / dur >= 0.5 {
                                     if let Ok(()) = sqlite::add_to_history(curr_song.get_info()) {
-                                        self.get_recent_songs();
                                         self.emit_by_name::<()>("history-changed", &[]);
                                     }
                                     self.imp().saved_to_history.set(true);

--- a/src/player/playback_controls.rs
+++ b/src/player/playback_controls.rs
@@ -126,15 +126,24 @@ impl PlaybackControls {
             move |_| player.toggle_playback()
         ));
         self.imp().next_btn.connect_clicked(clone!(
-            #[strong]
+            #[weak]
             player,
             move |_| player.next_song(true)
         ));
         let shuffle_btn = imp.random_btn.get();
-        shuffle_btn
-            .bind_property("active", player, "random")
-            .bidirectional()
+
+        // Don't use bidirectional to avoid erroneously firing once on UI init
+        player
+            .bind_property("random", &shuffle_btn, "active")
             .sync_create()
             .build();
+
+        shuffle_btn.connect_clicked(clone!(
+            #[weak]
+            player,
+            move |btn| {
+                player.set_random(btn.is_active());
+            }
+        ));
     }
 }

--- a/src/player/queue_view.rs
+++ b/src/player/queue_view.rs
@@ -418,11 +418,19 @@ impl QueueView {
             .sync_create()
             .build();
 
-        consume
-            .bind_property("active", player, "consume")
-            .bidirectional()
+        // Don't use bidirectional here or we'll fire once on UI init, erroneously resetting the state.
+        player
+            .bind_property("consume", &consume, "active")
             .sync_create()
             .build();
+
+        consume.connect_clicked(clone!(
+            #[weak]
+            player,
+            move |btn| {
+                player.set_consume(btn.is_active())
+            }
+        ));
 
         clear_queue_btn.connect_clicked(clone!(
             #[weak]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,6 +262,13 @@ pub fn rebuild_artist_delim_exception_automaton() {
     }
 }
 
+
+/// There are two guard layers against full fetches.
+/// - This LazyInit trait. All heavy views must implement it. A view's populate() will then be called
+/// by the sidebar upon navigating to that view. If that view is already initialised, populate() must
+/// be a noop(). TODO: enforce noop at sidebar level instead.
+/// - Additional checks at the controller level, to prevent new windows (after surfacing from background)
+/// from mistakenly reinitialising already-fetched models.
 pub trait LazyInit {
     fn clear(&self);
     fn populate(&self);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,13 +166,12 @@ pub fn strip_filename_linux(path: &str) -> &str {
 }
 
 pub fn read_image_from_bytes(bytes: Vec<u8>) -> Option<DynamicImage> {
-    if let Ok(reader) = ImageReader::new(Cursor::new(bytes)).with_guessed_format() {
-        if let Ok(dyn_img) = reader.decode() {
-            return Some(dyn_img);
-        }
-        return None;
+    if let Some(dyn_img) = image::load_from_memory(&bytes).ok() {
+        Some(dyn_img)
+    } else {
+        println!("read_image_from_bytes: Unable to infer image format from content");
+        None
     }
-    None
 }
 
 /// Automatically resize & based on user settings, then convert to RGB8.

--- a/src/window.rs
+++ b/src/window.rs
@@ -1074,6 +1074,7 @@ impl EuphonicaWindow {
                 imp.title.set_subtitle("Connecting");
                 imp.should_populate_visible.set(false);
                 library.clear();
+                // Player clears itself
                 imp.recent_view.clear();
                 imp.album_view.clear();
                 imp.artist_view.clear();


### PR DESCRIPTION
Should fix #161.

- [x] Fix wiki text not being fetched due to an erroneous `async` keyword on a function meant to be sync (and Rust in its infinite wisdom decided not to put up a warning, instead letting the thing go unexecuted).
- [x] Fix artist avatars not being downloaded due to missing user agent string (Wikimedia Commons now enforces them).
- [x] Make spinner occupy just the wiki/bio part and not the entire info panel.
- [x] Add metadata reload option.
- [x] Fix duplicated albums after resuming from background.
- [x] Fix consume mode resetting itself on new window openings.