### PR TITLE
Respect albumsort, artistsort and albumartistsort

### DIFF
--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -176,7 +176,7 @@ impl Cache {
                                 providers,
                                 move || {
                                     // Check whether there is one already
-                                    if key.mbid.is_some() || key.artist_tag.is_some() {
+                                    if key.mbid.is_some() || key.albumartist.is_some() {
                                         let folder_uri = key.folder_uri.to_owned();
                                         if overwrite || sqlite::find_album_meta(&key).ok().flatten().is_none() {
                                             let res = providers.read().unwrap().get_album_meta(&mut key, None);

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -281,8 +281,8 @@ impl AlbumView {
                     3 => {
                         // Album title
                         g_cmp_str_options(
-                            Some(album1.get_title()),
-                            Some(album2.get_title()),
+                            Some(album1.get_sortable_title()),
+                            Some(album2.get_sortable_title()),
                             nulls_first,
                             asc,
                             case_sensitive,
@@ -291,8 +291,8 @@ impl AlbumView {
                     4 => {
                         // AlbumArtist
                         g_cmp_str_options(
-                            album1.get_artist_str().as_deref(),
-                            album2.get_artist_str().as_deref(),
+                            album1.get_sortable_artist_tag().as_deref(),
+                            album2.get_sortable_artist_tag().as_deref(),
                             nulls_first,
                             asc,
                             case_sensitive,

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -247,8 +247,8 @@ impl ArtistView {
                 let nulls_first = library_settings.boolean("sort-nulls-first");
 
                 g_cmp_str_options(
-                    Some(artist1.get_name()),
-                    Some(artist2.get_name()),
+                    Some(artist1.get_sortable_name()),
+                    Some(artist2.get_sortable_name()),
                     nulls_first,
                     asc,
                     case_sensitive,


### PR DESCRIPTION
Fixes #134.

- `albumartistsort` tag will be used as-is (no splitting will be performed).
- In the case of multi-artist tracks, we expect one `artistsort` tag for each artist in the tag. This might change in the future.