### PR TITLE
Disambiguate albums by albumartist tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "mpd"
 version = "0.1.0"
-source = "git+https://github.com/htkhiem/rust-mpd.git?rev=3eedd021a0c46d22f1b31729e37a56a8f9bd99b0#3eedd021a0c46d22f1b31729e37a56a8f9bd99b0"
+source = "git+https://github.com/htkhiem/rust-mpd.git?rev=6e5fdbe1352fe91df3097e3b1e5f05b40a8c41c5#6e5fdbe1352fe91df3097e3b1e5f05b40a8c41c5"
 dependencies = [
  "bufstream",
  "fxhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.30"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 image = "0.25.1"
 librsvg = "2.58.1"
-mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "3eedd021a0c46d22f1b31729e37a56a8f9bd99b0" }
+mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "6e5fdbe1352fe91df3097e3b1e5f05b40a8c41c5" }
 once_cell = "1.19.0"
 time = { version = "0.3.36", features = ["formatting"] }
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -382,20 +382,27 @@ mod background {
         F: Fn(AlbumInfo) -> Result<(), SendError<AsyncClientMessage>>,
     {
         // TODO: batched windowed retrieval
-        // Get list of unique album tags
+        // Get list of unique album tags, grouped by albumartist
         // Will block child thread until info for all albums have been retrieved.
-        match client.list(&Term::Tag(Cow::Borrowed("album")), query) {
-            Ok(tag_list) => {
-                for tag in &tag_list {
-                    if let Ok(mut songs) = client.find(
-                        Query::new().and(Term::Tag(Cow::Borrowed("album")), tag),
-                        Window::from((0, 1)),
-                    ) {
-                        if !songs.is_empty() {
-                            let info = SongInfo::from(std::mem::take(&mut songs[0]))
-                                .into_album_info()
-                                .unwrap_or_default();
-                            let _ = respond(info);
+        match client.list(&Term::Tag(Cow::Borrowed("album")), query, Some("albumartist")) {
+            Ok(grouped_vals) => {
+                for (key, tags) in grouped_vals.groups.into_iter() {
+                    for tag in tags.iter() {
+                        match client.find(
+                            Query::new().and(Term::Tag(Cow::Borrowed("album")), tag).and(Term::Tag(Cow::Borrowed("albumartist")), &key),
+                            Window::from((0, 1)),
+                        ) {
+                            Ok(mut songs) => {
+                                if !songs.is_empty() {
+                                    let info = SongInfo::from(std::mem::take(&mut songs[0]))
+                                        .into_album_info()
+                                        .unwrap_or_default();
+                                    let _ = respond(info);
+                                }
+                            }
+                            Err(e) => {
+                                dbg!(e);
+                            }
                         }
                     }
                 }
@@ -405,7 +412,8 @@ mod background {
                 // Connection error => attempt to reconnect
                 Err(true)
             }
-            Err(_) => {
+            Err(e) => {
+                dbg!(e);
                 Err(false)
             }
         }
@@ -444,6 +452,7 @@ mod background {
         Ok(())
     }
 
+    /// Fetch all albums, using AlbumArtist to further disambiguate same-named ones.
     pub fn fetch_all_albums(client: &mut mpd::Client<StreamWrapper>, sender_to_fg: &Sender<AsyncClientMessage>) {
         match fetch_albums_by_query(client, &Query::new(), |info| {
             sender_to_fg.send_blocking(AsyncClientMessage::AlbumBasicInfoDownloaded(info))
@@ -539,10 +548,10 @@ mod background {
             "artist"
         };
         let mut already_parsed: FxHashSet<String> = FxHashSet::default();
-        match client.list(&Term::Tag(Cow::Borrowed(tag_type)), &Query::new()) {
-            Ok(tag_list) => {
+        match client.list(&Term::Tag(Cow::Borrowed(tag_type)), &Query::new(), None) {
+            Ok(grouped_vals) => {
                 // TODO: Limit tags to only what we need locally
-                for tag in &tag_list {
+                for tag in &grouped_vals.groups[0].1 {
                     if let Ok(mut songs) = client.find(
                         Query::new().and(Term::Tag(Cow::Borrowed(tag_type)), tag),
                         Window::from((0, 1)),

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -512,7 +512,7 @@ impl From<mpd::song::Song> for SongInfo {
         let mut albumsort: Option<String> = None;
         let mut artist_mbids: Vec<String> = Vec::new();
         let mut artistsorts: Vec<String> = Vec::new();
-        let mut album_artist_strs: Vec<String> = Vec::new();
+        let mut albumartist: Option<String> = None;
         let mut albumartistsort: Option<String> = None;
         let mut album_artist_mbids: Vec<String> = Vec::new();
         let mut album_mbid: Option<String> = None;
@@ -534,16 +534,16 @@ impl From<mpd::song::Song> for SongInfo {
                     }
                 }
                 "albumsort" => {
-                    albumsort = Some(val);
+                    albumsort.replace(val);
                 }
                 "albumartist" => {
-                    album_artist_strs.push(val);
+                    albumartist.replace(val);
                 }
                 "artistsort" => {
                     artistsorts.push(val);
                 }
                 "albumartistsort" => {
-                    albumartistsort = Some(val);
+                    albumartistsort.replace(val);
                 }
                 // "date" => res.imp().release_date.replace(Some(val.clone())),
                 "format" => {
@@ -621,9 +621,10 @@ impl From<mpd::song::Song> for SongInfo {
             album.albumartistsort = albumartistsort;
             album.release_date = res.release_date.clone();
             // Assume the albumartist IDs are given in the same order as the albumartist tags
-            for album_artist_str in album_artist_strs.iter() {
+            if let Some(album_artist_str) = albumartist.as_ref() {
                 album.add_artists_from_string(album_artist_str);
             }
+            album.albumartist = albumartist;
             for (idx, id) in album_artist_mbids.drain(..).enumerate() {
                 if idx < album.artists.len() {
                     let _ = album.artists[idx].mbid.replace(id);

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -2,7 +2,7 @@ extern crate mpd;
 use crate::{
     application::EuphonicaApplication,
     cache::{get_image_cache_path, sqlite, Cache, CacheState},
-    client::{BackgroundTask, ClientState, ConnectionState, MpdWrapper},
+    client::{ClientState, ConnectionState, MpdWrapper},
     common::{CoverSource, QualityGrade, Song},
     config::APPLICATION_ID,
     meta_providers::models::Lyrics,


### PR DESCRIPTION
Fixes #170. This also involved implementing support for group clauses in `list` queries in `rust-mpd`.

- [x] Update `rust-mpd` to support grouping
- [x] Implement Euphonica side
- [x] Migrate history DB to disambiguate future album entries. Existing ones can't be disambiguated as we didn't record artist or MBID information back then.