### PR TITLE
Redesign audio output widget to fit in bottom bar

### DIFF
--- a/src/gtk/player/output.ui
+++ b/src/gtk/player/output.ui
@@ -1,59 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-	<template class="EuphonicaMpdOutput" parent="GtkBox">
-		<style>
-			<class name="linked"/>
-		</style>
+  <template class="EuphonicaMpdOutput" parent="GtkBox">
     <property name="orientation">1</property>
-		<property name="halign">center</property>
-		<property name="valign">center</property>
-
-		<object class="GtkPopover" id="options_popover">
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <object class="GtkPopover" id="options_popover">
       <property name="has-arrow">true</property>
       <property name="name">options_popover</property>
       <property name="child">
-        <object class="GtkLabel" id="options_preview">
-          <property name="use-markup">true</property>
-        </object>
+				<object class="GtkBox">
+					<property name="orientation">1</property>
+					<property name="spacing">6</property>
+					<child>
+						<object class="GtkLabel" id="options_preview">
+							<property name="use-markup">true</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkBox">
+							<property name="hexpand">true</property>
+							<child>
+								<object class="GtkSwitch" id="enable_output"/>
+							</child>
+							<child>
+								<object class="GtkLabel">
+									<property name="hexpand">true</property>
+									<property name="label" translatable="true">Enabled</property>
+								</object>
+							</child>
+						</object>
+					</child>
+				</object>
       </property>
     </object>
-
-		<child>
-			<object class="GtkButton" id="toggle_btn">
-				<style>
-					<class name="flat"/>
-				</style>
-				<child>
-					<object class="GtkBox">
-						<property name="spacing">6</property>
-						<property name="orientation">1</property>
-						<child>
-							<object class="GtkImage" id="icon">
-								<property name="icon-size">large</property>
-								<property name="icon-name">soundcard-symbolic</property>
-							</object>
-						</child>
-						<child>
-							<object class="GtkLabel" id="name">
-								<property name="ellipsize">end</property>
-								<style>
-									<class name="caption"/>
-								</style>
-							</object>
-						</child>
-					</object>
-				</child>
-			</object>
-		</child>
-		<child>
-			<object class="GtkMenuButton" id="options">
-				<property name="icon-name">dialog-information-symbolic</property>
-				<property name="visible">false</property>
+    <child>
+      <object class="GtkMenuButton" id="icon_btn">
+        <style>
+          <class name="flat"/>
+        </style>
 				<property name="popover">options_popover</property>
-				<style>
-					<class name="flat"/>
-				</style>
-			</object>
-		</child>
-	</template>
+        <child>
+          <object class="GtkBox">
+            <property name="spacing">6</property>
+            <property name="orientation">1</property>
+            <child>
+              <object class="GtkImage" id="icon">
+                <property name="icon-size">large</property>
+                <property name="icon-name">soundcard-symbolic</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="name">
+                <property name="ellipsize">end</property>
+                <style>
+                  <class name="caption"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
 </interface>

--- a/src/player/output.rs
+++ b/src/player/output.rs
@@ -22,22 +22,19 @@ fn map_icon_name(plugin_name: &str) -> &'static str {
 mod imp {
     use super::*;
 
-    #[derive(Properties, Default, CompositeTemplate)]
-    #[properties(wrapper_type = super::MpdOutput)]
+    #[derive(Default, CompositeTemplate)]
     #[template(resource = "/io/github/htkhiem/Euphonica/gtk/player/output.ui")]
     pub struct MpdOutput {
         #[template_child]
-        pub toggle_btn: TemplateChild<gtk::Button>,
+        pub icon_btn: TemplateChild<gtk::MenuButton>,
         #[template_child]
         pub icon: TemplateChild<gtk::Image>,
         #[template_child]
         pub name: TemplateChild<gtk::Label>,
         #[template_child]
-        pub options: TemplateChild<gtk::MenuButton>,
+        pub enable_output: TemplateChild<gtk::Switch>,
         #[template_child]
-        pub options_preview: TemplateChild<gtk::Label>,
-        #[property(get, set)]
-        pub enabled: Cell<bool>,
+        pub options_preview: TemplateChild<gtk::Label>
     }
 
     // The central trait for subclassing a GObject
@@ -57,7 +54,6 @@ mod imp {
         }
     }
 
-    #[glib::derived_properties]
     impl ObjectImpl for MpdOutput {}
 
     // Trait shared by all widgets
@@ -78,7 +74,7 @@ impl MpdOutput {
         let icon = self.imp().icon.get();
         let label = self.imp().name.get();
         let is_dimmed = icon.has_css_class("dim-label");
-        let is_enabled = self.imp().enabled.get();
+        let is_enabled = self.imp().enable_output.is_active();
         if is_enabled && is_dimmed {
             icon.remove_css_class("dim-label");
             label.remove_css_class("dim-label");
@@ -93,24 +89,26 @@ impl MpdOutput {
         let imp = self.imp();
         let name = imp.name.get();
         let icon = imp.icon.get();
-        let options = imp.options.get();
+        let enable_output = imp.enable_output.get();
         let options_preview = imp.options_preview.get();
 
         name.set_label(&output.name);
+        if enable_output.is_active() != output.enabled {
+            enable_output.set_active(output.enabled);
+        }
         icon.set_icon_name(Some(map_icon_name(&output.plugin)));
-        let _ = self.imp().enabled.replace(output.enabled);
         if output.attributes.len() > 0 {
             // Big TODO: editable runtime attributes
-            options.set_visible(true);
             let mut attribs: Vec<String> = Vec::with_capacity(output.attributes.len());
             for (k, v) in output.attributes.iter() {
-                println!("<b>{}</b>: {}", k, v);
                 attribs.push(format!("<b>{}</b>: {}", k, v));
             }
 
+            options_preview.set_visible(true);
             options_preview.set_label(&attribs.join("\n"));
         } else {
-            options.set_visible(false);
+            options_preview.set_label("");
+            options_preview.set_visible(false);
         }
         self.set_dim();
     }
@@ -120,17 +118,11 @@ impl MpdOutput {
         res.update_state(output);
 
         let id = output.id;
-        let toggle_btn = res.imp().toggle_btn.get();
-        toggle_btn.connect_clicked(clone!(
-            #[weak(rename_to = this)]
-            res,
+        res.imp().enable_output.connect_active_notify(clone!(
             #[weak]
             player,
-            move |_| {
-                let was_enabled = this.imp().enabled.get();
-                let _ = this.imp().enabled.replace(!was_enabled);
-                this.set_dim();
-                player.set_output(id, !was_enabled);
+            move |sw| {
+                player.set_output(id, sw.is_active());
             }
         ));
 


### PR DESCRIPTION
Fixes #189. All controls are now tucked into a popover. This should avoid raising the bottom bar's designed height.