### PR TITLE
metadata: Add vcs-browser URL

### DIFF
--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -9,6 +9,7 @@
   </developer>
   <url type="bugtracker">https://github.com/htkhiem/euphonica/issues</url>
   <url type="homepage">https://github.com/htkhiem/euphonica</url>
+  <url type="vcs-browser">https://github.com/htkhiem/euphonica</url>  
   <content_rating type="oars-1.1" />
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>


### PR DESCRIPTION
Add vcs-browser URL to fix Flathub linter warning.