### PR TITLE
Fix Album Metadata Fetch

### DIFF
--- a/src/meta_providers/musicbrainz/controller.rs
+++ b/src/meta_providers/musicbrainz/controller.rs
@@ -60,6 +60,7 @@ impl MetadataProvider for MusicBrainzWrapper {
                 let res = Release::search(
                     ReleaseSearchQuery::query_builder()
                         .release(title)
+                        .and()
                         .artist(artist)
                         .build(),
                 )


### PR DESCRIPTION
The album fetcher doesn't work correctly - it only searches for the artist name and not for artist name + album name. This fixes that.