### PR TITLE
Use keyring only when MPD needs a password

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -438,32 +438,36 @@ impl Connection {
             .map_err(Error::Mpd)?
         };
 
-        // eprintln!("Connected, now authenticating");
-
-        // If there is a password configured, use it to authenticate.
-        let mut cred_store_fail = false;
-        match password::get_mpd_password().map_err(|_| Error::CredentialStore) {
-            Ok(Some(password)) => {
-                if let Err(e) = client.login(&password).map_err(Error::Mpd) {
-                    return Err(dbg!(e));
-                }
-                // eprintln!("Successfully authenticated");
-            }
-            Ok(None) => {
-                // eprintln!("No password was specified.");
-            }
-            Err(_) => {
-                cred_store_fail = true;
-            }
-        }
-
         // Doubles as a litmus test to see if we are authenticated.
         if let Err(e) = client.subscribe(&self.wake_channel).map_err(Error::Mpd) {
-            return Err(dbg!(if cred_store_fail {
-                Error::CredentialStore
-            } else {
-                e
-            }));
+            let needs_password = matches!(
+                &e,
+                Error::Mpd(MpdError::Server(ServerError {
+                    code: MpdErrorCode::Password | MpdErrorCode::Permission,
+                    ..
+                }))
+            );
+            if !needs_password {
+                return Err(dbg!(e));
+            }
+
+            match password::get_mpd_password().map_err(|_| Error::CredentialStore) {
+                Ok(Some(password)) => {
+                    if let Err(e) = client.login(&password).map_err(Error::Mpd) {
+                        return Err(dbg!(e));
+                    }
+                    if let Err(e) = client.subscribe(&self.wake_channel).map_err(Error::Mpd) {
+                        return Err(dbg!(e));
+                    }
+                    // eprintln!("Successfully authenticated");
+                }
+                Ok(None) => {
+                    return Err(dbg!(e));
+                }
+                Err(e) => {
+                    return Err(dbg!(e));
+                }
+            }
         }
         // eprintln!("Subscribed to wake channel");
 

--- a/src/client/password.rs
+++ b/src/client/password.rs
@@ -1,8 +1,61 @@
-use gtk::gio::Cancellable;
+use gtk::{
+    gio::{self, Cancellable},
+    glib::{self, variant::ToVariant},
+};
 use libsecret::*;
 use std::collections::HashMap;
 
 use crate::config::APPLICATION_ID;
+
+pub fn secret_service_available() -> bool {
+    let Ok(bus) = gio::bus_get_sync(gio::BusType::Session, Cancellable::NONE) else {
+        return false;
+    };
+    let reply_type = glib::VariantTy::new("(b)").unwrap();
+    let Ok(reply) = bus.call_sync(
+        Some("org.freedesktop.DBus"),
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus",
+        "NameHasOwner",
+        Some(&("org.freedesktop.secrets",).to_variant()),
+        Some(reply_type),
+        gio::DBusCallFlags::NO_AUTO_START,
+        -1,
+        Cancellable::NONE,
+    ) else {
+        return false;
+    };
+
+    reply
+        .get::<(bool,)>()
+        .is_some_and(|(available,)| available)
+}
+
+pub async fn secret_service_available_async() -> bool {
+    let Ok(bus) = gio::bus_get_future(gio::BusType::Session).await else {
+        return false;
+    };
+    let reply_type = glib::VariantTy::new("(b)").unwrap();
+    let Ok(reply) = bus
+        .call_future(
+            Some("org.freedesktop.DBus"),
+            "/org/freedesktop/DBus",
+            "org.freedesktop.DBus",
+            "NameHasOwner",
+            Some(&("org.freedesktop.secrets",).to_variant()),
+            Some(reply_type),
+            gio::DBusCallFlags::NO_AUTO_START,
+            -1,
+        )
+        .await
+    else {
+        return false;
+    };
+
+    reply
+        .get::<(bool,)>()
+        .is_some_and(|(available,)| available)
+}
 
 pub fn get_mpd_password_schema() -> Schema {
     let mut attributes = HashMap::new();
@@ -12,6 +65,10 @@ pub fn get_mpd_password_schema() -> Schema {
 }
 
 pub fn get_mpd_password() -> Result<Option<String>, String> {
+    if !secret_service_available() {
+        return Err(String::from("Default credential store is not available"));
+    }
+
     let schema = get_mpd_password_schema();
     let mut attributes = HashMap::new();
     attributes.insert("type", "mpd");
@@ -29,6 +86,10 @@ pub fn get_mpd_password() -> Result<Option<String>, String> {
 }
 
 pub async fn get_mpd_password_async() -> Result<Option<String>, String> {
+    if !secret_service_available_async().await {
+        return Err(String::from("Default credential store is not available"));
+    }
+
     let schema = get_mpd_password_schema();
     let mut attributes = HashMap::new();
     attributes.insert("type", "mpd");
@@ -46,6 +107,10 @@ pub async fn get_mpd_password_async() -> Result<Option<String>, String> {
 }
 
 pub async fn set_mpd_password(maybe_password: Option<&str>) -> Result<(), String> {
+    if !secret_service_available_async().await {
+        return Err(String::from("Default credential store is not available"));
+    }
+
     let schema = get_mpd_password_schema();
     let mut attributes = HashMap::new();
     attributes.insert("type", "mpd");

--- a/src/preferences/client.rs
+++ b/src/preferences/client.rs
@@ -16,7 +16,7 @@ use crate::{
     application::EuphonicaApplication,
     client::{
         ClientState, ConnectionState,
-        password::{get_mpd_password_async, set_mpd_password},
+        password::{get_mpd_password_async, secret_service_available_async, set_mpd_password},
         state::StickersSupportLevel,
     },
     player::{FftStatus, Player},
@@ -394,18 +394,20 @@ impl ClientPreferences {
             .set_text(&conn_settings.uint("mpd-port").to_string());
         let password_field = imp.mpd_password.get();
         glib::spawn_future_local(async move {
-            match get_mpd_password_async().await {
-                Ok(maybe_password) => {
-                    // At startup the password entry is disabled with a tooltip stating that
-                    // the credential store is not available.
-                    password_field.set_sensitive(true);
-                    password_field.set_tooltip_text(None);
-                    if let Some(password) = maybe_password {
-                        password_field.set_text(&password);
+            if secret_service_available_async().await {
+                match get_mpd_password_async().await {
+                    Ok(maybe_password) => {
+                        // At startup the password entry is disabled with a tooltip stating that
+                        // the credential store is not available.
+                        password_field.set_sensitive(true);
+                        password_field.set_tooltip_text(None);
+                        if let Some(password) = maybe_password {
+                            password_field.set_text(&password);
+                        }
                     }
-                }
-                Err(e) => {
-                    dbg!(e);
+                    Err(e) => {
+                        println!("{e:?}");
+                    }
                 }
             }
         });
@@ -492,10 +494,18 @@ impl ClientPreferences {
                 }
 
                 let password_val = this.imp().mpd_password.text();
+                let password_available = this.imp().mpd_password.is_sensitive();
                 glib::spawn_future_local(clone!(
                     #[weak]
                     app,
                     async move {
+                        if !password_available {
+                            if let Err(e) = app.refresh().await {
+                                dbg!(e);
+                            }
+                            return;
+                        }
+
                         let password: Option<&str> = if password_val.is_empty() {
                             None
                         } else {


### PR DESCRIPTION
Probe MPD before reading stored credentials, so passwordless and SSH tunneled setups can connect when gnome-keyring-daemon or another Secret Service provider is absent.

Keep Secret Service required for password based setups; password reads and writes still fail when credential storage is unavailable, while the preferences UI leaves the password field disabled and refreshes without attempting a password update.