### PR TITLE
v0.99.5: Multi-core texture handling & time-to-album-grid reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "euphonica"
-version = "0.99.4"
+version = "0.99.5"
 dependencies = [
  "aho-corasick",
  "ashpd",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "mpd"
 version = "0.1.0"
-source = "git+https://github.com/htkhiem/rust-mpd.git?rev=55cb92d0abfd13616769b437586d70e43eda7ed6#55cb92d0abfd13616769b437586d70e43eda7ed6"
+source = "git+https://github.com/htkhiem/rust-mpd.git?rev=e9f5ad589e0eaaeb1d9758cc3a6b5762bb67e4b5#e9f5ad589e0eaaeb1d9758cc3a6b5762bb67e4b5"
 dependencies = [
  "bufstream",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "mpd"
 version = "0.1.0"
-source = "git+https://github.com/htkhiem/rust-mpd.git?rev=a8ddd7d624ee7ea2f4128e6df878e6b05fe5b0e7#a8ddd7d624ee7ea2f4128e6df878e6b05fe5b0e7"
+source = "git+https://github.com/htkhiem/rust-mpd.git?rev=55cb92d0abfd13616769b437586d70e43eda7ed6#55cb92d0abfd13616769b437586d70e43eda7ed6"
 dependencies = [
  "bufstream",
  "fxhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ futures = "0.3.30"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 image = { version = "0.25.1", features = ["webp"] }
 librsvg = "2.58.1"
-mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "a8ddd7d624ee7ea2f4128e6df878e6b05fe5b0e7", features = ["serde"] }
+mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "55cb92d0abfd13616769b437586d70e43eda7ed6", features = ["serde"] }
+# mpd = { path = "../rust-mpd", features = ["serde"] }
 once_cell = "1.19.0"
 time = { version = "0.3.47", features = ["alloc", "formatting", "local-offset"] }
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euphonica"
-version = "0.99.4"
+version = "0.99.5"
 edition = "2024"
 
 [dev-dependencies]
@@ -13,8 +13,7 @@ futures = "0.3.30"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 image = { version = "0.25.1", features = ["webp"] }
 librsvg = "2.58.1"
-mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "55cb92d0abfd13616769b437586d70e43eda7ed6", features = ["serde"] }
-# mpd = { path = "../rust-mpd", features = ["serde"] }
+mpd = { git = "https://github.com/htkhiem/rust-mpd.git", rev = "e9f5ad589e0eaaeb1d9758cc3a6b5762bb67e4b5", features = ["serde"] }
 once_cell = "1.19.0"
 time = { version = "0.3.47", features = ["alloc", "formatting", "local-offset"] }
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -156,6 +156,11 @@
 			<default>1024</default>
 			<summary>Maximum resolution for cached images</summary>
 		</key>
+
+		<key name="use-hires-backlog-threshold" type="u">
+			<default>10</default>
+			<summary>Number of pending cover load tasks at which hires album art loading is deferred in favor of thumbnails</summary>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.metaprovider" path="/io/github/htkhiem/Euphonica/metaprovider/">

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -161,6 +161,12 @@
 			<default>10</default>
 			<summary>Number of pending cover load tasks at which hires album art loading is deferred in favor of thumbnails</summary>
 		</key>
+
+		<key name="n-image-threads" type="u">
+			<default>4</default>
+			<summary>Number of threads for image processing operations</summary>
+			<description>Controls the number of threads used for parallel image processing (resizing, encoding, decoding). More threads does not always mean better performance. Requires restart to take effect.</description>
+		</key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.metaprovider" path="/io/github/htkhiem/Euphonica/metaprovider/">

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('euphonica', 'rust',
-          version: '0.99.4',
+          version: '0.99.5',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -229,11 +229,11 @@ fn load_image(
 // thrashing while quickly scrolling through like a million albums.
 // This cache's keys are the filenames themselves.
 
-// Keeping ~256 textures around doesn't mean there can only be 256 on screen at any time.
+// Keeping ~1024 textures around doesn't mean there can only be 1024 on screen at any time.
 // This cache merely keeps an additional strong ref alive in case a texture goes out of view.
 // As long as one is in view it is held by the widget displaying it.
 static IMAGE_CACHE: Lazy<Mutex<LruCache<String, Texture>>> =
-    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(256).unwrap())));
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1024).unwrap())));
 
 /// Threshold for deferring hires album art loading. When the pending task count
 /// reaches this value, new album art requests fall back to thumbnails.

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -333,10 +333,14 @@ impl Cache {
         song: &SongInfo,
         thumbnail: bool,
     ) -> Result<Option<Texture>> {
+        // Track pending tasks for backpressure-aware hires loading.
+        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
         let folder_uri = strip_filename_linux(&song.uri).to_owned();
         let album = song.album.as_ref().cloned();
-        self.get_cover(&folder_uri, &song.uri, thumbnail, album)
-            .await
+        let res = self.clone().get_cover_internal(&folder_uri, &song.uri, thumbnail, album)
+            .await;
+        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+        res
     }
 
     /// Try to get a cover image for the given album. This prioritises the folder image
@@ -349,15 +353,22 @@ impl Cache {
         album: &AlbumInfo,
         thumbnail: bool,
     ) -> Result<Option<Texture>> {
-        self.get_cover(
+        // Track pending tasks for backpressure-aware hires loading.
+        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
+        let res = self.clone().get_cover_internal(
             &album.folder_uri,
             &album.example_uri,
             thumbnail,
             Some(album.to_owned()),
         )
-        .await
+        .await;
+        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+        res
     }
 
+    /// Shared cover lookup. `folder_key` is the URI used for folder-level images,
+    /// `embedded_key` is the URI used for embedded (track-level) images.
+    /// If `album` is provided, it is used for external metadata lookups.
     #[inline]
     async fn get_cover_internal(
         self: Rc<Self>,
@@ -443,28 +454,6 @@ impl Cache {
         }
 
         Ok(None)
-    }
-
-    /// Shared cover lookup. `folder_key` is the URI used for folder-level images,
-    /// `embedded_key` is the URI used for embedded (track-level) images.
-    /// If `album` is provided, it is used for external metadata lookups.
-    /// Actual implementation is in get_cover_internal. This is a thin RAII wrapper
-    /// to handle incrementing/decrementing self.pending_tasks.
-    async fn get_cover(
-        self: Rc<Self>,
-        folder_key: &str,
-        embedded_key: &str,
-        thumbnail: bool,
-        album: Option<AlbumInfo>,
-    ) -> Result<Option<Texture>> {
-        // Track pending tasks for backpressure-aware hires loading.
-        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
-        let res = self
-            .clone()
-            .get_cover_internal(folder_key, embedded_key, thumbnail, album)
-            .await;
-        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
-        res
     }
 
     /// Load the specified image, resize it, load into cache then send a message to frontend.

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -16,6 +16,7 @@ use image::ImageReader;
 use lru::LruCache;
 use once_cell::sync::Lazy;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, fs::create_dir_all, rc::Rc, result, sync::Mutex};
 
 use crate::{
@@ -234,6 +235,16 @@ fn load_image(
 static IMAGE_CACHE: Lazy<Mutex<LruCache<String, Texture>>> =
     Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(256).unwrap())));
 
+/// Threshold for deferring hires album art loading. When the pending task count
+/// reaches this value, new album art requests fall back to thumbnails.
+pub static BACKLOG_THRESHOLD: Lazy<usize> = Lazy::new(|| {
+    settings_manager()
+        .child("library")
+        .uint("use-hires-backlog-threshold")
+        .try_into()
+        .unwrap_or(10)
+});
+
 // We use an Asyncified container to queue tasks, such that two requests for the
 // same texture are never run concurrently. This allows one request to cache the
 // texture in-memory for all subsequent requests.
@@ -245,6 +256,8 @@ pub struct Cache {
     // Asyncified container for operations involving API calls (should sleep after each call).
     external: Asyncified<()>,
     state: CacheState,
+    // Tracks in-flight get_cover requests for backpressure-aware hires loading.
+    pending_tasks: AtomicUsize,
 }
 
 impl fmt::Debug for Cache {
@@ -284,6 +297,7 @@ impl Cache {
                 }))
                 .unwrap(),
             state: CacheState::default(),
+            pending_tasks: AtomicUsize::new(0),
         };
 
         Rc::new(cache)
@@ -293,21 +307,24 @@ impl Cache {
         self.state.clone()
     }
 
+    /// Returns the number of pending cover lookup tasks.
+    pub fn backlog(&self) -> usize {
+        self.pending_tasks.load(Ordering::Relaxed)
+    }
+
     /// Try to get a cover image for the given song. This prioritises the folder-level
     /// cover image over embedded covers of the track.
     /// Returns a gdk::Texture from cache if available.
     /// Failing that, we'll search local storage.
-    /// Still failing that, if `external` is true, it will try to get one from MPD
-    /// or external metadata providers.
+    /// Still failing that, it will try to get one from MPD or external metadata providers.
     pub async fn get_song_cover(
         self: Rc<Self>,
         song: &SongInfo,
         thumbnail: bool,
-        external: bool,
     ) -> Result<Option<Texture>> {
         let folder_uri = strip_filename_linux(&song.uri).to_owned();
         let album = song.album.as_ref().cloned();
-        self.get_cover(&folder_uri, &song.uri, thumbnail, external, album)
+        self.get_cover(&folder_uri, &song.uri, thumbnail, album)
             .await
     }
 
@@ -315,19 +332,16 @@ impl Cache {
     /// file over embedded covers of its tracks.
     /// Returns a gdk::Texture from cache if available.
     /// Failing that, we'll search local storage.
-    /// Still failing that, if `external` is true, it will try to get one from MPD
-    /// or external metadata providers.
+    /// Still failing that, it will try to get one from MPD or external metadata providers.
     pub async fn get_album_cover(
         self: Rc<Self>,
         album: &AlbumInfo,
         thumbnail: bool,
-        external: bool,
     ) -> Result<Option<Texture>> {
         self.get_cover(
             &album.folder_uri,
             &album.example_uri,
             thumbnail,
-            external,
             Some(album.to_owned()),
         )
         .await
@@ -341,9 +355,11 @@ impl Cache {
         folder_key: &str,
         embedded_key: &str,
         thumbnail: bool,
-        external: bool,
         album: Option<AlbumInfo>,
     ) -> Result<Option<Texture>> {
+        // Track pending tasks for backpressure-aware hires loading.
+        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
+
         let mut failed_before = false;
 
         let folder_key_owned = folder_key.to_owned();
@@ -356,25 +372,31 @@ impl Cache {
             .call(move |_| get_image_internal(&folder_key_cached, None, thumbnail))
             .await
         {
-            Ok(Some(tex)) => return Ok(Some(tex)),
+            Ok(Some(tex)) => {
+                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+                return Ok(Some(tex))
+            },
             Ok(None) => {}
             Err(Error::PriorFailure) => failed_before = true,
             Err(Error::FileNotFound) => {
+                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                 // Retry (DB entry should have been purged by get_image_internal)
                 return Box::pin(self.get_cover(
                     &folder_key_owned,
                     &embedded_key_owned,
                     thumbnail,
-                    external,
                     album,
                 ))
                 .await;
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+                return Err(e)
+            },
         }
 
         // 2. Nope, fall back to downloading fresh
-        if external && !failed_before {
+        if !failed_before {
             if settings_manager()
                 .child("client")
                 .boolean("mpd-download-album-art")
@@ -386,6 +408,7 @@ impl Cache {
                     .map_err(Error::Client)
                     .await?
                 {
+                    self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                     return Ok(bundle.take_texture(thumbnail).map(Some)?);
                 }
                 // 2b. MPD embedded cover, WILL BE SAVED AS FOLDER-LEVEL ART such that all future calls from tracks in the
@@ -396,6 +419,7 @@ impl Cache {
                     .map_err(Error::Client)
                     .await?
                 {
+                    self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                     return Ok(bundle.take_texture(thumbnail).map(Some)?);
                 }
             }
@@ -404,6 +428,7 @@ impl Cache {
             if let Some(album) = album
                 && let Some(meta) = self.get_album_meta(&album, true, false, None).await?
             {
+                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                 return self
                     .external
                     .call(move |_| load_image(&album.folder_uri, None, &meta.image, thumbnail))

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -194,7 +194,7 @@ fn read_texture_from_name(name: &str) -> Result<gdk::Texture> {
 }
 
 #[inline]
-fn load_image(
+fn download_image_from_provider(
     key: &str,
     prefix: Option<&'static str>,
     fallback_images: &[models::ImageMeta],
@@ -371,9 +371,7 @@ impl Cache {
         let folder_key_cached = folder_key_owned.clone();
         match self
             .pool
-            .push_future(
-            move || get_image_internal(&folder_key_cached, None, thumbnail)
-            )
+            .push_future(move || get_image_internal(&folder_key_cached, None, thumbnail))
             .expect("get_cover_internal: cache threadpool error")
             .await
             .expect("get_cover_internal: cache threadpool error")
@@ -417,7 +415,7 @@ impl Cache {
                     .get_embedded_cover(embedded_key_owned.to_owned())
                     .map_err(Error::Client)
                     .await?
-                {   
+                {
                     return Ok(bundle.take_texture(thumbnail).map(Some)?);
                 }
             }
@@ -428,7 +426,14 @@ impl Cache {
             {
                 return self
                     .external
-                    .call(move |_| load_image(&album.folder_uri, None, &meta.image, thumbnail))
+                    .call(move |_| {
+                        download_image_from_provider(
+                            &album.folder_uri,
+                            None,
+                            &meta.image,
+                            thumbnail,
+                        )
+                    })
                     .await;
             }
         }
@@ -450,7 +455,10 @@ impl Cache {
     ) -> Result<Option<Texture>> {
         // Track pending tasks for backpressure-aware hires loading.
         self.pending_tasks.fetch_add(1, Ordering::Relaxed);
-        let res = self.clone().get_cover_internal(folder_key, embedded_key, thumbnail, album).await;
+        let res = self
+            .clone()
+            .get_cover_internal(folder_key, embedded_key, thumbnail, album)
+            .await;
         self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
         res
     }
@@ -750,7 +758,14 @@ impl Cache {
             let artist = artist.to_owned();
             return self
                 .external
-                .call(move |_| load_image(&artist.name, Some("avatar"), &meta.image, thumbnail))
+                .call(move |_| {
+                    download_image_from_provider(
+                        &artist.name,
+                        Some("avatar"),
+                        &meta.image,
+                        thumbnail,
+                    )
+                })
                 .await;
         }
 
@@ -763,8 +778,7 @@ impl Cache {
         is_dynamic_playlist: bool,
         thumbnail: bool,
     ) -> Result<Option<gdk::Texture>> {
-        self
-            .pool
+        self.pool
             .push_future(move || {
                 let prefix = Some(if is_dynamic_playlist {
                     "dynamic_playlist"

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -251,10 +251,15 @@ pub static BACKLOG_THRESHOLD: Lazy<usize> = Lazy::new(|| {
 pub struct Cache {
     mpd_client: Rc<MpdWrapper>,
     meta_providers: MetadataChain,
-    // Asyncified container for local operations (no delay between calls).
+    // Asyncified container for local operations (no delay between calls). Serves as a task queue.
+    // Background tasks that shouldn't be parallelised, such as image downloads, should be run there.
+    // This allows us to cleanly avoid duplicate downloads.
     local: Asyncified<()>,
-    // Asyncified container for operations involving API calls (should sleep after each call).
+    // Same as above but for operations involving API calls (should sleep after each call).
     external: Asyncified<()>,
+    // Thread pool for parallelisable operations such as texture read from disk and resizing ops.
+    pool: glib::ThreadPool,
+    // Cache state object for emitting signals.
     state: CacheState,
     // Tracks in-flight get_cover requests for backpressure-aware hires loading.
     pending_tasks: AtomicUsize,
@@ -296,6 +301,8 @@ impl Cache {
                         .await
                 }))
                 .unwrap(),
+            pool: glib::ThreadPool::shared(Some(4))
+                .expect("Unable to start threadpool for cache operations"),
             state: CacheState::default(),
             pending_tasks: AtomicUsize::new(0),
         };
@@ -347,41 +354,37 @@ impl Cache {
         .await
     }
 
-    /// Shared cover lookup. `folder_key` is the URI used for folder-level images,
-    /// `embedded_key` is the URI used for embedded (track-level) images.
-    /// If `album` is provided, it is used for external metadata lookups.
-    async fn get_cover(
+    #[inline]
+    async fn get_cover_internal(
         self: Rc<Self>,
         folder_key: &str,
         embedded_key: &str,
         thumbnail: bool,
         album: Option<AlbumInfo>,
     ) -> Result<Option<Texture>> {
-        // Track pending tasks for backpressure-aware hires loading.
-        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
-
         let mut failed_before = false;
 
         let folder_key_owned = folder_key.to_owned();
         let embedded_key_owned = embedded_key.to_owned();
 
-        // 1. Check if we have it cached locally
+        // 1. Check if we have it cached locally. This is parallelisable so we'll use the threadpool.
         let folder_key_cached = folder_key_owned.clone();
         match self
-            .local
-            .call(move |_| get_image_internal(&folder_key_cached, None, thumbnail))
+            .pool
+            .push_future(
+            move || get_image_internal(&folder_key_cached, None, thumbnail)
+            )
+            .expect("get_cover_internal: cache threadpool error")
             .await
+            .expect("get_cover_internal: cache threadpool error")
         {
-            Ok(Some(tex)) => {
-                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
-                return Ok(Some(tex))
-            },
+            Ok(Some(tex)) => return Ok(Some(tex)),
             Ok(None) => {}
             Err(Error::PriorFailure) => failed_before = true,
             Err(Error::FileNotFound) => {
-                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                 // Retry (DB entry should have been purged by get_image_internal)
-                return Box::pin(self.get_cover(
+                // No need to increment/decrement pending_tasks here.
+                return Box::pin(self.get_cover_internal(
                     &folder_key_owned,
                     &embedded_key_owned,
                     thumbnail,
@@ -389,10 +392,7 @@ impl Cache {
                 ))
                 .await;
             }
-            Err(e) => {
-                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
-                return Err(e)
-            },
+            Err(e) => return Err(e),
         }
 
         // 2. Nope, fall back to downloading fresh
@@ -408,7 +408,6 @@ impl Cache {
                     .map_err(Error::Client)
                     .await?
                 {
-                    self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                     return Ok(bundle.take_texture(thumbnail).map(Some)?);
                 }
                 // 2b. MPD embedded cover, WILL BE SAVED AS FOLDER-LEVEL ART such that all future calls from tracks in the
@@ -418,8 +417,7 @@ impl Cache {
                     .get_embedded_cover(embedded_key_owned.to_owned())
                     .map_err(Error::Client)
                     .await?
-                {
-                    self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+                {   
                     return Ok(bundle.take_texture(thumbnail).map(Some)?);
                 }
             }
@@ -428,7 +426,6 @@ impl Cache {
             if let Some(album) = album
                 && let Some(meta) = self.get_album_meta(&album, true, false, None).await?
             {
-                self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
                 return self
                     .external
                     .call(move |_| load_image(&album.folder_uri, None, &meta.image, thumbnail))
@@ -437,6 +434,25 @@ impl Cache {
         }
 
         Ok(None)
+    }
+
+    /// Shared cover lookup. `folder_key` is the URI used for folder-level images,
+    /// `embedded_key` is the URI used for embedded (track-level) images.
+    /// If `album` is provided, it is used for external metadata lookups.
+    /// Actual implementation is in get_cover_internal. This is a thin RAII wrapper
+    /// to handle incrementing/decrementing self.pending_tasks.
+    async fn get_cover(
+        self: Rc<Self>,
+        folder_key: &str,
+        embedded_key: &str,
+        thumbnail: bool,
+        album: Option<AlbumInfo>,
+    ) -> Result<Option<Texture>> {
+        // Track pending tasks for backpressure-aware hires loading.
+        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
+        let res = self.clone().get_cover_internal(folder_key, embedded_key, thumbnail, album).await;
+        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
+        res
     }
 
     /// Load the specified image, resize it, load into cache then send a message to frontend.
@@ -708,9 +724,11 @@ impl Cache {
         let name = artist.name.to_owned();
         let mut failed_before = false;
         match self
-            .local
-            .call(move |_| get_image_internal(&name, Some("avatar"), thumbnail))
+            .pool
+            .push_future(move || get_image_internal(&name, Some("avatar"), thumbnail))
+            .expect("get_artist_avatar: threadpool error")
             .await
+            .expect("get_artist_avatar: threadpool error")
         {
             Ok(Some(tex)) => {
                 return Ok(Some(tex));
@@ -745,8 +763,9 @@ impl Cache {
         is_dynamic_playlist: bool,
         thumbnail: bool,
     ) -> Result<Option<gdk::Texture>> {
-        self.local
-            .call(move |_| {
+        self
+            .pool
+            .push_future(move || {
                 let prefix = Some(if is_dynamic_playlist {
                     "dynamic_playlist"
                 } else {
@@ -754,7 +773,9 @@ impl Cache {
                 });
                 get_image_internal(&playlist_name, prefix, thumbnail)
             })
+            .expect("get_playlist_cover: threadpool error")
             .await
+            .expect("get_playlist_cover: threadpool error")
     }
 
     pub async fn insert_dynamic_playlist(

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -202,9 +202,9 @@ fn download_image_from_provider(
 ) -> Result<Option<Texture>> {
     // Always check with our DB first as a prior call might have downloaded the
     // necessary image for us.
-    if let Some(file) = sqlite::find_image_by_key(key, prefix, thumbnail).expect("Sqlite DB error")
-    {
-        read_texture_from_name(&file).map(Some)
+    let maybe_file = sqlite::find_image_by_key(key, prefix, thumbnail).expect("Sqlite DB error");
+    if maybe_file.as_ref().is_some_and(|s| !s.is_empty()) {
+        read_texture_from_name(&maybe_file.unwrap()).map(Some)
     } else {
         match get_best_image(fallback_images) {
             Ok(dyn_img) => {

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -301,8 +301,12 @@ impl Cache {
                         .await
                 }))
                 .unwrap(),
-            pool: glib::ThreadPool::shared(Some(4))
-                .expect("Unable to start threadpool for cache operations"),
+            pool: glib::ThreadPool::shared(Some(
+                settings_manager()
+                    .child("library")
+                    .uint("n-image-threads"),
+            ))
+            .expect("Unable to start threadpool for cache operations"),
             state: CacheState::default(),
             pending_tasks: AtomicUsize::new(0),
         };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -5,6 +5,7 @@ mod state;
 pub use state::CacheState;
 pub mod placeholders;
 
+pub use controller::BACKLOG_THRESHOLD;
 pub use controller::Cache;
 pub use controller::Error;
 pub use controller::ImageAction;

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -563,7 +563,13 @@ pub fn find_image_by_key(
             r.get::<usize, String>(0)
         });
     match query {
-        Ok(filename) => Ok(Some(filename)),
+        Ok(filename) => {
+            if !filename.is_empty() {
+                Ok(Some(filename))
+            } else {
+                Ok(None)
+            }
+        },
         Err(SqliteError::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(Error::Db(e)),
     }

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -563,13 +563,7 @@ pub fn find_image_by_key(
             r.get::<usize, String>(0)
         });
     match query {
-        Ok(filename) => {
-            if !filename.is_empty() {
-                Ok(Some(filename))
-            } else {
-                Ok(None)
-            }
-        },
+        Ok(filename) => Ok(Some(filename)),
         Err(SqliteError::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(Error::Db(e)),
     }

--- a/src/cache/state.rs
+++ b/src/cache/state.rs
@@ -6,11 +6,6 @@ use gtk::{gdk, glib};
 use std::sync::OnceLock;
 
 mod imp {
-    // use glib::{
-    //     ParamSpec,
-    //     ParamSpecBoolean,
-    //     ParamSpecEnum
-    // };
     use super::*;
 
     #[derive(Debug, Default)]
@@ -23,36 +18,6 @@ mod imp {
     }
 
     impl ObjectImpl for CacheState {
-        // fn properties() -> &'static [ParamSpec] {
-        //     static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-        //         vec![
-        //             ParamSpecBoolean::builder("busy").read_only().build(),
-        //             ParamSpecEnum::builder::<ConnectionState>("connection-state").read_only().build()
-        //         ]
-        //     });
-        //     PROPERTIES.as_ref()
-        // }
-
-        // fn property(&self, _id: usize, pspec: &ParamSpec) -> glib::Value {
-        //     let obj = self.obj();
-        //     match pspec.name() {
-        //         "connection-state" => obj.get_connection_state().to_value(),
-        //         "busy" => obj.is_busy().to_value(),
-        //         _ => unimplemented!(),
-        //     }
-        // }
-
-        // fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
-        //     let obj = self.obj();
-        //     match pspec.name() {
-        //         "connection-state" => {
-        //             let state = value.get().expect("Error in CacheState::set_property");
-        //             obj.set_connection_state(state);
-        //         },
-        //         _ => unimplemented!()
-        //     }
-        // }
-
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -576,7 +576,10 @@ impl Connection {
         // should start using the local cached version as soon as possible.
         let hires = sqlite::find_image_by_key(key, None, false).expect("Sqlite DB error");
         let thumb = sqlite::find_image_by_key(key, None, true).expect("Sqlite DB error");
-        if let (Some(hires), Some(thumb)) = (hires, thumb) {
+        // The above might return empty strings verbatim. Normally we wouldn't even reach this if the strings were empty,
+        // but there might be some race conditions when there are multiple distinct album tags in the same folder?
+        if hires.as_ref().is_some_and(|s| !s.is_empty()) && thumb.as_ref().is_some_and(|s| !s.is_empty()) {
+            let (hires, thumb) = (hires.unwrap(), thumb.unwrap());
             let _ = resp.send(Ok(Some(ImageHandle::Registered(
                 utils::RegisteredImageBundle {
                     hires: utils::RegisteredImage {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -333,6 +333,13 @@ pub enum Task {
         Responder<GroupedValues>,
     ),
     Find(Query<'static>, Window, Responder<Vec<SongInfo>>),
+    /// Batched version of Find.
+    FindMultiple(
+        Vec<(Query<'static>, Window)>, 
+        /// Optional list of tagtypes to limit to.
+        Option<Vec<&'static str>>, 
+        Responder<Vec<SongInfo>>
+    ),
     LsInfo(String, Responder<Vec<INodeInfo>>),
     GetPlaylist(
         /// Playlist name
@@ -1053,6 +1060,18 @@ impl Connection {
                         },
                         resp,
                     ),
+                    Task::FindMultiple(queries_windows, tagtypes,resp) => {
+                        self.respond_with_client(
+                        move |c| {
+                            c.find_multiple(
+                                &queries_windows, 
+                                tagtypes.as_deref()
+                            ).map(|mpd_songs| {
+                                mpd_songs.into_iter().map(SongInfo::from).collect()
+                            })
+                        },
+                        resp,
+                    )},
                     Task::LsInfo(path, resp) => self.respond_with_client(
                         |c| {
                             c.lsinfo(&path)

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -151,6 +151,7 @@ pub fn build_comparator(
 pub enum Error {
     NoExist,
     Mpd(MpdError),
+    Image(image::error::ImageError),
     Internal,
     Socket,
     CredentialStore,
@@ -163,6 +164,15 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 pub type Responder<T> = OneShotSender<Result<T>>;
+
+/// maybe_download_image can either return a registered image bundle (ready for use)
+/// or, if newly downloaded from MPD, a raw bytes vector for processing. This is so
+/// that we can do said processing in a simple glib threadpool handled from the main
+/// thread & avoid blocking this one.
+pub enum ImageHandle {
+    Registered(utils::RegisteredImageBundle),
+    New(Vec<u8>, String), // bytes and key to register as
+}
 
 /// The successor to BackgroundTask.
 pub enum Task {
@@ -305,7 +315,7 @@ pub enum Task {
         /// URI to song file
         String,
         /// Full paths to high-resolution and low-resolution file, respectively
-        Responder<Option<utils::RegisteredImageBundle>>,
+        Responder<Option<ImageHandle>>,
     ),
     /// Get a song's folder cover (cover.jpg/png/webp in the same folder).
     /// Will try to download from MPD if one isn't already available locally.
@@ -313,7 +323,7 @@ pub enum Task {
         /// URI to folder with trailing slash
         String,
         /// Full paths to high-resolution and low-resolution file, respectively
-        Responder<Option<utils::RegisteredImageBundle>>,
+        Responder<Option<ImageHandle>>,
     ),
     /// Query distinct values of a tag, optionally grouped by another
     List(
@@ -537,20 +547,20 @@ impl Connection {
     /// Note to self: no prefix handling here because all images downloaded from MPD are album arts.
     fn maybe_download_image<F>(
         &mut self,
-        example_uri: String,   // Must be a full URI (not the truncated folder_uri) to avoid problems with remote connections
+        example_uri: String, // Must be a full URI (not the truncated folder_uri) to avoid problems with remote connections
         download_func: F,
-        register_key: Option<String>,   // defaults to folder-level URI of the above example_uri
-        resp: Responder<Option<utils::RegisteredImageBundle>>,
+        register_key: Option<String>, // defaults to folder-level URI of the above example_uri
+        resp: Responder<Option<ImageHandle>>,
     ) where
         F: Fn(&mut Client<StreamWrapper>, &String) -> MpdResult<Vec<u8>>,
     {
         // `register_key` overrides the key used for DB lookup and registration.
-        // This lets us store a folder-level key even when the fetch URI is track-level.   
+        // This lets us store a folder-level key even when the fetch URI is track-level.
         // unwrap_or_else to avoid having to run strip_filename_linux when register_key.is_some().
         let key = register_key.as_deref().unwrap_or_else(
             // We still internally truncate to folder-level URI for mapping purposes, e.g. avoiding downloading
             // the same album art more than once when given different URIs within the same folder.
-            || strip_filename_linux(&example_uri)
+            || strip_filename_linux(&example_uri),
         );
 
         // Always check with our DB first, as multiple calls may be spawned
@@ -560,30 +570,24 @@ impl Connection {
         let hires = sqlite::find_image_by_key(key, None, false).expect("Sqlite DB error");
         let thumb = sqlite::find_image_by_key(key, None, true).expect("Sqlite DB error");
         if let (Some(hires), Some(thumb)) = (hires, thumb) {
-            let _ = resp.send(Ok(Some(utils::RegisteredImageBundle {
-                hires: utils::RegisteredImage {
-                    name: hires,
-                    img: RefCell::new(None),
+            let _ = resp.send(Ok(Some(ImageHandle::Registered(
+                utils::RegisteredImageBundle {
+                    hires: utils::RegisteredImage {
+                        name: hires,
+                        img: RefCell::new(None),
+                    },
+                    thumb: utils::RegisteredImage {
+                        name: thumb,
+                        img: RefCell::new(None),
+                    },
                 },
-                thumb: utils::RegisteredImage {
-                    name: thumb,
-                    img: RefCell::new(None),
-                },
-            })));
+            ))));
         } else {
             // Not available locally => try to download
             self.respond_with_client(
                 |c| {
                     match download_func(c, &example_uri) {
-                        Ok(bytes) => Ok(Some(utils::save_and_register_image(
-                            image::load_from_memory(&bytes).map_err(|_| {
-                                MpdError::Parse(mpd::error::ParseError::BadValue(
-                                    "unexpected EOF in texture".into(),
-                                ))
-                            })?,
-                            key,
-                            None,
-                        ))),
+                        Ok(bytes) => Ok(Some(ImageHandle::New(bytes, key.to_owned()))),
                         Err(MpdError::Proto(ProtoError::NotPair)) => {
                             // Empty output. Treat as not available.
                             Ok(None)

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::cache::sqlite;
 use crate::client::connection::ImageHandle;
-use crate::common::DynamicPlaylist;
+use crate::common::{DynamicPlaylist, tags};
 use crate::utils::settings_manager;
 use crate::{
     common::{Album, Artist, INode, Song, SongInfo, Stickers},
@@ -873,9 +873,9 @@ impl MpdWrapper {
         let grouped_vals = self
             .foreground(
                 Task::List(
-                    Term::Tag(Cow::Borrowed("album")),
+                    Term::Tag(tags::ALBUM.into()),
                     query,
-                    Some("albumartist"),
+                    Some(tags::ALBUMARTIST),
                     s,
                 ),
                 r,
@@ -893,33 +893,20 @@ impl MpdWrapper {
         for ta_chunk in titles_artists.chunks(256) {
             let queries_windows: Vec<(Query, mpd::search::Window)> = ta_chunk.iter().map(|title_artist| {
                 let mut query = Query::new();
-                query.and(Term::Tag(Cow::Borrowed("album")), title_artist.0.to_string());
-                query.and(Term::Tag(Cow::Borrowed("albumartist")), title_artist.1.to_string());
+                query.and(Term::Tag(Cow::Borrowed(tags::ALBUM)), title_artist.0.to_string());
+                query.and(Term::Tag(Cow::Borrowed(tags::ALBUMARTIST)), title_artist.1.to_string());
                 (query, mpd::search::Window::from((0, 1)))
             }).collect();
             let (s, r) = oneshot::channel();
-            let mut songs = dbg!(self
+            let mut songs = self
                 .foreground(Task::FindMultiple(queries_windows, Some(vec![
-                    "album", "albumartist", "albumsort", "albumartistsort", "musicbrainz_albumid"
+                    tags::ALBUM, tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUM_MBID
                 ]), s), r)
-                .await?);
+                .await?;
             for i in (0 .. songs.len()) {
                 // Insert our local album & albumartist tags
                 if let Some(album_info) = std::mem::take(&mut songs[i]).into_album_info() {
-                    let res: Album = album_info.into();
-                    // let (s, r) = oneshot::channel();
-                    // // Optionally fetch album stickers
-                    // // TODO: BATCH STICKERS FETCH TOO
-                    // if let Ok(stickers) = self
-                    //     .foreground(
-                    //         Task::GetKnownStickers("album", res.get_title().to_owned(), s),
-                    //         r,
-                    //     )
-                    //     .await
-                    // {
-                    //     res.set_stickers(stickers);
-                    // }
-                    respond(res);
+                    respond(album_info.into());
                 }
             }
         }
@@ -936,12 +923,12 @@ impl MpdWrapper {
             sqlite::get_last_n_albums(settings.uint("n-recent-albums")).expect("Sqlite DB error");
         for tup in recent_albums.into_iter() {
             let mut query = Query::new();
-            query.and(Term::Tag(Cow::Borrowed("album")), tup.0);
+            query.and(Term::Tag(tags::ALBUM.into()), tup.0);
             if let Some(artist) = tup.1 {
-                query.and(Term::Tag(Cow::Borrowed("albumartist")), artist);
+                query.and(Term::Tag(tags::ALBUMARTIST.into()), artist);
             }
             if let Some(mbid) = tup.2 {
-                query.and(Term::Tag(Cow::Borrowed("musicbrainz_albumid")), mbid);
+                query.and(Term::Tag(tags::ALBUM_MBID.into()), mbid);
             }
             self.get_albums_by_query(query, respond).await?;
         }
@@ -1015,9 +1002,14 @@ impl MpdWrapper {
         // Here we'll reuse the artist parsing code in our SongInfo struct and put parsed
         // ArtistInfos in a Set to deduplicate them.
         let tag_type: &'static str = if use_album_artist {
-            "albumartist"
+            tags::ALBUMARTIST
         } else {
-            "artist"
+            tags::ARTIST
+        };
+        let tagtypes_to_load = if use_album_artist {
+            vec![tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUMARTIST_MBID]
+        } else {
+            vec![tags::ARTIST, tags::ARTISTSORT, tags::ARTIST_MBID]
         };
         let mut already_parsed: FxHashSet<String> = FxHashSet::default();
         let (s, r) = oneshot::channel();
@@ -1027,16 +1019,18 @@ impl MpdWrapper {
                 r,
             )
             .await?;
-        // TODO: Limit tags to only what we need locally
-        for mut tag in std::mem::take(&mut grouped_vals.groups[0].1).into_iter() {
-            let mut query = Query::new();
-            query.and(Term::Tag(Cow::Borrowed(tag_type)), std::mem::take(&mut tag));
+        for tag_chunk in std::mem::take(&mut grouped_vals.groups[0].1).chunks(256) {
+            let queries_windows: Vec<(Query, mpd::search::Window)> = tag_chunk.iter().map(|tag| {
+                let mut query = Query::new();
+                query.and(Term::Tag(tag_type.into()), tag.to_owned());
+                (query, mpd::search::Window::from((0, 1)))
+            }).collect();
             let (s, r) = oneshot::channel();
             let mut songs = self
-                .foreground(Task::Find(query, Window::from((0, 1)), s), r)
+                .foreground(Task::FindMultiple(queries_windows, Some(tagtypes_to_load.clone()), s), r)
                 .await?;
-            if !songs.is_empty() {
-                let artists = std::mem::take(&mut songs[0]).into_artist_infos();
+            for i in (0..songs.len()) {
+                let artists = std::mem::take(&mut songs[i]).into_artist_infos();
                 for artist in artists.into_iter() {
                     if already_parsed.insert(artist.get_comp_id().to_owned()) {
                         respond(artist.into());

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -900,7 +900,7 @@ impl MpdWrapper {
             let (s, r) = oneshot::channel();
             let mut songs = self
                 .foreground(Task::FindMultiple(queries_windows, Some(vec![
-                    tags::ALBUM, tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUM_MBID
+                    tags::ALBUM, tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUM_MBID, tags::RELEASE_DATE
                 ]), s), r)
                 .await?;
             for i in (0 .. songs.len()) {

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -890,7 +890,7 @@ impl MpdWrapper {
             }
         }
         // Chunk the queries
-        for ta_chunk in titles_artists.chunks(128) {
+        for ta_chunk in titles_artists.chunks(256) {
             let queries_windows: Vec<(Query, mpd::search::Window)> = ta_chunk.iter().map(|title_artist| {
                 let mut query = Query::new();
                 query.and(Term::Tag(Cow::Borrowed("album")), title_artist.0.to_string());
@@ -907,18 +907,18 @@ impl MpdWrapper {
                 // Insert our local album & albumartist tags
                 if let Some(album_info) = std::mem::take(&mut songs[i]).into_album_info() {
                     let res: Album = album_info.into();
-                    let (s, r) = oneshot::channel();
-                    // Optionally fetch album stickers
-                    // TODO: BATCH STICKERS FETCH TOO
-                    if let Ok(stickers) = self
-                        .foreground(
-                            Task::GetKnownStickers("album", res.get_title().to_owned(), s),
-                            r,
-                        )
-                        .await
-                    {
-                        res.set_stickers(stickers);
-                    }
+                    // let (s, r) = oneshot::channel();
+                    // // Optionally fetch album stickers
+                    // // TODO: BATCH STICKERS FETCH TOO
+                    // if let Ok(stickers) = self
+                    //     .foreground(
+                    //         Task::GetKnownStickers("album", res.get_title().to_owned(), s),
+                    //         r,
+                    //     )
+                    //     .await
+                    // {
+                    //     res.set_stickers(stickers);
+                    // }
                     respond(res);
                 }
             }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -105,7 +105,12 @@ impl MpdWrapper {
                     .run()
                     .is_err()
             }),
-            pool: ThreadPool::shared(Some(4)).expect("Unable to start MpdWrapper threadpool"),
+            pool: ThreadPool::shared(Some(
+                settings_manager()
+                    .child("library")
+                    .uint("n-image-threads"),
+            ))
+            .expect("Unable to start MpdWrapper threadpool"),
             state: ClientState::default(),
             fg_sender,
             bg_sender,

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1,6 +1,6 @@
 use async_channel::{Receiver, Sender};
 use futures::executor;
-use glib::clone;
+use glib::{ThreadPool, clone};
 use gtk::gio::prelude::*;
 use gtk::{gio, glib};
 use lru::LruCache;
@@ -23,6 +23,7 @@ use std::{cell::RefCell, rc::Rc};
 use uuid::Uuid;
 
 use crate::cache::sqlite;
+use crate::client::connection::ImageHandle;
 use crate::common::DynamicPlaylist;
 use crate::utils::settings_manager;
 use crate::{
@@ -69,6 +70,8 @@ pub struct MpdWrapper {
     // (true) or disconnection request (false).
     fg_handle: thread::JoinHandle<bool>,
     bg_handle: thread::JoinHandle<bool>,
+    // For heavy but parallelisable local tasks.
+    pool: ThreadPool,
     state: ClientState,
     fg_sender: Sender<Task>, // For sending tasks to the interactive client
     bg_sender: Sender<Task>, // For sending tasks to the background client
@@ -102,6 +105,7 @@ impl MpdWrapper {
                     .run()
                     .is_err()
             }),
+            pool: ThreadPool::shared(Some(4)).expect("Unable to start MpdWrapper threadpool"),
             state: ClientState::default(),
             fg_sender,
             bg_sender,
@@ -783,8 +787,35 @@ impl MpdWrapper {
         &self,
         uri: String,
     ) -> ClientResult<Option<utils::RegisteredImageBundle>> {
+        // Leave downloading to the background connection thread, but local operations
+        // (resizing, transcoding, writing to disk) will be done with a threadpool, whose
+        // handle is held by the this thread (the main one).
         let (s, r) = oneshot::channel();
-        self.background(Task::GetEmbeddedCover(uri, s), r).await
+        match self.background(Task::GetEmbeddedCover(uri, s), r).await {
+            Err(e) => Err(e),
+            Ok(None) => Ok(None),
+            Ok(Some(handle)) => {
+                match handle {
+                    ImageHandle::Registered(bundle) => Ok(Some(bundle)),
+                    ImageHandle::New(bytes, key) => {
+                        // process in threadpool
+                        self.pool
+                            .push_future(move || {
+                                Ok(utils::save_and_register_image(
+                                    image::load_from_memory(&bytes)?,
+                                    &key,
+                                    None,
+                                ))
+                            })
+                            .expect("get_embedded_cover: threadpool error")
+                            .await
+                            .expect("get_embedded_cover: threadpool error")
+                            .map_err(ClientError::Image)
+                            .map(Some)
+                    }
+                }
+            }
+        }
     }
 
     pub async fn get_folder_cover(
@@ -792,8 +823,34 @@ impl MpdWrapper {
         example_uri: String,
     ) -> ClientResult<Option<utils::RegisteredImageBundle>> {
         let (s, r) = oneshot::channel();
-        self.background(Task::GetFolderCover(example_uri, s), r)
+        match self
+            .background(Task::GetFolderCover(example_uri, s), r)
             .await
+        {
+            Err(e) => Err(e),
+            Ok(None) => Ok(None),
+            Ok(Some(handle)) => {
+                match handle {
+                    ImageHandle::Registered(bundle) => Ok(Some(bundle)),
+                    ImageHandle::New(bytes, key) => {
+                        // process in threadpool
+                        self.pool
+                            .push_future(move || {
+                                Ok(utils::save_and_register_image(
+                                    image::load_from_memory(&bytes)?,
+                                    &key,
+                                    None,
+                                ))
+                            })
+                            .expect("get_folder_cover: threadpool error")
+                            .await
+                            .expect("get_folder_cover: threadpool error")
+                            .map_err(ClientError::Image)
+                            .map(Some)
+                    }
+                }
+            }
+        }
     }
 
     pub async fn get_albums_by_query<F>(

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -881,34 +881,45 @@ impl MpdWrapper {
                 r,
             )
             .await?;
+        let mut titles_artists = Vec::new();
+        // let mut queries = Vec::new();
+        // Construct queries all at once. Each query fetches one song from one album.
         for (key, tags) in grouped_vals.groups.into_iter() {
-            for tag in tags.iter() {
+            for tag in tags.into_iter() {
+                titles_artists.push((tag, key.clone()));
+            }
+        }
+        // Chunk the queries
+        for ta_chunk in titles_artists.chunks(128) {
+            let queries_windows: Vec<(Query, mpd::search::Window)> = ta_chunk.iter().map(|title_artist| {
                 let mut query = Query::new();
-                query.and(Term::Tag(Cow::Borrowed("album")), tag.to_string());
-                query.and(Term::Tag(Cow::Borrowed("albumartist")), key.to_string());
-                let (s, r) = oneshot::channel();
-                let mut songs = self
-                    .foreground(Task::Find(query, Window::from((0, 1)), s), r)
-                    .await?;
-                if !songs.is_empty() {
-                    if let Some(album_info) = std::mem::take(&mut songs[0]).into_album_info() {
-                        let res: Album = album_info.into();
-                        let (s, r) = oneshot::channel();
-                        // Optionally fetch album stickers
-                        if let Ok(stickers) = self
-                            .foreground(
-                                Task::GetKnownStickers("album", res.get_title().to_owned(), s),
-                                r,
-                            )
-                            .await
-                        {
-                            res.set_stickers(stickers);
-                        }
-                        respond(res);
+                query.and(Term::Tag(Cow::Borrowed("album")), title_artist.0.to_string());
+                query.and(Term::Tag(Cow::Borrowed("albumartist")), title_artist.1.to_string());
+                (query, mpd::search::Window::from((0, 1)))
+            }).collect();
+            let (s, r) = oneshot::channel();
+            let mut songs = dbg!(self
+                .foreground(Task::FindMultiple(queries_windows, Some(vec![
+                    "album", "albumartist", "albumsort", "albumartistsort", "musicbrainz_albumid"
+                ]), s), r)
+                .await?);
+            for i in (0 .. songs.len()) {
+                // Insert our local album & albumartist tags
+                if let Some(album_info) = std::mem::take(&mut songs[i]).into_album_info() {
+                    let res: Album = album_info.into();
+                    let (s, r) = oneshot::channel();
+                    // Optionally fetch album stickers
+                    // TODO: BATCH STICKERS FETCH TOO
+                    if let Ok(stickers) = self
+                        .foreground(
+                            Task::GetKnownStickers("album", res.get_title().to_owned(), s),
+                            r,
+                        )
+                        .await
+                    {
+                        res.set_stickers(stickers);
                     }
-                    // else {
-                    //     println!("No album info found for {tag}");
-                    // }
+                    respond(res);
                 }
             }
         }

--- a/src/common/album.rs
+++ b/src/common/album.rs
@@ -285,6 +285,11 @@ impl Album {
         &self.imp().stickers
     }
 
+    /// Call this after mutating stickers to alert UI widgets
+    pub fn notify_stickers_changed(&self) {
+        self.notify("rating");
+    }
+
     pub fn set_stickers(&self, stickers: Stickers) {
         let _ = &self.imp().stickers.replace(stickers);
     }

--- a/src/common/song_row.rs
+++ b/src/common/song_row.rs
@@ -333,7 +333,7 @@ impl SongRow {
                 if let (Some(cache), Some(song)) = (this.imp().cache.get(), this.song()) {
                     let res = cache
                         .clone()
-                        .get_song_cover(song.get_info(), true, true)
+                        .get_song_cover(song.get_info(), true)
                         .await;
                     // Check again as row might have been bound to a different song
                     // while awaiting

--- a/src/gtk/preferences/library.ui
+++ b/src/gtk/preferences/library.ui
@@ -183,12 +183,27 @@
 						<property name="icon-name">view-refresh-symbolic</property>
 					</object>
 				</property>
-				<child>
-					<object class="AdwSwitchRow" id="store_lossless_images">
-						<property name="title" translatable="true">Store images as lossless</property>
-						<property name="subtitle" translatable="true">WebP supports both lossy and lossless. Lossless files are much larger but may look slightly better. Requires redownloading.</property>
-					</object>
-				</child>
+		<child>
+				<object class="AdwSpinRow" id="n_image_threads">
+					<property name="title" translatable="true">Image processing thread count</property>
+					<property name="subtitle" translatable="true">Number of threads used for parallel image processing (resizing, encoding, decoding). More threads does not always mean better performance. Requires restart to take effect.</property>
+					<property name="adjustment">
+						<object class="GtkAdjustment">
+							<property name="lower">1</property>
+							<property name="upper">24</property>
+							<property name="value">4</property>
+							<property name="page-increment">1</property>
+							<property name="step-increment">1</property>
+						</object>
+					</property>
+				</object>
+			</child>
+			<child>
+				<object class="AdwSwitchRow" id="store_lossless_images">
+					<property name="title" translatable="true">Store images as lossless</property>
+					<property name="subtitle" translatable="true">WebP supports both lossy and lossless. Lossless files are much larger but may look slightly better. Requires redownloading.</property>
+				</object>
+			</child>
 				<child>
 					<object class="AdwActionRow">
 						<property name="title" translatable="true">Maximum resolution</property>

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -48,7 +48,7 @@
         <child>
           <object class="AdwSwitchRow" id="use_hires_for_album_cells">
             <property name="title" translatable="true">Use high-resolution textures for album cells</property>
-            <property name="subtitle" translatable="true">Increases VRAM usage.</property>
+            <property name="subtitle" translatable="true">Increases VRAM usage. Thumbnails will still be loaded first when system is under load.</property>
           </object>
         </child>
         <child>

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -491,7 +491,7 @@ impl AlbumCell {
                             }
                             Err(e) => {
                                 this.imp().cover.clear();
-                                dbg!(e);
+                                eprintln!("Failed to read cover for album `{}` (URI `{}`):\n{:?}", album.get_title(), album.get_folder_uri(), e);
                             }
                         }
                     }

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use crate::{
+    window::EuphonicaWindow,
     cache::{
         Cache, CacheState,
         placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
@@ -58,9 +59,12 @@ mod imp {
         pub cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
         pub cache: OnceCell<Rc<Cache>>,
         pub hires: Cell<bool>,
-        // Stored GridView for visibility checks in bind() and the tick callback.
+        // Stored GridView for visibility checks in bind() and the signal handler.
         pub viewport: OnceCell<WeakRef<gtk::GridView>>,
-        pub tick_callback: RefCell<Option<gtk::TickCallbackId>>,
+        // Weak reference to the window for connecting to the check-visible signal.
+        pub window: WeakRef<EuphonicaWindow>,
+        // Signal handler ID for disconnecting from the window's check-visible signal.
+        pub check_visible_handler: RefCell<Option<SignalHandlerId>>,
         // Tracks whether the cell is currently within the viewport, used
         // to detect visibility transitions (entering/exiting the viewport).
         pub should_load_texture: Cell<bool>,
@@ -92,8 +96,8 @@ mod imp {
                 child.unparent();
             }
 
-            if let Some(tick_callback) = self.tick_callback.take() {
-                tick_callback.remove();
+            if let Some(handler) = self.check_visible_handler.take() {
+                self.obj().disconnect(handler);
             }
 
             if let Some((update_id, clear_id)) = self.cover_signal_ids.take() {
@@ -256,6 +260,7 @@ impl AlbumCell {
         item: &gtk::ListItem,
         cache: Rc<Cache>,
         wrap_mode: Option<MarqueeWrapMode>,
+        window: Option<crate::window::EuphonicaWindow>,
         viewport: Option<gtk::GridView>,
     ) -> Self {
         let res: Self = Object::builder().build();
@@ -384,34 +389,45 @@ impl AlbumCell {
             let weak_vp = WeakRef::new();
             weak_vp.set(Some(&vp));
             let _ = res.imp().viewport.set(weak_vp);
-            let _ = res.imp().tick_callback.replace(Some(res.add_tick_callback(
-                move |this, _frameclock| {
-                    let imp = this.imp();
-                    let is_visible = this.should_load_texture();
-                    let was_visible = imp.should_load_texture.replace(is_visible);
+        }
 
-                    if was_visible != is_visible {
-                        if is_visible {
-                            // println!("AlbumCell is now visible");
-                            if imp.album.upgrade().is_some() {
-                                glib::idle_add_local_once(clone!(
-                                    #[weak]
-                                    this,
-                                    move || {
-                                        this.update_cover();
-                                    }
-                                ));
+        // Store weak reference to the window for signal connection.
+        res.imp().window.set(window.as_ref());
+
+        // Connect to the window's check-visible signal for visibility checks.
+        if let Some(window) = window {
+            let handler = window.connect_closure(
+                "check-visible",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    res,
+                    move |_: &EuphonicaWindow| {
+                        let imp = this.imp();
+                        let is_visible = this.should_load_texture();
+                        let was_visible = imp.should_load_texture.replace(is_visible);
+
+                        if was_visible != is_visible {
+                            if is_visible {
+                                if imp.album.upgrade().is_some() {
+                                    glib::idle_add_local_once(clone!(
+                                        #[weak]
+                                        this,
+                                        move || {
+                                            this.update_cover();
+                                        }
+                                    ));
+                                }
+                            } else {
+                                imp.cover.clear();
                             }
-                        } else {
-                            // println!("AlbumCell scrolled out of view");
-                            imp.cover.clear();
                         }
                     }
-
-                    glib::ControlFlow::Continue
-                },
-            )));
+                ),
+            );
+            res.imp().check_visible_handler.replace(Some(handler));
         }
+
         res.imp().obj_ready.set(true);
 
         res

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -16,10 +16,8 @@ use std::{
 
 use crate::{
     window::EuphonicaWindow,
-    cache::{
-        Cache, CacheState,
-        placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
-    },
+    cache::{BACKLOG_THRESHOLD, Cache, CacheState},
+    cache::placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
     common::{
         Album, PictureStack, Rating,
         marquee::{Marquee, MarqueeWrapMode},
@@ -71,6 +69,9 @@ mod imp {
         // Use this to block loading images immediately upon construction when hires
         // is set to true (as that would trigger the setter before a viewport is set)
         pub obj_ready: Cell<bool>,
+        // Set to true when hires was deferred due to high backlog; triggers an
+        // upgrade to hires once the backlog drops below the threshold.
+        pub deferred_hires: Cell<bool>,
     }
 
     // The central trait for subclassing a GObject
@@ -407,20 +408,22 @@ impl AlbumCell {
                         let is_visible = this.should_load_texture();
                         let was_visible = imp.should_load_texture.replace(is_visible);
 
-                        if was_visible != is_visible {
-                            if is_visible {
+                        if is_visible {
+                            if was_visible != is_visible {
                                 if imp.album.upgrade().is_some() {
                                     glib::idle_add_local_once(clone!(
                                         #[weak]
                                         this,
                                         move || {
-                                            this.update_cover();
+                                            this.update_cover(true);
                                         }
                                     ));
                                 }
-                            } else {
-                                imp.cover.clear();
+                            } else if imp.deferred_hires.get() {
+                                this.try_upgrade_hires();
                             }
+                        } else if was_visible != is_visible {
+                            imp.cover.clear();
                         }
                     }
                 ),
@@ -437,8 +440,24 @@ impl AlbumCell {
         self.imp().album.upgrade()
     }
 
-    fn update_cover(&self) {
-        self.imp().cover.show_spinner();
+  fn update_cover(&self, show_spinner: bool) {
+        let imp = self.imp();
+
+        // If hires is requested, check backlog to decide resolution.
+        if imp.hires.get() {
+            let backlog = imp.cache.get().unwrap().backlog();
+            if backlog >= *BACKLOG_THRESHOLD {
+                // Too many pending tasks; defer hires and load thumbnail instead.
+                imp.deferred_hires.set(true);
+            }
+        } else {
+            imp.deferred_hires.set(false);
+        }
+
+        let thumbnail_for_fetch = !imp.hires.get() || imp.deferred_hires.get();
+        if show_spinner {
+            imp.cover.show_spinner();
+        }
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -450,7 +469,7 @@ impl AlbumCell {
                         .get()
                         .unwrap()
                         .clone()
-                        .get_album_cover(album.get_info(), !this.imp().hires.get(), true)
+                        .get_album_cover(album.get_info(), thumbnail_for_fetch)
                         .await;
                     // Check again as cell might have been bound to a different album
                     // while awaiting
@@ -470,12 +489,20 @@ impl AlbumCell {
                             }
                         }
                     }
-                    // else {
-                    //     println!("AlbumCell now bound to a different album, ignoring texture");
-                    // }
                 }
             }
         ));
+    }
+
+    fn try_upgrade_hires(&self) {
+        let imp = self.imp();
+        if imp.deferred_hires.get() && self.should_load_texture() {
+            let backlog = imp.cache.get().unwrap().backlog();
+            if backlog < *BACKLOG_THRESHOLD {
+                imp.deferred_hires.set(false);
+                self.update_cover(false);
+            }
+        }
     }
 
     fn should_load_texture(&self) -> bool {
@@ -518,14 +545,16 @@ impl AlbumCell {
 
     pub fn bind(&self, album: &Album) {
         self.imp().album.set(Some(album));
+        self.imp().deferred_hires.set(false);
         if self.should_load_texture() {
-            self.update_cover();
+            self.update_cover(true);
         }
     }
 
     pub fn unbind(&self) {
         self.imp().cover.clear();
         self.imp().album.set(None);
+        self.imp().deferred_hires.set(false);
     }
 
     pub fn image_size(&self) -> i32 {
@@ -548,8 +577,13 @@ impl AlbumCell {
         if old != new {
             self.imp().cover.set_is_thumbnail(!new);
             self.notify("hires");
-            if self.should_load_texture() {
-                self.update_cover();
+            if new {
+                self.imp().deferred_hires.set(false);
+          if self.should_load_texture() {
+                    self.update_cover(true);
+                }
+            } else {
+                self.imp().deferred_hires.set(false);
             }
         }
     }

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -96,8 +96,8 @@ mod imp {
                 child.unparent();
             }
 
-            if let Some(handler) = self.check_visible_handler.take() {
-                self.obj().disconnect(handler);
+            if let (Some(handler), Some(window)) = (self.check_visible_handler.take(), self.window.upgrade()) {
+                window.disconnect(handler);
             }
 
             if let Some((update_id, clear_id)) = self.cover_signal_ids.take() {

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -27,7 +27,7 @@ use crate::{
 
 // As soon as a cell comes within this close of the render area, treat it as
 // visible & load album art early to avoid showing loading spinners.
-static WING_DEPTH: f64 = 384.0;
+static WING_DEPTH: f64 = 512.0;
 
 mod imp {
     use super::*;
@@ -69,6 +69,9 @@ mod imp {
         // Use this to block loading images immediately upon construction when hires
         // is set to true (as that would trigger the setter before a viewport is set)
         pub obj_ready: Cell<bool>,
+        // Set to true when the bind-time visibility check was skipped due to 
+        // backpressure.
+        pub deferred: Cell<bool>,
         // Set to true when hires was deferred due to high backlog; triggers an
         // upgrade to hires once the backlog drops below the threshold.
         pub deferred_hires: Cell<bool>,
@@ -409,7 +412,10 @@ impl AlbumCell {
                         let was_visible = imp.should_load_texture.replace(is_visible);
 
                         if is_visible {
-                            if was_visible != is_visible {
+                            // Also go through this if visibility status didn't change, 
+                            // but album art load hasn't been attempted yet.
+                            if was_visible != is_visible || imp.deferred.get() {
+                                imp.deferred.set(false);
                                 if imp.album.upgrade().is_some() {
                                     glib::idle_add_local_once(clone!(
                                         #[weak]
@@ -544,16 +550,26 @@ impl AlbumCell {
     }
 
     pub fn bind(&self, album: &Album) {
-        self.imp().album.set(Some(album));
-        self.imp().deferred_hires.set(false);
-        if self.should_load_texture() {
-            self.update_cover(true);
+        let imp = self.imp();
+        imp.album.set(Some(album));
+        imp.deferred.set(false);
+        imp.deferred_hires.set(false);
+        // Only check this eagerly if backpressure is low
+        let backlog = imp.cache.get().unwrap().backlog();
+        if backlog < *BACKLOG_THRESHOLD {
+            if self.should_load_texture() {
+                self.update_cover(true);
+            }
+        } else {
+            imp.deferred.set(true);
         }
+        
     }
 
     pub fn unbind(&self) {
         self.imp().cover.clear();
         self.imp().album.set(None);
+        self.imp().deferred.set(false);
         self.imp().deferred_hires.set(false);
     }
 

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -804,7 +804,7 @@ impl AlbumContentView {
                     self.show_cache_error("Couldn't clear cover", e);
                 }
             }
-            match cache.get_album_cover(info, false, true).await {
+            match cache.get_album_cover(info, false).await {
                 Ok(Some(tex)) => {
                     self.update_cover(tex);
                 }

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -592,6 +592,7 @@ impl LazyInit for AlbumView {
                 let this = self.clone();
                 stack.show_spinner();
                 glib::spawn_future_local(async move {
+                    // Just get basic info first to reduce spinner time
                     let _ = library.init_albums().await;
                     if library.albums().n_items() > 0 {
                         stack.show_content();
@@ -599,6 +600,8 @@ impl LazyInit for AlbumView {
                         stack.show_placeholder();
                     }
                     this.imp().initializing.set(false);
+                    // Now populate the stickers
+                    let _ = library.init_album_stickers();
                 });
             }
         }

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -6,7 +6,7 @@ use gtk::{
     glib::{self},
     glib::{Properties, SignalHandlerId, WeakRef, clone, subclass::Signal},
 };
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::{cell::Cell, cmp::Ordering, rc::Rc, sync::OnceLock};
 
 use super::{AlbumCell, AlbumContentView, Library};
@@ -73,6 +73,7 @@ mod imp {
         pub collapsed: Cell<bool>,
 
         pub initializing: Cell<bool>,
+        pub window: OnceCell<WeakRef<EuphonicaWindow>>,
     }
 
     #[glib::object_subclass]
@@ -438,7 +439,13 @@ impl AlbumView {
         window: &EuphonicaWindow,
     ) {
         self.imp().library.set(Some(library));
-        self.setup_gridview(cache.clone());
+        let weak = WeakRef::new();
+        weak.set(Some(window));
+        self.imp()
+            .window
+            .set(weak)
+            .expect("AlbumView window already set");
+        self.setup_gridview(cache.clone(), window);
 
         let content_view = self.imp().content_view.get();
         content_view.setup(library, client_state, cache, window);
@@ -468,7 +475,7 @@ impl AlbumView {
         }
     }
 
-    fn setup_gridview(&self, cache: Rc<Cache>) {
+    fn setup_gridview(&self, cache: Rc<Cache>, window: &EuphonicaWindow) {
         let settings = settings_manager().child("ui");
         // Setup search bar
         let album_list = self.imp().library.upgrade().unwrap().albums();
@@ -508,11 +515,13 @@ impl AlbumView {
             cache,
             #[weak]
             grid_view,
+            #[weak]
+            window,
             move |_, list_item| {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
-                let album_cell = AlbumCell::new(item, cache, None, Some(grid_view));
+                let album_cell = AlbumCell::new(item, cache, None, Some(window.clone()), Some(grid_view));
                 item.set_child(Some(&album_cell));
             }
         ));

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -601,7 +601,7 @@ impl LazyInit for AlbumView {
                     }
                     this.imp().initializing.set(false);
                     // Now populate the stickers
-                    let _ = library.init_album_stickers();
+                    let _ = library.init_album_stickers().await;
                 });
             }
         }

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -641,9 +641,10 @@ impl ArtistContentView {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
-                // TODO: refactor album cells to use expressions too
+               // TODO: refactor album cells to use expressions too
                 let album_subview = this.imp().album_subview.get();
-                let album_cell = AlbumCell::new(item, cache, None, Some(album_subview));
+                let window = this.imp().window.upgrade();
+                let album_cell = AlbumCell::new(item, cache, None, window, Some(album_subview));
                 item.set_child(Some(&album_cell));
             }
         ));

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -618,17 +618,35 @@ impl Library {
         Ok(())
     }
 
+    /// Fetch basic info for all albums to display them in a grid.
+    /// Note: this function no longer fetches stickers s.t. we can return the grid to the user earlier.
     pub async fn init_albums(&self) -> ClientResult<()> {
         if !self.imp().albums_initialized.get() {
             self.imp().albums_initialized.set(true);
             let model = self.imp().albums.clone();
             model.remove_all();
-
             self.client()
                 .get_albums_by_query(Query::new(), &mut |album| {
                     model.append(&album);
                 })
                 .await?;
+        }
+        Ok(())
+    }
+
+    /// Fetch known album stickers for those discovered by init_albums.
+    pub async fn init_album_stickers(&self) -> ClientResult<()> {
+        if self.imp().albums_initialized.get() {
+            for album in self.imp().albums.iter::<Album>() {
+                // Right now the only sticker we use is album rating
+                let album = album.unwrap();
+                let rating_str = self.client().get_sticker("album", album.get_title().into(), "rating".into()).await?;
+                let mut stickers = album.get_stickers().borrow_mut();
+                stickers.set_rating(&rating_str);
+            }
+        }
+        else {
+            eprintln!("WARNING: init_album_stickers called before init_albums. This is a no-op.");
         }
         Ok(())
     }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -640,9 +640,14 @@ impl Library {
             for album in self.imp().albums.iter::<Album>() {
                 // Right now the only sticker we use is album rating
                 let album = album.unwrap();
-                let rating_str = self.client().get_sticker("album", album.get_title().into(), "rating".into()).await?;
-                let mut stickers = album.get_stickers().borrow_mut();
-                stickers.set_rating(&rating_str);
+                if let Ok(rating_str) = self.client().get_sticker("album", album.get_title().into(), "rating".into()).await {
+                    {
+                        let mut stickers = album.get_stickers().borrow_mut();
+                        stickers.set_rating(&rating_str);
+                        // End borrow
+                    }
+                    album.notify_stickers_changed();
+                }
             }
         }
         else {

--- a/src/library/recent_view.rs
+++ b/src/library/recent_view.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::cell::OnceCell;
 use std::rc::Rc;
 use std::{cell::Cell, sync::OnceLock};
 
@@ -69,8 +70,9 @@ mod imp {
         pub player: WeakRef<Player>,
         pub history_changed_id: RefCell<Option<SignalHandlerId>>,
 
-        #[property(get, set)]
+       #[property(get, set)]
         pub collapsed: Cell<bool>,
+        pub window: OnceCell<WeakRef<EuphonicaWindow>>,
     }
 
     #[glib::object_subclass]
@@ -222,7 +224,7 @@ impl RecentView {
         res
     }
 
-    pub fn setup(
+   pub fn setup(
         &self,
         library: &Library,
         player: &Player,
@@ -231,6 +233,12 @@ impl RecentView {
     ) {
         self.imp().library.set(Some(library));
         self.imp().player.set(Some(player));
+        let weak = WeakRef::new();
+        weak.set(Some(window));
+        self.imp()
+            .window
+            .set(weak)
+            .expect("RecentView window already set");
 
         self.imp()
             .history_changed_id
@@ -293,11 +301,13 @@ impl RecentView {
         // Reset scroll position to zero every time a new item is created such that
         // upon startup or insertion of a new just-listened album we'll be at the
         // start of the row.
-        factory.connect_setup(clone!(
+       factory.connect_setup(clone!(
             #[weak]
             cache,
             #[weak]
             adj,
+            #[weak]
+            window,
             #[weak(rename_to = this)]
             self,
             move |_, list_item| {
@@ -305,8 +315,13 @@ impl RecentView {
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
                 let album_row = this.imp().album_row.get();
-                let album_cell =
-                    AlbumCell::new(item, cache, Some(MarqueeWrapMode::Scroll), Some(album_row));
+                let album_cell = AlbumCell::new(
+                    item,
+                    cache,
+                    Some(MarqueeWrapMode::Scroll),
+                    Some(window.clone()),
+                    Some(album_row),
+                );
                 // propagating the tallest cell's height to the revealer if said row wasn't
                 // the first initialised.
                 item.set_child(Some(&album_cell));

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -259,7 +259,7 @@ impl PlayerBar {
             async move {
                 if let Some(song) = song {
                     this.imp().albumart.show_spinner();
-                    match cache.get_song_cover(song.get_info(), true, true).await {
+                    match cache.get_song_cover(song.get_info(), true).await {
                         Ok(Some(tex)) => this.imp().albumart.show(&tex),
                         Ok(None) => this.imp().albumart.clear(),
                         Err(e) => {

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -646,7 +646,7 @@ impl PlayerPane {
             async move {
                 if let Some(song) = song {
                     this.imp().albumart.show_spinner();
-                    match cache.get_song_cover(song.get_info(), false, true).await {
+                    match cache.get_song_cover(song.get_info(), false).await {
                         Ok(Some(tex)) => this.imp().albumart.show(&tex),
                         Ok(None) => this.imp().albumart.clear(),
                         Err(e) => {

--- a/src/preferences/library.rs
+++ b/src/preferences/library.rs
@@ -47,10 +47,12 @@ mod imp {
         #[template_child]
         pub refresh_cache_stats_btn: TemplateChild<gtk::Button>,
 
-        #[template_child]
-        pub store_lossless_images: TemplateChild<adw::SwitchRow>,
-        #[template_child]
-        pub max_image_resolution: TemplateChild<gtk::Scale>,
+	#[template_child]
+		pub n_image_threads: TemplateChild<adw::SpinRow>,
+		#[template_child]
+		pub store_lossless_images: TemplateChild<adw::SwitchRow>,
+		#[template_child]
+		pub max_image_resolution: TemplateChild<gtk::Scale>,
         #[template_child]
         pub clear_cache_row: TemplateChild<adw::ActionRow>,
         #[template_child]
@@ -142,10 +144,14 @@ impl LibraryPreferences {
             .bind("pause-recent", &imp.pause_recent.get(), "active")
             .build();
 
-        // Image cache settings
-        library_settings
-            .bind("store-lossless-images", &imp.store_lossless_images.get(), "active")
-            .build();
+	// Image processing settings
+		library_settings
+			.bind("n-image-threads", &imp.n_image_threads.get(), "value")
+			.build();
+
+		library_settings
+			.bind("store-lossless-images", &imp.store_lossless_images.get(), "active")
+			.build();
 
         let max_res = imp.max_image_resolution.get();
         library_settings

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,11 +270,6 @@ pub fn save_and_register_single_image(
         let webp: webp::WebPMemory = encoder.encode(90.0);
         std::fs::write(&path, &*webp).unwrap();
     }
-    
-    
-
-    
-
     sqlite::register_image_key(key, prefix, Some(&name), is_thumb).expect("Sqlite error");
 
     name

--- a/src/window.rs
+++ b/src/window.rs
@@ -260,7 +260,7 @@ mod imp {
         pub accent_color: RefCell<Option<RGB>>,
         pub should_populate_visible: Cell<bool>,
 
-        // Single async loop that emits "check-visible" every 500ms to drive
+        // Single async loop that emits "check-visible" periodically to drive
         // visibility checks for all AlbumCell instances
         pub check_visible_loop: RefCell<Option<glib::JoinHandle<()>>>,
 
@@ -358,13 +358,13 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            // Spawn a single async loop that emits "check-visible" every 500ms.
+            // Spawn a single async loop that emits "check-visible" periodically.
             // All AlbumCell instances connect to this signal for visibility checks,
             // replacing the old per-cell tick callback approach.
             let win = self.obj().clone();
             *self.check_visible_loop.borrow_mut() = Some(glib::spawn_future_local(async move {
                 loop {
-                    glib::timeout_future(Duration::from_millis(500)).await;
+                    glib::timeout_future(Duration::from_millis(50)).await;
                     win.emit_by_name::<()>("check-visible", &[]);
                 }
             }));

--- a/src/window.rs
+++ b/src/window.rs
@@ -36,7 +36,7 @@ use glib::WeakRef;
 use gtk::{
     CssProvider, cairo, gdk,
     gio::{self, SimpleActionGroup},
-    glib::{self, BoxedAnyObject, SignalHandlerId, clone, closure_local},
+    glib::{self, BoxedAnyObject, SignalHandlerId, clone, closure_local, subclass::Signal},
     graphene, gsk,
 };
 use image::{DynamicImage, imageops::FilterType};
@@ -45,7 +45,7 @@ use mpd::Subsystem;
 use std::{cell::RefCell, ops::Deref, path::PathBuf, thread, time::Duration};
 use std::{
     cell::{Cell, OnceCell},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use async_channel::Sender;
@@ -260,6 +260,10 @@ mod imp {
         pub accent_color: RefCell<Option<RGB>>,
         pub should_populate_visible: Cell<bool>,
 
+        // Single async loop that emits "check-visible" every 500ms to drive
+        // visibility checks for all AlbumCell instances
+        pub check_visible_loop: RefCell<Option<glib::JoinHandle<()>>>,
+
         pub provider: CssProvider,
         pub client_state: OnceCell<ClientState>,
 
@@ -298,6 +302,13 @@ mod imp {
 
     #[glib::derived_properties]
     impl ObjectImpl for EuphonicaWindow {
+        fn signals() -> &'static [glib::subclass::Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("check-visible").build()]
+            })
+        }
+
         fn dispose(&self) {
             // Disconnect all signal handlers registered on global/long-lived objects
             if let Some(id) = self.settings_bg_blur_id.take() {
@@ -334,6 +345,9 @@ mod imp {
                 }
             }
 
+            // Cancel the check-visible signal loop
+            self.check_visible_loop.take();
+
             // Remove display-level CSS provider
             if let Some(display) = gdk::Display::default() {
                 let provider = &self.provider;
@@ -343,6 +357,18 @@ mod imp {
 
         fn constructed(&self) {
             self.parent_constructed();
+
+            // Spawn a single async loop that emits "check-visible" every 500ms.
+            // All AlbumCell instances connect to this signal for visibility checks,
+            // replacing the old per-cell tick callback approach.
+            let win = self.obj().clone();
+            *self.check_visible_loop.borrow_mut() = Some(glib::spawn_future_local(async move {
+                loop {
+                    glib::timeout_future(Duration::from_millis(500)).await;
+                    win.emit_by_name::<()>("check-visible", &[]);
+                }
+            }));
+
             let settings = settings_manager().child("ui");
             let obj_borrow = self.obj();
             let obj = obj_borrow.as_ref();


### PR DESCRIPTION
Refactors this PR brings:

# Album & Artist Grid init speedup

TL;DR: if you run MPD on a remote server with a big library and have been waiting for >1min for the Album View to stop showing the giant spinner, you're in luck. I've sped it up to the point a 3,000-album test library takes ~3s to show up as the grid.

To display each album in the grid, we need to fetch its first track from MPD (to get things like albumartist, example URI for albumart, audio quality, etc). Previously Euphonica would send, per album, one `find` command that would resolve to all information about a single track, then one `stickers` command that would then fetch all of its stickers. For the above example, that meant 6,000 commands having to be sent and responded to.

This PR (and a new commit to my fork of `rust-mpd`) enabled multiple `find` commands to be executed in a command list. By batching 256 `find`s into one call, we massively reduced latency and improved network bandwidth utilisation at the same time.

Stickers, however, can't be batched that way (as not every album has a rating sticker, and querying the sticker for such an album would be an error and would halt the whole command list). I've instead deferred the stickers fetching, such that we'll now fetch the basic info first, display the grid, THEN fetch the stickers to fill in later.

The same optimisation has been applied to the Artist View too with similarly great uplifts.

# Multi-core texture handling

Upon downloading an image, Euphonica must transcode it to RGB8 and perform 2 resizes to a hi-res version and a thumbnail version. On later reads from disk, each compressed file must also be decoded before going into VRAM. This is currently queued on a single CPU core. While this doesn't block the main UI thread, it causes other background tasks to backlog, so everything else takes more time to load.

This PR parallelises such operations using `glib::ThreadPool`s. The threadpool size is configurable in the UI and defaults to 4, though if you have more CPU cores/threads it might be worth trying higher values.

This should somewhat speedup cold-start population of textures, as the population speed should now be solely bounded by your download speed and not single-core performance.

Note that external download operations, including from your MPD server, are still sequential to avoid clogging the server and/or getting banned.

# Smarter visibility checks & LOD-like resolution progression

Viz check frequency has been reduced to every 50ms (~20fps), and all viz checks are now synchronised to a central clock.

When there is a >=10-task backlog in the background queue and if high-resolution album grid is enabled (by default), we'll fall back to thumbnails. Once said backlog is cleared, album cells currently visible on screen will then attempt to upgrade to high-resolution arts. Those once loaded at thumbnail resolution but no longer on screen (i.e. scrolled past) won't be upgraded. In other words, this reduces the number of high-resolution album arts having to be loaded with zero visual impact.

This enables textures to more quickly fill the album grid for already-downloaded cases.