### PR TITLE
Add a toggle to view only album artists in Artist view

### DIFF
--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -387,7 +387,12 @@
 		<key name="sort-direction" enum='io.github.htkhiem.Euphonica.sortdir'>
 			<default>'asc'</default>
 			<summary>Artist View sort direction</summary>
-		</key>
+        </key>
+
+        <key name="album-artists-only" type="b">
+            <default>false</default>
+            <summary>Show only album artists</summary>
+        </key>
 	</schema>
 
 	<schema id="io.github.htkhiem.Euphonica.state.folderview" path="/io/github/htkhiem/Euphonica/state/folderview/">

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1007,7 +1007,7 @@ impl MpdWrapper {
             tags::ARTIST
         };
         let tagtypes_to_load = if use_album_artist {
-            vec![tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUMARTIST_MBID]
+            vec![tags::ALBUMARTIST, tags::ALBUMARTISTSORT, tags::ALBUMARTIST_MBID, tags::ALBUM]
         } else {
             vec![tags::ARTIST, tags::ARTISTSORT, tags::ARTIST_MBID]
         };
@@ -1030,7 +1030,16 @@ impl MpdWrapper {
                 .foreground(Task::FindMultiple(queries_windows, Some(tagtypes_to_load.clone()), s), r)
                 .await?;
             for i in (0..songs.len()) {
-                let artists = std::mem::take(&mut songs[i]).into_artist_infos();
+                let song = &mut songs[i];
+                // if we're getting album artists we need to long at song.album.artists
+                // instead of just song.artists
+                let artists = if use_album_artist {
+                    song.album.as_ref()
+                        .map(|a| a.artists.clone())
+                        .unwrap_or_default()
+                } else {
+                    std::mem::take(&mut song.artists)
+                };
                 for artist in artists.into_iter() {
                     if already_parsed.insert(artist.get_comp_id().to_owned()) {
                         respond(artist.into());

--- a/src/gtk/library/artist-view.ui
+++ b/src/gtk/library/artist-view.ui
@@ -10,7 +10,7 @@
             <child>
               <object class="AdwToolbarView">
                 <child type="top">
-					        <object class="AdwHeaderBar">
+					<object class="AdwHeaderBar">
                     <property name="show-title">false</property>
                     <child type="start">
                       <object class="GtkButton" id="show_sidebar">
@@ -22,6 +22,15 @@
                     <child type="end">
                       <object class="GtkToggleButton" id="search_btn">
                         <property name="icon-name">edit-find-symbolic</property>
+                      </object>
+                    </child>
+                    <child type="end">
+                      <object class="GtkToggleButton" id="album_artist_only_btn">
+                        <property name="icon-name">avatar-default-symbolic</property>
+                        <property name="tooltip-text" translatable="true">Show only album artists</property>
+                        <style>
+                            <class name="flat"/>
+                        </style>
                       </object>
                     </child>
                     <child type="end">
@@ -45,7 +54,7 @@
                           </object>
                         </child>
                       </object>
-                    </child>
+                  </child>
                   </object>
                 </child>
                 <child type="top">
@@ -66,7 +75,7 @@
                       </object>
                     </property>
                     <property name="content">
-                      <object class="GtkScrolledWindow">
+                      <object class="GtkScrolledWindow" id="scrolled_window">
                         <property name="hscrollbar-policy">never</property>
                         <property name="vscrollbar-policy">automatic</property>
                         <property name="propagate-natural-height">true</property>

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -333,6 +333,9 @@ impl ArtistView {
                     library.artists()
                 };
                 this.imp().artist_source.set_model(Some(&model));
+                // todo: this makes the pane flash and scroll to the bottom.
+                // the only way to avoid this that I can think of is to return to the
+                // "single list containing artist + album artists", and then filter it
             })
         );
 

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -37,6 +37,8 @@ mod imp {
         pub search_bar: TemplateChild<gtk::SearchBar>,
         #[template_child]
         pub search_entry: TemplateChild<gtk::SearchEntry>,
+        #[template_child]
+        pub album_artist_only_btn: TemplateChild<gtk::ToggleButton>,
 
         // Content
         #[template_child]
@@ -47,10 +49,14 @@ mod imp {
         pub content_page: TemplateChild<adw::NavigationPage>,
         #[template_child]
         pub content_view: TemplateChild<ArtistContentView>,
+        #[template_child]
+        pub scrolled_window: TemplateChild<gtk::ScrolledWindow>,
 
         // Search & filter models
         pub search_filter: gtk::CustomFilter,
         pub sorter: gtk::CustomSorter,
+        // points to album artists or to artists
+        pub artist_source: gtk::FilterListModel,
         // Keep last length to optimise search
         // If search term is now longer, only further filter still-matching
         // items.
@@ -141,6 +147,7 @@ impl ArtistView {
         self.imp().library.set(Some(library));
         self.setup_sort();
         self.setup_search();
+        self.setup_album_artist();
         self.setup_gridview(cache.clone());
 
         let content_view = self.imp().content_view.get();
@@ -292,6 +299,45 @@ impl ArtistView {
         ));
     }
 
+    pub fn setup_album_artist(&self) {
+        // sync the state of the album_artist_only widget to our library state
+        let state = settings_manager().child("state").child("artistview");
+        let album_artist_only_btn = self.imp().album_artist_only_btn.get();
+        let filter_state = state.boolean("album-artists-only");
+        album_artist_only_btn.set_active(filter_state);
+
+        // set up initial state
+        let library = self.imp().library.upgrade().unwrap();
+        self.imp().artist_source.set_model(Some(&
+            if filter_state { 
+                library.album_artists()
+            } else {
+                library.artists()
+            }
+        ));
+
+        album_artist_only_btn.connect_toggled(clone!(
+            #[weak(rename_to = this)]
+            self,
+            move |btn| {
+                // update the ui when clicked
+                let use_album = btn.is_active();
+                let _ =  settings_manager()
+                        .child("state").child("artistview")
+                        .set_boolean("album-artists-only", use_album);
+                // and then update the artist_source model to point to the right ListStore
+                let library = this.imp().library.upgrade().unwrap();
+                let model = if use_album {
+                    library.album_artists()
+                } else {
+                    library.artists()
+                };
+                this.imp().artist_source.set_model(Some(&model));
+            })
+        );
+
+    }
+
     pub fn on_artist_clicked(&self, artist: &Artist) {
         // - Upon receiving click signal, get the list item at the indicated activate index.
         // - Extract artist from that list item.
@@ -329,7 +375,7 @@ impl ArtistView {
         // Refresh upon reconnection.
         // User-initiated refreshes will also trigger a reconnection, which will
         // in turn trigger this.
-        let artists = self.imp().library.upgrade().unwrap().artists();
+        let artists = self.imp().artist_source.clone();
 
         // Setup search bar
         let search_bar = self.imp().search_bar.get();
@@ -443,7 +489,9 @@ impl LazyInit for ArtistView {
                 let this = self.clone();
                 stack.show_spinner();
                 glib::spawn_future_local(async move {
-                    let _ = library.init_artists(false).await;
+                    let _ = library.init_artists().await;
+                    // artists is almost surely a superset of albumartists, so it suffices to see if
+                    // we've found artists only
                     if library.artists().n_items() > 0 {
                         stack.show_content();
                     } else {

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -44,6 +44,8 @@ mod imp {
         pub recent_albums: gio::ListStore,
         #[derivative(Default(value = "gio::ListStore::new::<Artist>()"))]
         pub artists: gio::ListStore,
+        #[derivative(Default(value = "gio::ListStore::new::<Artist>()"))]
+        pub album_artists: gio::ListStore,
         pub artists_initialized: Cell<bool>,
         #[derivative(Default(value = "gio::ListStore::new::<Artist>()"))]
         pub recent_artists: gio::ListStore,
@@ -442,6 +444,12 @@ impl Library {
         self.imp().artists.clone()
     }
 
+
+    /// Get a reference to the local album artists store
+    pub fn album_artists(&self) -> gio::ListStore {
+        self.imp().album_artists.clone()
+    }
+
     /// Get a reference to the local recent artists store
     pub fn recent_artists(&self) -> gio::ListStore {
         self.imp().recent_artists.clone()
@@ -633,17 +641,30 @@ impl Library {
         Ok(())
     }
 
-    pub async fn init_artists(&self, use_album_artist: bool) -> ClientResult<()> {
+    pub async fn init_artists(&self) -> ClientResult<()> {
         if !self.imp().artists_initialized.get() {
             self.imp().artists_initialized.set(true);
-            let model = self.imp().artists.clone();
-            model.remove_all();
+
+            // init the album artists list
+            let album_artist_model = self.imp().album_artists.clone();
+            album_artist_model.remove_all();
 
             self.client()
-                .get_artists(use_album_artist, &mut |artist| {
-                    model.append(&artist);
+                .get_artists(true, &mut |artist| {
+                    album_artist_model.append(&artist);
                 })
                 .await?;
+
+            // init the artists list
+            let artist_model = self.imp().artists.clone();
+            artist_model.remove_all();
+
+            self.client()
+                .get_artists(false, &mut |artist| {
+                    artist_model.append(&artist);
+                })
+                .await?;
+
         }
         Ok(())
     }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -678,6 +678,9 @@ impl Library {
                 })
                 .await?;
 
+            dbg!(album_artist_model.n_items());
+
+
             // init the artists list
             let artist_model = self.imp().artists.clone();
             artist_model.remove_all();
@@ -687,6 +690,8 @@ impl Library {
                     artist_model.append(&artist);
                 })
                 .await?;
+
+
 
         }
         Ok(())


### PR DESCRIPTION
This feature has been requested (#197) and without it, browsing a large library by artist is super messy and confusing.

The method that this PR uses is to collect both artists and album artists into the artists tab (and merging them if they have the same name), and marking which artists have at least one album. the settings toggle just hides the artists who don't have an album, at the UI level.