### PR TITLE
feat: add optional rotating album artwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target/
 build/
 src/config.rs
+data/gschemas.compiled

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -342,6 +342,15 @@
 		<key name="auto-accent" type='b'>
 			<default>true</default>
 		</key>
+		<key name="rotate-album-art" type='b'>
+			<default>false</default>
+			<summary>Show the player album art as a rotating disc</summary>
+		</key>
+		<key name="album-art-rotation-speed" type='d'>
+			<range min="0" max="2"/>
+			<default>1.0</default>
+			<summary>Album art rotation speed</summary>
+		</key>
 		<key name="title-wrap-mode" enum='io.github.htkhiem.Euphonica.titlewrapmode'>
 			<default>'ellipsis'</default>
 		</key>

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -346,6 +346,10 @@
 			<default>false</default>
 			<summary>Show the player album art as a rotating disc</summary>
 		</key>
+		<key name="return-to-starting-angle" type='b'>
+			<default>false</default>
+			<summary>Adjust rotation speed so tracks end at their starting angle</summary>
+		</key>
 		<key name="album-art-rotation-speed" type='d'>
 			<range min="0" max="2"/>
 			<default>1.0</default>

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -347,7 +347,7 @@
 			<summary>Show the player album art as a rotating disc</summary>
 		</key>
 		<key name="return-to-starting-angle" type='b'>
-			<default>false</default>
+			<default>true</default>
 			<summary>Adjust rotation speed so tracks end at their starting angle</summary>
 		</key>
 		<key name="album-art-rotation-speed" type='d'>

--- a/src/common/paintables/mod.rs
+++ b/src/common/paintables/mod.rs
@@ -1,2 +1,4 @@
 mod fade;
 pub use fade::FadePaintable;
+mod rotating;
+pub use rotating::RotatingPaintable;

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -1,0 +1,178 @@
+use gtk::{
+    gdk::{self, prelude::*, subclass::paintable::*},
+    glib, graphene, gsk,
+    prelude::*,
+    subclass::prelude::*,
+};
+use std::cell::{Cell, RefCell};
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct RotatingPaintable {
+        pub paintable: RefCell<Option<gdk::Paintable>>,
+        pub rotation: Cell<f64>,
+        pub circular: Cell<bool>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RotatingPaintable {
+        const NAME: &'static str = "EuphonicaRotatingPaintable";
+        type Type = super::RotatingPaintable;
+        type Interfaces = (gdk::Paintable,);
+    }
+
+    impl ObjectImpl for RotatingPaintable {
+        fn dispose(&self) {
+            self.paintable.borrow_mut().take();
+        }
+    }
+
+    impl PaintableImpl for RotatingPaintable {
+        fn current_image(&self) -> gdk::Paintable {
+            let current = super::RotatingPaintable::new();
+            if let Some(paintable) = self.paintable.borrow().as_ref() {
+                current.set_paintable(Some(&paintable.current_image()));
+            }
+            current.set_rotation(self.rotation.get());
+            current.set_circular(self.circular.get());
+            current.upcast()
+        }
+
+        fn intrinsic_width(&self) -> i32 {
+            self.intrinsic_size(|paintable| paintable.intrinsic_width())
+        }
+
+        fn intrinsic_height(&self) -> i32 {
+            self.intrinsic_size(|paintable| paintable.intrinsic_height())
+        }
+
+        fn intrinsic_aspect_ratio(&self) -> f64 {
+            if self.circular.get() {
+                1.0
+            } else {
+                self.paintable
+                    .borrow()
+                    .as_ref()
+                    .map_or(1.0, |paintable| paintable.intrinsic_aspect_ratio())
+            }
+        }
+
+        fn snapshot(&self, snapshot: &gdk::Snapshot, width: f64, height: f64) {
+            let paintable = self.paintable.borrow();
+            let Some(paintable) = paintable.as_ref() else {
+                return;
+            };
+
+            if !self.circular.get() {
+                paintable.snapshot(snapshot, width, height);
+                return;
+            }
+
+            // Inset the disc to prevent clipping
+            let diameter = width.min(height) * 0.96;
+            if diameter <= 0.0 {
+                return;
+            }
+
+            let bounds = graphene::Rect::new(
+                ((width - diameter) / 2.0) as f32,
+                ((height - diameter) / 2.0) as f32,
+                diameter as f32,
+                diameter as f32,
+            );
+            let clip = gsk::RoundedRect::from_rect(bounds, diameter as f32 / 2.0);
+            snapshot.push_rounded_clip(&clip);
+
+            snapshot.save();
+            let center = graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
+            snapshot.translate(&center);
+            snapshot.rotate(self.rotation.get() as f32);
+            snapshot.translate(&graphene::Point::new(-center.x(), -center.y()));
+
+            let source_ratio = paintable.intrinsic_aspect_ratio();
+            let (paint_width, paint_height) = if source_ratio.is_finite() && source_ratio > 0.0 {
+                if source_ratio >= 1.0 {
+                    (diameter * source_ratio, diameter)
+                } else {
+                    (diameter, diameter / source_ratio)
+                }
+            } else {
+                (diameter, diameter)
+            };
+            snapshot.translate(&graphene::Point::new(
+                ((width - paint_width) / 2.0) as f32,
+                ((height - paint_height) / 2.0) as f32,
+            ));
+            paintable.snapshot(snapshot, paint_width, paint_height);
+
+            snapshot.restore();
+            snapshot.pop();
+        }
+    }
+
+    impl RotatingPaintable {
+        fn intrinsic_size(&self, get: impl FnOnce(&gdk::Paintable) -> i32) -> i32 {
+            self.paintable.borrow().as_ref().map_or(1, |paintable| {
+                if self.circular.get() {
+                    let width = paintable.intrinsic_width();
+                    let height = paintable.intrinsic_height();
+                    match (width > 0, height > 0) {
+                        (true, true) => width.min(height),
+                        (true, false) => width,
+                        (false, true) => height,
+                        (false, false) => 1,
+                    }
+                } else {
+                    get(paintable)
+                }
+            })
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct RotatingPaintable(ObjectSubclass<imp::RotatingPaintable>) @implements gdk::Paintable;
+}
+
+impl RotatingPaintable {
+    pub fn new() -> Self {
+        glib::Object::new()
+    }
+
+    pub fn set_paintable(&self, paintable: Option<&impl IsA<gdk::Paintable>>) {
+        self.imp()
+            .paintable
+            .replace(paintable.map(|paintable| paintable.as_ref().clone()));
+        self.invalidate_size();
+        self.invalidate_contents();
+    }
+
+    pub fn rotation(&self) -> f64 {
+        self.imp().rotation.get()
+    }
+
+    pub fn set_rotation(&self, rotation: f64) {
+        if self.imp().rotation.replace(rotation) != rotation {
+            self.invalidate_contents();
+        }
+    }
+
+    pub fn is_circular(&self) -> bool {
+        self.imp().circular.get()
+    }
+
+    pub fn set_circular(&self, circular: bool) {
+        if self.imp().circular.replace(circular) != circular {
+            self.invalidate_size();
+            self.invalidate_contents();
+        }
+    }
+}
+
+impl Default for RotatingPaintable {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -15,10 +15,13 @@ mod imp {
     pub struct RotatingPaintable {
         pub paintable: RefCell<Option<gdk::Paintable>>,
         pub rotation: Cell<f64>,
+        pub duration: Cell<f64>,
         #[property(get, set = Self::set_circular)]
         pub circular: Cell<bool>,
         #[property(get, set)]
         pub degrees_per_second: Cell<f64>,
+        #[property(get, set)]
+        pub return_to_starting_angle: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -158,6 +161,21 @@ impl RotatingPaintable {
         self.imp().paintable.replace(paintable);
         self.invalidate_size();
         self.invalidate_contents();
+    }
+
+    pub fn set_duration(&self, duration: f64) {
+        self.imp().duration.set(duration);
+    }
+
+    pub fn rotation_speed(&self) -> f64 {
+        let speed = self.degrees_per_second();
+        let duration = self.imp().duration.get();
+        if self.return_to_starting_angle() && duration > 0.0 {
+            let rotations = (duration * speed / 360.0).round().max(1.0);
+            rotations * 360.0 / duration
+        } else {
+            speed
+        }
     }
 
     // Don't make property as it changes every frame

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -90,16 +90,15 @@ mod imp {
             let clip = gsk::RoundedRect::from_rect(bounds, diameter as f32 / 2.0);
             snapshot.push_rounded_clip(&clip);
 
-            let source_ratio = paintable.intrinsic_aspect_ratio();
-            let (paint_width, paint_height) = if source_ratio.is_finite() && source_ratio > 0.0 {
-                if source_ratio >= 1.0 {
-                    (diameter * source_ratio, diameter)
-                } else {
-                    (diameter, diameter / source_ratio)
-                }
-            } else {
-                (diameter, diameter)
+            // Scale the shorter side to fill the disc. The circular clip crops any overflow.
+            let source_ratio = match paintable.intrinsic_aspect_ratio() {
+                ratio if ratio.is_finite() && ratio > 0.0 => ratio,
+                _ => 1.0,
             };
+            let (paint_width, paint_height) = (
+                diameter * source_ratio.max(1.0),
+                diameter / source_ratio.min(1.0),
+            );
 
             let center = graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
             snapshot.translate(&center);
@@ -126,14 +125,11 @@ mod imp {
             self.paintable.borrow().as_ref().map_or(1, |paintable| {
                 if self.circular.get() {
                     // A zero width/height means that dimension is unavailable
-                    let width = paintable.intrinsic_width();
-                    let height = paintable.intrinsic_height();
-                    match (width > 0, height > 0) {
-                        (true, true) => width.min(height),
-                        (true, false) => width,
-                        (false, true) => height,
-                        (false, false) => 1,
-                    }
+                    [paintable.intrinsic_width(), paintable.intrinsic_height()]
+                        .into_iter()
+                        .filter(|dimension| *dimension > 0)
+                        .min()
+                        .unwrap_or(1)
                 } else {
                     get(paintable)
                 }
@@ -174,9 +170,7 @@ impl RotatingPaintable {
         let remaining = self.imp().duration.get() - position;
         if self.return_to_starting_angle() && remaining > 0.0 {
             let rotation = rotation.rem_euclid(360.0);
-            let rotations = ((remaining * speed + rotation) / 360.0)
-                .round()
-                .max(1.0);
+            let rotations = ((remaining * speed + rotation) / 360.0).round().max(1.0);
             (rotations * 360.0 - rotation) / remaining
         } else {
             speed

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -168,11 +168,18 @@ impl RotatingPaintable {
     }
 
     pub fn rotation_speed(&self) -> f64 {
+        self.rotation_speed_from(0.0, 0.0)
+    }
+
+    pub fn rotation_speed_from(&self, rotation: f64, position: f64) -> f64 {
         let speed = self.degrees_per_second();
-        let duration = self.imp().duration.get();
-        if self.return_to_starting_angle() && duration > 0.0 {
-            let rotations = (duration * speed / 360.0).round().max(1.0);
-            rotations * 360.0 / duration
+        let remaining = self.imp().duration.get() - position;
+        if self.return_to_starting_angle() && remaining > 0.0 {
+            let rotation = rotation.rem_euclid(360.0);
+            let rotations = ((remaining * speed + rotation) / 360.0)
+                .round()
+                .max(1.0);
+            (rotations * 360.0 - rotation) / remaining
         } else {
             speed
         }

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -1,6 +1,7 @@
 use gtk::{
     gdk::{self, prelude::*, subclass::paintable::*},
-    glib, graphene, gsk,
+    glib::{self, Properties},
+    graphene, gsk,
     prelude::*,
     subclass::prelude::*,
 };
@@ -9,11 +10,15 @@ use std::cell::{Cell, RefCell};
 mod imp {
     use super::*;
 
-    #[derive(Default)]
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RotatingPaintable)]
     pub struct RotatingPaintable {
         pub paintable: RefCell<Option<gdk::Paintable>>,
         pub rotation: Cell<f64>,
+        #[property(get, set = Self::set_circular)]
         pub circular: Cell<bool>,
+        #[property(get, set)]
+        pub degrees_per_second: Cell<f64>,
     }
 
     #[glib::object_subclass]
@@ -23,11 +28,8 @@ mod imp {
         type Interfaces = (gdk::Paintable,);
     }
 
-    impl ObjectImpl for RotatingPaintable {
-        fn dispose(&self) {
-            self.paintable.borrow_mut().take();
-        }
-    }
+    #[glib::derived_properties]
+    impl ObjectImpl for RotatingPaintable {}
 
     impl PaintableImpl for RotatingPaintable {
         fn current_image(&self) -> gdk::Paintable {
@@ -85,12 +87,6 @@ mod imp {
             let clip = gsk::RoundedRect::from_rect(bounds, diameter as f32 / 2.0);
             snapshot.push_rounded_clip(&clip);
 
-            snapshot.save();
-            let center = graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
-            snapshot.translate(&center);
-            snapshot.rotate(self.rotation.get() as f32);
-            snapshot.translate(&graphene::Point::new(-center.x(), -center.y()));
-
             let source_ratio = paintable.intrinsic_aspect_ratio();
             let (paint_width, paint_height) = if source_ratio.is_finite() && source_ratio > 0.0 {
                 if source_ratio >= 1.0 {
@@ -101,9 +97,14 @@ mod imp {
             } else {
                 (diameter, diameter)
             };
+
+            snapshot.save();
+            let center = graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
+            snapshot.translate(&center);
+            snapshot.rotate(self.rotation.get() as f32);
             snapshot.translate(&graphene::Point::new(
-                ((width - paint_width) / 2.0) as f32,
-                ((height - paint_height) / 2.0) as f32,
+                (-paint_width / 2.0) as f32,
+                (-paint_height / 2.0) as f32,
             ));
             paintable.snapshot(snapshot, paint_width, paint_height);
 
@@ -113,9 +114,17 @@ mod imp {
     }
 
     impl RotatingPaintable {
+        fn set_circular(&self, circular: bool) {
+            if self.circular.replace(circular) != circular {
+                self.obj().invalidate_size();
+                self.obj().invalidate_contents();
+            }
+        }
+
         fn intrinsic_size(&self, get: impl FnOnce(&gdk::Paintable) -> i32) -> i32 {
             self.paintable.borrow().as_ref().map_or(1, |paintable| {
                 if self.circular.get() {
+                    // A zero width/height means that dimension is unavailable
                     let width = paintable.intrinsic_width();
                     let height = paintable.intrinsic_height();
                     match (width > 0, height > 0) {
@@ -142,30 +151,22 @@ impl RotatingPaintable {
     }
 
     pub fn set_paintable(&self, paintable: Option<&impl IsA<gdk::Paintable>>) {
-        self.imp()
-            .paintable
-            .replace(paintable.map(|paintable| paintable.as_ref().clone()));
+        let paintable = paintable.map(|paintable| paintable.as_ref().clone());
+        if *self.imp().paintable.borrow() == paintable {
+            return;
+        }
+        self.imp().paintable.replace(paintable);
         self.invalidate_size();
         self.invalidate_contents();
     }
 
+    // Don't make property as it changes every frame
     pub fn rotation(&self) -> f64 {
         self.imp().rotation.get()
     }
 
     pub fn set_rotation(&self, rotation: f64) {
         if self.imp().rotation.replace(rotation) != rotation {
-            self.invalidate_contents();
-        }
-    }
-
-    pub fn is_circular(&self) -> bool {
-        self.imp().circular.get()
-    }
-
-    pub fn set_circular(&self, circular: bool) {
-        if self.imp().circular.replace(circular) != circular {
-            self.invalidate_size();
             self.invalidate_contents();
         }
     }

--- a/src/common/paintables/rotating.rs
+++ b/src/common/paintables/rotating.rs
@@ -101,7 +101,6 @@ mod imp {
                 (diameter, diameter)
             };
 
-            snapshot.save();
             let center = graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
             snapshot.translate(&center);
             snapshot.rotate(self.rotation.get() as f32);
@@ -111,7 +110,6 @@ mod imp {
             ));
             paintable.snapshot(snapshot, paint_width, paint_height);
 
-            snapshot.restore();
             snapshot.pop();
         }
     }

--- a/src/common/picture_stack.rs
+++ b/src/common/picture_stack.rs
@@ -122,6 +122,10 @@ impl PictureStack {
         }
     }
 
+    pub fn set_content_fit(&self, content_fit: gtk::ContentFit) {
+        self.imp().picture.set_content_fit(content_fit);
+    }
+
     pub fn clear(&self) {
         self.show_placeholder(self.imp().is_thumbnail.get());
         if self
@@ -132,6 +136,11 @@ impl PictureStack {
         {
             self.imp().stack.set_visible_child_name("picture");
         }
+        self.set_state(ImageState::Empty);
+    }
+
+    pub fn clear_with(&self, paintable: &impl IsA<gdk::Paintable>) {
+        self.show(paintable);
         self.set_state(ImageState::Empty);
     }
 

--- a/src/common/picture_stack.rs
+++ b/src/common/picture_stack.rs
@@ -1,15 +1,15 @@
 use gtk::{
     CompositeTemplate,
     gdk::{self},
-    glib::{self, Properties, derived_properties},
+    glib::{self, Properties, clone, derived_properties},
     prelude::*,
     subclass::prelude::*,
 };
-use std::cell::Cell;
+use std::cell::{Cell, OnceCell};
 
 use crate::cache::placeholders::{ALBUMART_PLACEHOLDER, ALBUMART_THUMBNAIL_PLACEHOLDER};
 
-use super::ImageState;
+use super::{ImageState, paintables::RotatingPaintable};
 
 mod imp {
     use super::*;
@@ -23,6 +23,7 @@ mod imp {
         #[template_child]
         pub picture: TemplateChild<gtk::Picture>,
         pub state: Cell<ImageState>,
+        pub wrapper: OnceCell<RotatingPaintable>,
         #[property(get, set)]
         pub size: Cell<i32>,
         #[property(get)]
@@ -103,11 +104,46 @@ impl PictureStack {
 
     #[inline]
     fn show_placeholder(&self, thumb: bool) {
-        self.imp().picture.set_paintable(Some(if thumb {
+        self.display(if thumb {
             &*ALBUMART_THUMBNAIL_PLACEHOLDER
         } else {
             &*ALBUMART_PLACEHOLDER
-        }));
+        });
+    }
+
+    fn display(&self, paintable: &impl IsA<gdk::Paintable>) {
+        if let Some(wrapper) = self.imp().wrapper.get() {
+            wrapper.set_paintable(Some(paintable));
+            self.imp().picture.set_paintable(Some(wrapper));
+        } else {
+            self.imp().picture.set_paintable(Some(paintable));
+        }
+    }
+
+    pub fn install_wrapper(&self, wrapper: &RotatingPaintable) {
+        assert!(
+            self.imp().state.get() == ImageState::Empty,
+            "PictureStack: wrapper must be installed before any content is shown"
+        );
+        self.imp()
+            .wrapper
+            .set(wrapper.clone())
+            .expect("PictureStack: wrapper can only be installed once");
+        self.update_content_fit(wrapper.circular());
+        wrapper.connect_circular_notify(clone!(
+            #[weak(rename_to = this)]
+            self,
+            move |wrapper| this.update_content_fit(wrapper.circular())
+        ));
+        self.show_placeholder(self.imp().is_thumbnail.get());
+    }
+
+    fn update_content_fit(&self, circular: bool) {
+        self.imp().picture.set_content_fit(if circular {
+            gtk::ContentFit::Contain
+        } else {
+            gtk::ContentFit::Cover
+        });
     }
 
     pub fn set_is_thumbnail(&self, new: bool) {
@@ -122,10 +158,6 @@ impl PictureStack {
         }
     }
 
-    pub fn set_content_fit(&self, content_fit: gtk::ContentFit) {
-        self.imp().picture.set_content_fit(content_fit);
-    }
-
     pub fn clear(&self) {
         self.show_placeholder(self.imp().is_thumbnail.get());
         if self
@@ -136,11 +168,6 @@ impl PictureStack {
         {
             self.imp().stack.set_visible_child_name("picture");
         }
-        self.set_state(ImageState::Empty);
-    }
-
-    pub fn clear_with(&self, paintable: &impl IsA<gdk::Paintable>) {
-        self.show(paintable);
         self.set_state(ImageState::Empty);
     }
 
@@ -160,7 +187,7 @@ impl PictureStack {
     }
 
     pub fn show(&self, paintable: &impl IsA<gdk::Paintable>) {
-        self.imp().picture.set_paintable(Some(paintable));
+        self.display(paintable);
         if self
             .imp()
             .stack

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -195,6 +195,9 @@
     </child>
     <child>
       <object class="EuphonicaPictureStack" id="albumart">
+        <style>
+          <class name="sidebar-shade"/>
+        </style>
         <property name="hexpand">true</property>
       </object>
     </child>
@@ -202,11 +205,20 @@
       <object class="GtkRevealer" id="seekbar_revealer">
         <property name="transition-type">slide-up</property>
         <child>
-          <object class="EuphonicaSeekbar2" id="seekbar">
+          <object class="GtkBox">
             <property name="hexpand">true</property>
-            <style>
-              <class name="sidebar-shade"/>
-            </style>
+            <property name="orientation">1</property>
+            <child>
+              <object class="GtkSeparator"/>
+            </child>
+            <child>
+              <object class="EuphonicaSeekbar2" id="seekbar">
+                <property name="hexpand">true</property>
+                <style>
+                  <class name="sidebar-shade"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -36,6 +36,12 @@
           </object>
         </child>
         <child>
+          <object class="AdwSwitchRow" id="return_to_starting_angle">
+            <property name="title" translatable="true">Return to starting angle</property>
+            <property name="subtitle" translatable="true">Slightly adjust the rotation speed so each track ends at the angle it started.</property>
+          </object>
+        </child>
+        <child>
           <object class="AdwActionRow" id="album_art_rotation_speed_row">
             <property name="title" translatable="true">Rotation speed</property>
             <child>

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -30,6 +30,35 @@
           </object>
         </child>
         <child>
+          <object class="AdwSwitchRow" id="rotate_album_art">
+            <property name="title" translatable="true">Rotate album art</property>
+            <property name="subtitle" translatable="true">Show the player album art as a rotating disc while music is playing.</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow" id="album_art_rotation_speed_row">
+            <property name="title" translatable="true">Rotation speed</property>
+            <child>
+              <object class="GtkScale" id="album_art_rotation_speed">
+                <property name="draw-value">false</property>
+                <property name="width-request">200</property>
+                <marks>
+                  <mark value="0" position="3" translatable="true">Slow</mark>
+                  <mark value="1" position="3" translatable="true">Medium</mark>
+                  <mark value="2" position="3" translatable="true">Fast</mark>
+                </marks>
+                <property name="adjustment">
+                  <object class="GtkAdjustment">
+                    <property name="lower">0</property>
+                    <property name="upper">2</property>
+                    <property name="value">1</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="AdwSpinRow" id="recent_playlists_count">
             <property name="title" translatable="true">Number of recent playlists to show</property>
             <property name="subtitle" translatable="true">Sorted by last-modified time, latest first.</property>

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -30,36 +30,37 @@
           </object>
         </child>
         <child>
-          <object class="AdwSwitchRow" id="rotate_album_art">
+          <object class="AdwExpanderRow" id="rotate_album_art">
             <property name="title" translatable="true">Rotate album art</property>
             <property name="subtitle" translatable="true">Show the player album art as a rotating disc while music is playing.</property>
-          </object>
-        </child>
-        <child>
-          <object class="AdwSwitchRow" id="return_to_starting_angle">
-            <property name="title" translatable="true">Return to starting angle</property>
-            <property name="subtitle" translatable="true">Slightly adjust the rotation speed so each track ends at the angle it started.</property>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow" id="album_art_rotation_speed_row">
-            <property name="title" translatable="true">Rotation speed</property>
+            <property name="show-enable-switch">true</property>
             <child>
-              <object class="GtkScale" id="album_art_rotation_speed">
-                <property name="draw-value">false</property>
-                <property name="width-request">200</property>
-                <marks>
-                  <mark value="0" position="3" translatable="true">Slow</mark>
-                  <mark value="1" position="3" translatable="true">Medium</mark>
-                  <mark value="2" position="3" translatable="true">Fast</mark>
-                </marks>
-                <property name="adjustment">
-                  <object class="GtkAdjustment">
-                    <property name="lower">0</property>
-                    <property name="upper">2</property>
-                    <property name="value">1</property>
+              <object class="AdwSwitchRow" id="return_to_starting_angle">
+                <property name="title" translatable="true">Return to starting angle</property>
+                <property name="subtitle" translatable="true">Slightly adjust the rotation speed so each track ends at the angle it started.</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="true">Rotation speed</property>
+                <child>
+                  <object class="GtkScale" id="album_art_rotation_speed">
+                    <property name="draw-value">false</property>
+                    <property name="width-request">200</property>
+                    <marks>
+                      <mark value="0" position="3" translatable="true">Slow</mark>
+                      <mark value="1" position="3" translatable="true">Medium</mark>
+                      <mark value="2" position="3" translatable="true">Fast</mark>
+                    </marks>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="lower">0</property>
+                        <property name="upper">2</property>
+                        <property name="value">1</property>
+                      </object>
+                    </property>
                   </object>
-                </property>
+                </child>
               </object>
             </child>
           </object>

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -587,6 +587,9 @@ mod imp {
                     Signal::builder("history-changed").build(),
                     // For simplicity we'll always use the hires version
                     Signal::builder("cover-changed").build(),
+                    Signal::builder("seeked")
+                        .param_types([f64::static_type()])
+                        .build(),
                     Signal::builder("fft-param-changed")
                         .param_types([
                             String::static_type(),
@@ -1613,9 +1616,10 @@ impl Player {
         old
     }
 
-    /// Seek to current position. Called when the seekbar is released.
     pub async fn send_seek(&self, new_pos: f64) -> ClientResult<()> {
-        self.client()?.seek_current_song(new_pos).await
+        self.client()?.seek_current_song(new_pos).await?;
+        self.emit_by_name::<()>("seeked", &[&new_pos]);
+        Ok(())
     }
 
     /// No cycling (too confusing with the default slide animation)
@@ -1659,14 +1663,13 @@ impl Player {
 
     /// Seek to the timestamp of a lyric line
     pub async fn seek_to_lyric_line(&self, line: i32) -> ClientResult<()> {
-        if let Some(lyrics) = self.imp().lyrics.borrow().as_ref()
-            && lyrics.synced
-            && line >= 0
-            && line < lyrics.lines.len() as i32
-        {
-            self.client()?
-                .seek_current_song(lyrics.lines[line as usize].0 as f64)
-                .await?;
+        // Release the lyrics borrow before seek handlers run.
+        let timestamp = self.imp().lyrics.borrow().as_ref().and_then(|lyrics| {
+            (lyrics.synced && line >= 0 && line < lyrics.lines.len() as i32)
+                .then(|| lyrics.lines[line as usize].0 as f64)
+        });
+        if let Some(timestamp) = timestamp {
+            self.send_seek(timestamp).await?;
         }
         Ok(())
     }
@@ -1719,7 +1722,7 @@ impl Player {
                     backend.name() == "pipewire" && backend.status() != FftStatus::ValidNotReading
                 })
         {
-            
+
             self.maybe_stop_fft_thread().await;
         }
         self.client()?.prev().await

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -27,6 +27,7 @@ use std::{
     path::PathBuf,
     rc::Rc,
     sync::{Arc, Mutex, OnceLock},
+    time::{Duration, Instant},
     vec::Vec,
 };
 
@@ -34,6 +35,8 @@ use super::fft_backends::{
     FifoFftBackend, PipeWireFftBackend,
     backend::{FftBackendExt, FftStatus},
 };
+
+const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, glib::Enum, PartialEq, Default)]
 #[enum_type(name = "EuphonicaPlaybackState")]
@@ -177,10 +180,13 @@ mod imp {
     pub struct Player {
         pub state: Cell<PlaybackState>,
         pub position: Cell<f64>,
+        pub position_sampled_at: Cell<Instant>,
+        pub position_sampled_while_playing: Cell<bool>,
         pub queue_initialized: Cell<bool>,
         pub queue: gio::ListStore,
         pub lyric_lines: gtk::StringList, // Line by line for display. May be empty.
         pub lyrics: RefCell<Option<Lyrics>>,
+        pub lyrics_loading: Cell<bool>,
         pub queue_len: Cell<u32>,
         pub current_song: RefCell<Option<Song>>,
         pub current_lyric_line: Cell<u32>,
@@ -255,8 +261,11 @@ mod imp {
             Self {
                 state: Cell::new(PlaybackState::Stopped),
                 position: Cell::new(0.0),
+                position_sampled_at: Cell::new(Instant::now()),
+                position_sampled_while_playing: Cell::new(false),
                 lyric_lines: gtk::StringList::new(&[]),
                 lyrics: RefCell::new(None),
+                lyrics_loading: Cell::new(false),
                 random: Cell::new(false),
                 consume: Cell::new(false),
                 supports_playlists: Cell::new(false),
@@ -410,6 +419,9 @@ mod imp {
                     ParamSpecUInt::builder("current-lyric-line")
                         .read_only()
                         .build(),
+                    ParamSpecBoolean::builder("lyrics-loading")
+                        .read_only()
+                        .build(),
                     ParamSpecString::builder("title").read_only().build(),
                     ParamSpecString::builder("artist").read_only().build(),
                     ParamSpecString::builder("album").read_only().build(),
@@ -449,6 +461,7 @@ mod imp {
                 "replaygain" => get_replaygain_icon_name(self.replaygain.get()).to_value(),
                 "position" => obj.position().to_value(),
                 "current-lyric-line" => self.current_lyric_line.get().to_value(),
+                "lyrics-loading" => self.lyrics_loading.get().to_value(),
                 // These are proxies for Song properties
                 "title" => obj.title().to_value(),
                 "artist" => obj.artist().to_value(),
@@ -587,6 +600,9 @@ mod imp {
                     Signal::builder("history-changed").build(),
                     // For simplicity we'll always use the hires version
                     Signal::builder("cover-changed").build(),
+                    Signal::builder("song-changed")
+                        .param_types([bool::static_type(), bool::static_type()])
+                        .build(),
                     Signal::builder("seeked")
                         .param_types([f64::static_type()])
                         .build(),
@@ -921,7 +937,25 @@ impl Player {
         } else {
             status = mpd::Status::default();
         }
+        let status_time = Instant::now();
+        let was_playing = self.imp().position_sampled_while_playing.get();
+        let automatic_transition = was_playing
+            && self.current_song().is_some_and(|song| {
+                song.get_info().duration.as_ref().is_some_and(|duration| {
+                    self.position()
+                        + status_time
+                            .saturating_duration_since(self.imp().position_sampled_at.get())
+                            .as_secs_f64()
+                        + status
+                            .crossfade
+                            .map_or(0.0, |crossfade| crossfade.as_secs_f64())
+                        // Allow one polling interval because the last sampled position may precede the song change
+                        + STATUS_POLL_INTERVAL.as_secs_f64()
+                        >= duration.as_secs_f64()
+                })
+            });
         let mut mpris_changes: Vec<Property> = Vec::new();
+        let mut song_change = None;
         match status.state {
             State::Play => {
                 let new_state = PlaybackState::Playing;
@@ -1114,6 +1148,7 @@ impl Player {
 
                         // Get new lyrics
                         // First remove all current lines
+                        self.set_lyrics_loading(true);
                         self.imp()
                             .lyric_lines
                             .splice(0, self.imp().lyric_lines.n_items(), &[]);
@@ -1128,27 +1163,29 @@ impl Player {
                             new_song,
                             async move {
                                 println!("Fetching new lyrics...");
-                                match this
+                                let result = this
                                     .imp()
                                     .cache
                                     .get()
                                     .unwrap()
                                     .get_lyrics(new_song.get_info(), true, None)
-                                    .await
-                                {
+                                    .await;
+                                if !this.current_song().is_some_and(|song| {
+                                    song.get_info().get_comp_id()
+                                        == new_song.get_info().get_comp_id()
+                                }) {
+                                    return;
+                                }
+                                match result {
                                     Ok(Some(lyrics)) => {
-                                        if this.current_song().is_some_and(|s| {
-                                            s.get_info().get_comp_id()
-                                                == new_song.get_info().get_comp_id()
-                                        }) {
-                                            this.update_lyrics(lyrics);
-                                        }
+                                        this.update_lyrics(lyrics);
                                     }
                                     Ok(None) => {}
                                     Err(e) => {
                                         dbg!(e);
                                     }
                                 }
+                                this.set_lyrics_loading(false);
                             }
                         ));
 
@@ -1156,6 +1193,17 @@ impl Player {
                         if self.imp().mpris_enabled.get() {
                             mpris_changes.push(Property::Metadata(new_song.get_mpris_metadata()));
                         }
+
+                        let album_changed = self
+                            .imp()
+                            .current_song
+                            .borrow()
+                            .as_ref()
+                            .and_then(Song::get_album)
+                            .zip(new_song.get_album())
+                            .is_none_or(|(current, new)| {
+                                current.get_comp_id() != new.get_comp_id()
+                            });
 
                         // We're now ready to update the UI elements
                         self.imp().current_song.replace(Some(new_song));
@@ -1167,9 +1215,7 @@ impl Player {
                         self.notify("quality-grade");
                         self.notify("format-desc");
                         self.notify("album");
-                        self.notify("queue-id");
-                        // Update album art
-                        self.emit_by_name::<()>("cover-changed", &[]);
+                        song_change = Some((album_changed, automatic_transition));
                     }
                     Ok(None) => {
                         eprintln!(
@@ -1231,14 +1277,14 @@ impl Player {
         if status.song.is_none() || status.state == State::Stop {
             // No song is playing. Update state accordingly.
             if let Some(_) = self.imp().current_song.take() {
+                self.set_lyrics_loading(false);
                 self.imp().saved_to_history.set(false);
                 self.notify("title");
                 self.notify("artist");
                 self.notify("album");
                 self.notify("rating");
                 self.notify("duration");
-                self.notify("queue-id");
-                self.emit_by_name::<()>("cover-changed", &[]);
+                song_change = Some((true, automatic_transition));
                 // Update MPRIS side
                 if self.imp().mpris_enabled.get() {
                     mpris_changes.push(Property::Metadata(
@@ -1248,10 +1294,22 @@ impl Player {
             }
         }
 
-        if let Some(new_position_dur) = status.elapsed {
-            let new = new_position_dur.as_secs_f64();
-            let old = self.set_position(new);
-            if new != old && self.imp().mpris_enabled.get() {
+        let position = status.elapsed.map(|position| position.as_secs_f64());
+        let old_position = self.set_position(position.unwrap_or_default());
+        self.imp().position_sampled_at.set(status_time);
+        self.imp()
+            .position_sampled_while_playing
+            .set(status.state == State::Play);
+        if let Some((album_changed, automatic_transition)) = song_change {
+            self.notify("queue-id");
+            self.emit_by_name::<()>("song-changed", &[&album_changed, &automatic_transition]);
+            if album_changed {
+                self.emit_by_name::<()>("cover-changed", &[]);
+            }
+        }
+
+        if let Some(new) = position {
+            if new != old_position && self.imp().mpris_enabled.get() {
                 self.seek_mpris(new).await;
             }
             // If using PipeWire visualiser and auto-restart is enabled, stop the thread
@@ -1272,8 +1330,6 @@ impl Player {
             {
                 self.maybe_stop_fft_thread().await; // FIXME: we can't block while running in an async loop
             }
-        } else {
-            self.set_position(0.0);
         }
         if let Some(lyrics) = self.imp().lyrics.borrow().as_ref() {
             let new_idx = lyrics.get_line_at_timestamp(self.imp().position.get() as f32) as u32;
@@ -1329,6 +1385,16 @@ impl Player {
 
     pub fn n_lyric_lines(&self) -> u32 {
         self.imp().lyric_lines.n_items()
+    }
+
+    pub fn lyrics_loading(&self) -> bool {
+        self.imp().lyrics_loading.get()
+    }
+
+    fn set_lyrics_loading(&self, loading: bool) {
+        if self.imp().lyrics_loading.replace(loading) != loading {
+            self.notify("lyrics-loading");
+        }
     }
 
     pub fn register_local_queue_changes(&self, n_changes: u32) {
@@ -1907,7 +1973,7 @@ impl Player {
                     {
                         dbg!(e);
                     }
-                    glib::timeout_future_seconds(1).await;
+                    glib::timeout_future(STATUS_POLL_INTERVAL).await;
                 }
             });
             self.imp().poller_handle.replace(Some(poller_handle));

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -189,6 +189,7 @@ mod imp {
         pub position: Cell<f64>,
         pub position_sampled_at: Cell<Instant>,
         pub position_sampled_while_playing: Cell<bool>,
+        pub expected_next_song_id: Cell<Option<u32>>,
         pub queue_initialized: Cell<bool>,
         pub queue: gio::ListStore,
         pub lyric_lines: gtk::StringList, // Line by line for display. May be empty.
@@ -270,6 +271,7 @@ mod imp {
                 position: Cell::new(0.0),
                 position_sampled_at: Cell::new(Instant::now()),
                 position_sampled_while_playing: Cell::new(false),
+                expected_next_song_id: Cell::new(None),
                 lyric_lines: gtk::StringList::new(&[]),
                 lyrics: RefCell::new(None),
                 lyrics_handle: RefCell::default(),
@@ -603,6 +605,8 @@ mod imp {
                     Signal::builder("history-changed").build(),
                     // For simplicity we'll always use the hires version
                     Signal::builder("cover-changed").build(),
+                    // Params: whether the cover changed, and whether this was an automatic
+                    // transition to the next song rather than the user changing the song manually.
                     Signal::builder("song-changed")
                         .param_types([bool::static_type(), bool::static_type()])
                         .build(),
@@ -930,6 +934,23 @@ impl Player {
     // Signals will be sent for properties whose values have changed, even though
     // we will be receiving updates for many properties at once.
 
+    /// Whether the previous song had reached its end by `at`, allowing for crossfade
+    /// and a status update arriving one poll late.
+    fn previous_song_ran_out(&self, at: Instant, crossfade: Option<Duration>) -> bool {
+        self.imp()
+            .current_song
+            .borrow()
+            .as_ref()
+            .and_then(|song| song.get_info().duration)
+            .is_some_and(|duration| {
+                Duration::from_secs_f64(self.position())
+                    + at.saturating_duration_since(self.imp().position_sampled_at.get())
+                    + crossfade.unwrap_or_default()
+                    + STATUS_POLL_INTERVAL
+                    >= duration
+            })
+    }
+
     /// Main update function. MPD's protocol has a single "status" commands
     /// that returns everything at once. This update function will take what's
     /// relevant and update the GObject properties accordingly.
@@ -941,24 +962,13 @@ impl Player {
             status = mpd::Status::default();
         }
         let status_time = Instant::now();
-        let was_playing = self.imp().position_sampled_while_playing.get();
-        let automatic_transition = was_playing
-            && self.current_song().is_some_and(|song| {
-                song.get_info().duration.as_ref().is_some_and(|duration| {
-                    self.position()
-                        + status_time
-                            .saturating_duration_since(self.imp().position_sampled_at.get())
-                            .as_secs_f64()
-                        + status
-                            .crossfade
-                            .map_or(0.0, |crossfade| crossfade.as_secs_f64())
-                        // Allow one polling interval because the last sampled position may precede the song change
-                        + STATUS_POLL_INTERVAL.as_secs_f64()
-                        >= duration.as_secs_f64()
-                })
-            });
+        let expected_next_song_id = self
+            .imp()
+            .expected_next_song_id
+            .replace(status.nextsong.map(|place| place.id.0));
         let mut mpris_changes: Vec<Property> = Vec::new();
-        let mut song_change = None;
+        let mut cover_changed = None;
+        let mut automatic_transition = false;
         match status.state {
             State::Play => {
                 let new_state = PlaybackState::Playing;
@@ -1187,16 +1197,17 @@ impl Player {
                             mpris_changes.push(Property::Metadata(new_song.get_mpris_metadata()));
                         }
 
-                        let album_changed = self
-                            .imp()
-                            .current_song
-                            .borrow()
-                            .as_ref()
-                            .and_then(Song::get_album)
-                            .zip(new_song.get_album())
-                            .is_none_or(|(current, new)| {
-                                current.get_comp_id() != new.get_comp_id()
-                            });
+                        // Covers are cached per folder, so matching album IDs do not guarantee
+                        // matching cover art.
+                        cover_changed = Some(self.imp().current_song.borrow().as_ref().is_none_or(
+                            |current| current.get_folder_uri() != new_song.get_folder_uri(),
+                        ));
+
+                        // MPD's next song can also be selected manually. The previous song must
+                        // have run out to confirm an automatic transition.
+                        automatic_transition = self.imp().position_sampled_while_playing.get()
+                            && expected_next_song_id == Some(new_queue_place.id.0)
+                            && self.previous_song_ran_out(status_time, status.crossfade);
 
                         // We're now ready to update the UI elements
                         self.imp().current_song.replace(Some(new_song));
@@ -1208,7 +1219,6 @@ impl Player {
                         self.notify("quality-grade");
                         self.notify("format-desc");
                         self.notify("album");
-                        song_change = Some((album_changed, automatic_transition));
                     }
                     Ok(None) => {
                         eprintln!(
@@ -1276,7 +1286,7 @@ impl Player {
                 self.notify("album");
                 self.notify("rating");
                 self.notify("duration");
-                song_change = Some((true, automatic_transition));
+                cover_changed = Some(true);
                 // Update MPRIS side
                 if self.imp().mpris_enabled.get() {
                     mpris_changes.push(Property::Metadata(
@@ -1292,10 +1302,10 @@ impl Player {
         self.imp()
             .position_sampled_while_playing
             .set(status.state == State::Play);
-        if let Some((album_changed, automatic_transition)) = song_change {
+        if let Some(cover_changed) = cover_changed {
             self.notify("queue-id");
-            self.emit_by_name::<()>("song-changed", &[&album_changed, &automatic_transition]);
-            if album_changed {
+            self.emit_by_name::<()>("song-changed", &[&cover_changed, &automatic_transition]);
+            if cover_changed {
                 self.emit_by_name::<()>("cover-changed", &[]);
             }
         }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1,11 +1,17 @@
 extern crate mpd;
 use crate::{
-    application::EuphonicaApplication, cache::{Cache, sqlite}, client::{
+    application::EuphonicaApplication,
+    cache::{Cache, sqlite},
+    client::{
         ClientState, ConnectionState, Error as ClientError, MpdWrapper, Result as ClientResult,
         StickerSetMode,
-    }, common::{QualityGrade, Song, Stickers}, config::APPLICATION_ID, meta_providers::models::Lyrics, utils::{
+    },
+    common::{QualityGrade, Song, Stickers},
+    config::APPLICATION_ID,
+    meta_providers::models::Lyrics,
+    utils::{
         current_unix_timestamp, get_image_cache_path, prettify_audio_format, settings_manager,
-    }
+    },
 };
 use async_lock::OnceCell as AsyncOnceCell;
 use mpris_server::{
@@ -19,7 +25,8 @@ use adw::subclass::prelude::*;
 use glib::{BoxedAnyObject, clone, closure_local, subclass::Signal};
 use gtk::{gio, glib, prelude::*};
 use mpd::{
-    Output, ReplayGain, SaveMode, Subsystem, status::{AudioFormat, State}
+    Output, ReplayGain, SaveMode, Subsystem,
+    status::{AudioFormat, State},
 };
 use std::{
     cell::{Cell, OnceCell, RefCell},
@@ -186,7 +193,7 @@ mod imp {
         pub queue: gio::ListStore,
         pub lyric_lines: gtk::StringList, // Line by line for display. May be empty.
         pub lyrics: RefCell<Option<Lyrics>>,
-        pub lyrics_loading: Cell<bool>,
+        pub lyrics_handle: RefCell<Option<glib::JoinHandle<()>>>,
         pub queue_len: Cell<u32>,
         pub current_song: RefCell<Option<Song>>,
         pub current_lyric_line: Cell<u32>,
@@ -265,7 +272,7 @@ mod imp {
                 position_sampled_while_playing: Cell::new(false),
                 lyric_lines: gtk::StringList::new(&[]),
                 lyrics: RefCell::new(None),
-                lyrics_loading: Cell::new(false),
+                lyrics_handle: RefCell::default(),
                 random: Cell::new(false),
                 consume: Cell::new(false),
                 supports_playlists: Cell::new(false),
@@ -419,9 +426,6 @@ mod imp {
                     ParamSpecUInt::builder("current-lyric-line")
                         .read_only()
                         .build(),
-                    ParamSpecBoolean::builder("lyrics-loading")
-                        .read_only()
-                        .build(),
                     ParamSpecString::builder("title").read_only().build(),
                     ParamSpecString::builder("artist").read_only().build(),
                     ParamSpecString::builder("album").read_only().build(),
@@ -461,7 +465,6 @@ mod imp {
                 "replaygain" => get_replaygain_icon_name(self.replaygain.get()).to_value(),
                 "position" => obj.position().to_value(),
                 "current-lyric-line" => self.current_lyric_line.get().to_value(),
-                "lyrics-loading" => self.lyrics_loading.get().to_value(),
                 // These are proxies for Song properties
                 "title" => obj.title().to_value(),
                 "artist" => obj.artist().to_value(),
@@ -1146,17 +1149,8 @@ impl Player {
                             self.maybe_start_fft_thread();
                         }
 
-                        // Get new lyrics
-                        // First remove all current lines
-                        self.set_lyrics_loading(true);
-                        self.imp()
-                            .lyric_lines
-                            .splice(0, self.imp().lyric_lines.n_items(), &[]);
-                        let _ = self.imp().lyrics.take();
-
-                        // Fetch new lyrics in another future (don't await using this function as it will sleep after the request).
-                        // We'll have to check which song is playing again by the time we come back with the lyrics.
-                        glib::spawn_future_local(clone!(
+                        self.abort_lyrics_fetch();
+                        let lyrics_handle = glib::spawn_future_local(clone!(
                             #[weak(rename_to = this)]
                             self,
                             #[strong]
@@ -1177,17 +1171,16 @@ impl Player {
                                     return;
                                 }
                                 match result {
-                                    Ok(Some(lyrics)) => {
-                                        this.update_lyrics(lyrics);
-                                    }
-                                    Ok(None) => {}
+                                    Ok(lyrics) => this.update_lyrics(lyrics),
                                     Err(e) => {
                                         dbg!(e);
+                                        // Prevent highlighting and seeking with timestamps from the previous song.
+                                        this.update_lyrics(None);
                                     }
                                 }
-                                this.set_lyrics_loading(false);
                             }
                         ));
+                        self.imp().lyrics_handle.replace(Some(lyrics_handle));
 
                         // Update MPRIS side
                         if self.imp().mpris_enabled.get() {
@@ -1277,7 +1270,6 @@ impl Player {
         if status.song.is_none() || status.state == State::Stop {
             // No song is playing. Update state accordingly.
             if let Some(_) = self.imp().current_song.take() {
-                self.set_lyrics_loading(false);
                 self.imp().saved_to_history.set(false);
                 self.notify("title");
                 self.notify("artist");
@@ -1361,12 +1353,21 @@ impl Player {
         Ok(())
     }
 
-    pub fn update_lyrics(&self, lyrics: Lyrics) {
+    fn abort_lyrics_fetch(&self) {
+        if let Some(handle) = self.imp().lyrics_handle.take() {
+            handle.abort();
+        }
+    }
+
+    pub fn update_lyrics(&self, lyrics: Option<Lyrics>) {
         self.imp().current_lyric_line.set(0);
+        let lines = lyrics
+            .as_ref()
+            .map_or_else(Vec::new, Lyrics::to_plain_lines);
         self.imp()
             .lyric_lines
-            .splice(0, 0, &lyrics.to_plain_lines());
-        self.imp().lyrics.replace(Some(lyrics));
+            .splice(0, self.imp().lyric_lines.n_items(), &lines);
+        self.imp().lyrics.replace(lyrics);
         self.notify("current-lyric-line");
     }
 
@@ -1385,16 +1386,6 @@ impl Player {
 
     pub fn n_lyric_lines(&self) -> u32 {
         self.imp().lyric_lines.n_items()
-    }
-
-    pub fn lyrics_loading(&self) -> bool {
-        self.imp().lyrics_loading.get()
-    }
-
-    fn set_lyrics_loading(&self, loading: bool) {
-        if self.imp().lyrics_loading.replace(loading) != loading {
-            self.notify("lyrics-loading");
-        }
     }
 
     pub fn register_local_queue_changes(&self, n_changes: u32) {
@@ -1788,7 +1779,6 @@ impl Player {
                     backend.name() == "pipewire" && backend.status() != FftStatus::ValidNotReading
                 })
         {
-
             self.maybe_stop_fft_thread().await;
         }
         self.client()?.prev().await
@@ -2002,7 +1992,8 @@ impl Player {
         {
             sqlite::write_lyrics(curr_song.get_info(), Some(&lyrics))
                 .expect("Unable to import lyrics into SQLite DB");
-            self.update_lyrics(lyrics);
+            self.abort_lyrics_fetch();
+            self.update_lyrics(Some(lyrics));
         }
     }
 
@@ -2010,10 +2001,8 @@ impl Player {
         if let Some(curr_song) = self.current_song() {
             sqlite::write_lyrics(curr_song.get_info(), None)
                 .expect("Unable to clear lyrics from DB");
-            self.imp()
-                .lyric_lines
-                .splice(0, self.imp().lyric_lines.n_items(), &[]);
-            let _ = self.imp().lyrics.take();
+            self.abort_lyrics_fetch();
+            self.update_lyrics(None);
         }
     }
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -10,8 +10,29 @@ mod queue_view;
 mod ratio_center_box;
 mod seekbar2;
 
+use adw::prelude::AnimationExt;
+use gtk::glib::WeakRef;
+
 use knob::VolumeKnob;
 use output::MpdOutput;
+
+fn player_is_playing(player: &WeakRef<Player>) -> bool {
+    player
+        .upgrade()
+        .is_some_and(|player| player.state() == PlaybackState::Playing)
+}
+
+fn sync_animation(animation: &adw::TimedAnimation, should_run: bool) {
+    if should_run {
+        match animation.state() {
+            adw::AnimationState::Idle | adw::AnimationState::Finished => animation.play(),
+            adw::AnimationState::Paused => animation.resume(),
+            _ => {}
+        }
+    } else if animation.state() == adw::AnimationState::Playing {
+        animation.pause();
+    }
+}
 
 pub use bar::PlayerBar;
 pub use controller::{PlaybackState, PlaybackFlow, Player, get_next_replaygain};

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -870,9 +870,6 @@ impl PlayerPane {
     fn restart_album_art_animation(&self, rotation: f64, speed: f64) {
         let imp = self.imp();
         let animation = imp.albumart_animation.get().unwrap();
-        if animation.state() == adw::AnimationState::Playing {
-            animation.pause();
-        }
         animation.set_value_from(rotation);
         animation.set_value_to(rotation + 360.0);
         animation.set_duration((360_000.0 / speed).round() as u32);
@@ -881,25 +878,9 @@ impl PlayerPane {
     }
 
     fn sync_album_art_animation(&self) {
-        let state = self
-            .imp()
-            .player
-            .upgrade()
-            .map(|player| player.state())
-            .unwrap_or(PlaybackState::Stopped);
-
-        let should_rotate =
-            self.imp().albumart_paintable.circular() && state == PlaybackState::Playing;
-        let animation = self.imp().albumart_animation.get().unwrap();
-        if should_rotate {
-            match animation.state() {
-                adw::AnimationState::Idle | adw::AnimationState::Finished => animation.play(),
-                adw::AnimationState::Paused => animation.resume(),
-                _ => {}
-            }
-        } else if animation.state() == adw::AnimationState::Playing {
-            animation.pause();
-        }
+        let should_rotate = self.imp().albumart_paintable.circular()
+            && super::player_is_playing(&self.imp().player);
+        super::sync_animation(self.imp().albumart_animation.get().unwrap(), should_rotate);
     }
 }
 

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -95,7 +95,6 @@ mod imp {
         pub albumart_paintable: RotatingPaintable,
         pub albumart_animation: OnceCell<adw::TimedAnimation>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
-        pub lyrics_loading_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
         pub song_changed_id: RefCell<Option<SignalHandlerId>>,
         pub playback_state_id: RefCell<Option<SignalHandlerId>>,
@@ -241,9 +240,6 @@ mod imp {
                 if let Some(id) = self.current_lyric_line_id.take() {
                     player.disconnect(id);
                 }
-                if let Some(id) = self.lyrics_loading_id.take() {
-                    player.disconnect(id);
-                }
                 if let Some(id) = self.cover_changed_id.take() {
                     player.disconnect(id);
                 }
@@ -291,10 +287,9 @@ impl PlayerPane {
 
     pub fn update_lyrics_availability(&self, player: &Player) {
         let has_lyrics = player.n_lyric_lines() > 0;
-        // Keep the lyrics area visible while loading so the album art does not resize between tracks
-        self.imp().lyrics_window.set_visible(
-            (has_lyrics || player.lyrics_loading()) && self.imp().show_lyrics.is_active(),
-        );
+        self.imp()
+            .lyrics_window
+            .set_visible(has_lyrics && self.imp().show_lyrics.is_active());
         self.imp().export_lyrics.set_sensitive(has_lyrics);
         self.imp().clear_lyrics.set_sensitive(has_lyrics);
     }
@@ -563,17 +558,6 @@ impl PlayerPane {
                 }
             ),
         );
-        self.imp()
-            .lyrics_loading_id
-            .replace(Some(player.connect_notify_local(
-                Some("lyrics-loading"),
-                clone!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |player, _| this.update_lyrics_availability(player)
-                ),
-            )));
-
         // Synced lyrics handling:
         // - Upon loading new lyrics, player controller sets new lyrics object,
         // clears out lyric_lines and repopulates it with new lyrics.

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -1,13 +1,13 @@
+use adw::prelude::*;
 use ashpd::desktop::file_chooser::{FileFilter, SelectedFiles};
 use glib::{SignalHandlerId, WeakRef, clone, closure_local};
 use gtk::{
     CompositeTemplate,
     glib::{self, Variant},
-    prelude::*,
     subclass::prelude::*,
 };
 use std::{
-    cell::{Cell, RefCell},
+    cell::{OnceCell, RefCell},
     fs::{self, File},
     io::Write,
     rc::Rc,
@@ -93,7 +93,7 @@ mod imp {
 
         pub player: WeakRef<Player>,
         pub albumart_paintable: RotatingPaintable,
-        pub albumart_tick_id: RefCell<Option<gtk::TickCallbackId>>,
+        pub albumart_animation: OnceCell<adw::TimedAnimation>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
         pub playback_state_id: RefCell<Option<SignalHandlerId>>,
@@ -125,14 +125,33 @@ mod imp {
             let ui_settings = settings_manager().child("ui");
 
             self.albumart.install_wrapper(&self.albumart_paintable);
+            let target = adw::CallbackAnimationTarget::new(clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |rotation| this.albumart_paintable.set_rotation(rotation)
+            ));
+            self.albumart_animation
+                .set(
+                    adw::TimedAnimation::builder()
+                        .widget(self.obj().as_ref())
+                        .target(&target)
+                        .value_from(0.0)
+                        .value_to(360.0)
+                        .duration(20_000)
+                        .repeat_count(0)
+                        .easing(adw::Easing::Linear)
+                        .build(),
+                )
+                .unwrap();
             self.albumart_paintable.connect_circular_notify(clone!(
                 #[weak(rename_to = this)]
                 self,
                 move |paintable| {
                     if paintable.circular() {
                         this.obj().snap_album_art_to_player();
+                    } else {
+                        this.obj().sync_album_art_animation();
                     }
-                    this.obj().sync_album_art_animation();
                 }
             ));
             for property in ["return-to-starting-angle", "degrees-per-second"] {
@@ -144,6 +163,8 @@ mod imp {
                         move |paintable, _| {
                             if paintable.return_to_starting_angle() {
                                 this.obj().snap_album_art_to_player();
+                            } else {
+                                this.obj().restart_album_art_animation(paintable.rotation());
                             }
                         }
                     ),
@@ -225,14 +246,17 @@ mod imp {
                     player.disconnect(id);
                 }
             }
-            if let Some(id) = self.albumart_tick_id.take() {
-                id.remove();
-            }
+            self.albumart_animation.get().unwrap().reset();
         }
     }
 
     // Trait shared by all widgets
-    impl WidgetImpl for PlayerPane {}
+    impl WidgetImpl for PlayerPane {
+        fn map(&self) {
+            self.parent_map();
+            self.obj().sync_album_art_animation();
+        }
+    }
 
     impl BoxImpl for PlayerPane {}
 }
@@ -574,7 +598,6 @@ impl PlayerPane {
                     #[strong]
                     cache,
                     move |p: Player| {
-                        this.imp().albumart_paintable.set_rotation(0.0);
                         this.update_album_art(p.current_song(), cache.clone());
                     }
                 ),
@@ -735,6 +758,7 @@ impl PlayerPane {
                 .and_then(|song| song.get_info().duration.as_ref())
                 .map_or(0.0, |duration| duration.as_secs_f64()),
         );
+        self.restart_album_art_animation(0.0);
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -768,7 +792,19 @@ impl PlayerPane {
 
     fn snap_rotation_to_position(&self, position: f64) {
         let paintable = &self.imp().albumart_paintable;
-        paintable.set_rotation((position * paintable.rotation_speed()) % 360.0);
+        self.restart_album_art_animation((position * paintable.rotation_speed()) % 360.0);
+    }
+
+    fn restart_album_art_animation(&self, rotation: f64) {
+        let imp = self.imp();
+        let animation = imp.albumart_animation.get().unwrap();
+        animation.reset();
+        imp.albumart_paintable.set_rotation(rotation);
+        animation.set_value_from(rotation);
+        animation.set_value_to(rotation + 360.0);
+        animation
+            .set_duration((360_000.0 / imp.albumart_paintable.rotation_speed()).round() as u32);
+        self.sync_album_art_animation();
     }
 
     fn sync_album_art_animation(&self) {
@@ -781,33 +817,16 @@ impl PlayerPane {
 
         let should_rotate =
             self.imp().albumart_paintable.circular() && state == PlaybackState::Playing;
-        if !should_rotate {
-            if let Some(id) = self.imp().albumart_tick_id.take() {
-                id.remove();
+        let animation = self.imp().albumart_animation.get().unwrap();
+        if should_rotate {
+            match animation.state() {
+                adw::AnimationState::Idle | adw::AnimationState::Finished => animation.play(),
+                adw::AnimationState::Paused => animation.resume(),
+                _ => {}
             }
-            return;
+        } else if animation.state() == adw::AnimationState::Playing {
+            animation.pause();
         }
-        if self.imp().albumart_tick_id.borrow().is_some() {
-            return;
-        }
-
-        let last_frame_time = Cell::new(glib::monotonic_time());
-        let id = self.add_tick_callback(clone!(
-            #[weak(rename_to = this)]
-            self,
-            #[upgrade_or]
-            glib::ControlFlow::Break,
-            move |_, clock| {
-                let now = clock.frame_time();
-                let elapsed = (now - last_frame_time.replace(now)) as f64 / 1_000_000.0;
-                let paintable = &this.imp().albumart_paintable;
-                paintable.set_rotation(
-                    (paintable.rotation() + elapsed * paintable.rotation_speed()) % 360.0,
-                );
-                glib::ControlFlow::Continue
-            }
-        ));
-        self.imp().albumart_tick_id.replace(Some(id));
     }
 }
 

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -7,7 +7,7 @@ use gtk::{
     subclass::prelude::*,
 };
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     fs::{self, File},
     io::Write,
     rc::Rc,
@@ -16,10 +16,10 @@ use std::{
 use crate::{
     cache::{
         Cache,
-        placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
+        placeholders::{ALBUMART_PLACEHOLDER, EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
     },
     client::{ClientState, state::StickersSupportLevel},
-    common::{PictureStack, Rating, Song},
+    common::{PictureStack, Rating, Song, paintables::RotatingPaintable},
     player::seekbar2::Seekbar,
     utils::{self, settings_manager},
 };
@@ -92,8 +92,12 @@ mod imp {
         pub output_widgets: RefCell<Vec<MpdOutput>>,
 
         pub player: WeakRef<Player>,
+        pub albumart_paintable: RotatingPaintable,
+        pub albumart_tick_id: RefCell<Option<gtk::TickCallbackId>>,
+        pub albumart_degrees_per_second: Cell<f64>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
+        pub playback_state_id: RefCell<Option<SignalHandlerId>>,
     }
 
     // The central trait for subclassing a GObject
@@ -119,6 +123,41 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             let ui_settings = settings_manager().child("ui");
+
+            self.albumart_paintable
+                .set_paintable(Some(&*ALBUMART_PLACEHOLDER));
+            self.albumart.clear_with(&self.albumart_paintable);
+
+            self.obj()
+                .set_rotate_album_art(ui_settings.boolean("rotate-album-art"));
+            self.albumart_degrees_per_second
+                .set(super::rotation_degrees_per_second(
+                    ui_settings.double("album-art-rotation-speed"),
+                ));
+            ui_settings.connect_changed(
+                Some("rotate-album-art"),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |settings, _| {
+                        this.obj()
+                            .set_rotate_album_art(settings.boolean("rotate-album-art"));
+                    }
+                ),
+            );
+            ui_settings.connect_changed(
+                Some("album-art-rotation-speed"),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |settings, _| {
+                        this.albumart_degrees_per_second
+                            .set(super::rotation_degrees_per_second(
+                                settings.double("album-art-rotation-speed"),
+                            ));
+                    }
+                ),
+            );
             let knob = self.vol_knob.get();
             ui_settings
                 .bind("vol-knob-unit", &knob, "use-dbfs")
@@ -165,6 +204,12 @@ mod imp {
                 if let Some(id) = self.cover_changed_id.take() {
                     player.disconnect(id);
                 }
+                if let Some(id) = self.playback_state_id.take() {
+                    player.disconnect(id);
+                }
+            }
+            if let Some(id) = self.albumart_tick_id.take() {
+                id.remove();
             }
         }
     }
@@ -239,10 +284,38 @@ impl PlayerPane {
 
     pub fn setup(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
         self.imp().player.set(Some(player));
+        self.imp()
+            .playback_state_id
+            .replace(Some(player.connect_notify_local(
+                Some("playback-state"),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_, _| {
+                        this.sync_album_art_animation();
+                    }
+                ),
+            )));
+        self.sync_album_art_animation();
         self.bind_state(player, cache, client_state);
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
         self.imp().seekbar.setup(player);
+        self.imp().seekbar.connect_closure(
+            "seeked",
+            false,
+            closure_local!(
+                #[weak(rename_to = this)]
+                self,
+                move |_: Seekbar, position: f64| {
+                    if this.imp().albumart_paintable.is_circular() {
+                        this.imp()
+                            .albumart_paintable
+                            .set_rotation(position * this.imp().albumart_degrees_per_second.get());
+                    }
+                }
+            ),
+        );
     }
 
     fn bind_state(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
@@ -483,6 +556,7 @@ impl PlayerPane {
                     #[strong]
                     cache,
                     move |p: Player| {
+                        this.imp().albumart_paintable.set_rotation(0.0);
                         this.update_album_art(p.current_song(), cache.clone());
                     }
                 ),
@@ -647,17 +721,94 @@ impl PlayerPane {
                 if let Some(song) = song {
                     this.imp().albumart.show_spinner();
                     match cache.get_song_cover(song.get_info(), false).await {
-                        Ok(Some(tex)) => this.imp().albumart.show(&tex),
-                        Ok(None) => this.imp().albumart.clear(),
+                        Ok(Some(tex)) => {
+                            this.imp().albumart_paintable.set_paintable(Some(&tex));
+                            this.imp().albumart.show(&this.imp().albumart_paintable);
+                        }
+                        Ok(None) => this.clear_album_art(),
                         Err(e) => {
-                            this.imp().albumart.clear();
+                            this.clear_album_art();
                             dbg!(e);
                         }
                     }
                 } else {
-                    this.imp().albumart.clear();
+                    this.clear_album_art();
                 }
             }
         ));
+    }
+
+    fn clear_album_art(&self) {
+        self.imp()
+            .albumart_paintable
+            .set_paintable(Some(&*ALBUMART_PLACEHOLDER));
+        self.imp()
+            .albumart
+            .clear_with(&self.imp().albumart_paintable);
+    }
+
+    fn set_rotate_album_art(&self, enabled: bool) {
+        self.imp().albumart_paintable.set_circular(enabled);
+        if enabled && let Some(player) = self.imp().player.upgrade() {
+            self.imp()
+                .albumart_paintable
+                .set_rotation(player.position() * self.imp().albumart_degrees_per_second.get());
+        }
+        self.imp().albumart.set_content_fit(if enabled {
+            gtk::ContentFit::Contain
+        } else {
+            gtk::ContentFit::Cover
+        });
+        self.sync_album_art_animation();
+    }
+
+    fn sync_album_art_animation(&self) {
+        let state = self
+            .imp()
+            .player
+            .upgrade()
+            .map(|player| player.state())
+            .unwrap_or(PlaybackState::Stopped);
+
+        let should_rotate =
+            self.imp().albumart_paintable.is_circular() && state == PlaybackState::Playing;
+        if !should_rotate {
+            if let Some(id) = self.imp().albumart_tick_id.take() {
+                id.remove();
+            }
+            if !self.imp().albumart_paintable.is_circular() {
+                self.imp().albumart_paintable.set_rotation(0.0);
+            }
+            return;
+        }
+        if self.imp().albumart_tick_id.borrow().is_some() {
+            return;
+        }
+
+        let last_frame_time = Cell::new(glib::monotonic_time());
+        let id = self.add_tick_callback(clone!(
+            #[weak(rename_to = this)]
+            self,
+            #[upgrade_or]
+            glib::ControlFlow::Break,
+            move |_, _| {
+                let now = glib::monotonic_time();
+                let elapsed = (now - last_frame_time.replace(now)) as f64 / 1_000_000.0;
+                this.imp().albumart_paintable.set_rotation(
+                    this.imp().albumart_paintable.rotation()
+                        + elapsed * this.imp().albumart_degrees_per_second.get(),
+                );
+                glib::ControlFlow::Continue
+            }
+        ));
+        self.imp().albumart_tick_id.replace(Some(id));
+    }
+}
+
+fn rotation_degrees_per_second(setting: f64) -> f64 {
+    if setting <= 1.0 {
+        12.0 + setting * 6.0 // Slow to medium: 30 to 20 seconds per revolution
+    } else {
+        18.0 + (setting - 1.0) * 18.0 // Medium to fast: 20 to 10 seconds per revolution
     }
 }

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -129,14 +129,26 @@ mod imp {
                 #[weak(rename_to = this)]
                 self,
                 move |paintable| {
-                    if paintable.circular()
-                        && let Some(player) = this.player.upgrade()
-                    {
-                        this.obj().snap_rotation_to_position(player.position());
+                    if paintable.circular() {
+                        this.obj().snap_album_art_to_player();
                     }
                     this.obj().sync_album_art_animation();
                 }
             ));
+            for property in ["return-to-starting-angle", "degrees-per-second"] {
+                self.albumart_paintable.connect_notify_local(
+                    Some(property),
+                    clone!(
+                        #[weak(rename_to = this)]
+                        self,
+                        move |paintable, _| {
+                            if paintable.return_to_starting_angle() {
+                                this.obj().snap_album_art_to_player();
+                            }
+                        }
+                    ),
+                );
+            }
             ui_settings
                 .bind(
                     "album-art-rotation-speed",
@@ -147,6 +159,14 @@ mod imp {
                 .mapping(|v: &Variant, _| {
                     Some(super::rotation_degrees_per_second(v.get::<f64>().unwrap()).to_value())
                 })
+                .build();
+            ui_settings
+                .bind(
+                    "return-to-starting-angle",
+                    &self.albumart_paintable,
+                    "return-to-starting-angle",
+                )
+                .get_only()
                 .build();
             ui_settings
                 .bind("rotate-album-art", &self.albumart_paintable, "circular")
@@ -310,6 +330,7 @@ impl PlayerPane {
                 ),
             )));
         self.bind_state(player, cache, client_state);
+        self.snap_album_art_to_player();
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
         self.imp().seekbar.setup(player);
@@ -709,6 +730,11 @@ impl PlayerPane {
     }
 
     fn update_album_art(&self, song: Option<Song>, cache: Rc<Cache>) {
+        self.imp().albumart_paintable.set_duration(
+            song.as_ref()
+                .and_then(|song| song.get_info().duration.as_ref())
+                .map_or(0.0, |duration| duration.as_secs_f64()),
+        );
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -732,9 +758,17 @@ impl PlayerPane {
         ));
     }
 
+    fn snap_album_art_to_player(&self) {
+        if self.imp().albumart_paintable.circular()
+            && let Some(player) = self.imp().player.upgrade()
+        {
+            self.snap_rotation_to_position(player.position());
+        }
+    }
+
     fn snap_rotation_to_position(&self, position: f64) {
         let paintable = &self.imp().albumart_paintable;
-        paintable.set_rotation((position * paintable.degrees_per_second()) % 360.0);
+        paintable.set_rotation((position * paintable.rotation_speed()) % 360.0);
     }
 
     fn sync_album_art_animation(&self) {
@@ -768,7 +802,7 @@ impl PlayerPane {
                 let elapsed = (now - last_frame_time.replace(now)) as f64 / 1_000_000.0;
                 let paintable = &this.imp().albumart_paintable;
                 paintable.set_rotation(
-                    (paintable.rotation() + elapsed * paintable.degrees_per_second()) % 360.0,
+                    (paintable.rotation() + elapsed * paintable.rotation_speed()) % 360.0,
                 );
                 glib::ControlFlow::Continue
             }

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -7,7 +7,7 @@ use gtk::{
     subclass::prelude::*,
 };
 use std::{
-    cell::{OnceCell, RefCell},
+    cell::{Cell, OnceCell, RefCell},
     fs::{self, File},
     io::Write,
     rc::Rc,
@@ -94,6 +94,8 @@ mod imp {
         pub player: WeakRef<Player>,
         pub albumart_paintable: RotatingPaintable,
         pub albumart_animation: OnceCell<adw::TimedAnimation>,
+        pub albumart_rotation_offset: Cell<f64>,
+        pub albumart_rotation_speed: Cell<f64>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
         pub song_changed_id: RefCell<Option<SignalHandlerId>>,
@@ -147,13 +149,7 @@ mod imp {
             self.albumart_paintable.connect_circular_notify(clone!(
                 #[weak(rename_to = this)]
                 self,
-                move |paintable| {
-                    if paintable.circular() {
-                        this.obj().snap_album_art_to_player();
-                    } else {
-                        this.obj().sync_album_art_animation();
-                    }
-                }
+                move |_| this.obj().resync_album_art_rotation()
             ));
             for property in ["return-to-starting-angle", "degrees-per-second"] {
                 self.albumart_paintable.connect_notify_local(
@@ -161,14 +157,9 @@ mod imp {
                     clone!(
                         #[weak(rename_to = this)]
                         self,
-                        move |paintable, _| {
-                            if paintable.return_to_starting_angle() {
-                                this.obj().snap_album_art_to_player();
-                            } else {
-                                this.obj().restart_album_art_animation(
-                                    paintable.rotation(),
-                                    paintable.rotation_speed(),
-                                );
+                        move |_, _| {
+                            if let Some(player) = this.player.upgrade() {
+                                this.obj().rebase_album_art_rotation(player.position());
                             }
                         }
                     ),
@@ -197,6 +188,9 @@ mod imp {
                 .bind("rotate-album-art", &self.albumart_paintable, "circular")
                 .get_only()
                 .build();
+            // The settings bindings above must run before reading degrees-per-second.
+            self.albumart_rotation_speed
+                .set(self.albumart_paintable.rotation_speed());
             let knob = self.vol_knob.get();
             ui_settings
                 .bind("vol-knob-unit", &knob, "use-dbfs")
@@ -261,7 +255,7 @@ mod imp {
     impl WidgetImpl for PlayerPane {
         fn map(&self) {
             self.parent_map();
-            self.obj().snap_album_art_to_player();
+            self.obj().resync_album_art_rotation();
         }
     }
 
@@ -340,11 +334,11 @@ impl PlayerPane {
                 closure_local!(
                     #[weak(rename_to = this)]
                     self,
-                    move |player: Player, album_changed: bool, automatic_transition: bool| {
+                    move |player: Player, cover_changed: bool, automatic_transition: bool| {
                         this.sync_album_art_animation_for_song(
                             player.current_song(),
                             player.position(),
-                            album_changed,
+                            cover_changed,
                             automatic_transition,
                         );
                     }
@@ -368,22 +362,19 @@ impl PlayerPane {
                     }
                 ),
             )));
-        self.sync_album_art_animation();
-        self.imp()
-            .seeked_id
-            .replace(Some(player.connect_closure(
-                "seeked",
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |_: Player, position: f64| {
-                        if this.imp().albumart_paintable.circular() {
-                            this.snap_rotation_to_position(position);
-                        }
+        self.imp().seeked_id.replace(Some(player.connect_closure(
+            "seeked",
+            false,
+            closure_local!(
+                #[weak(rename_to = this)]
+                self,
+                move |_: Player, position: f64| {
+                    if this.imp().albumart_paintable.circular() {
+                        this.resync_album_art_rotation_to(position);
                     }
-                ),
-            )));
+                }
+            ),
+        )));
         self.bind_state(player, cache, client_state);
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
@@ -809,46 +800,67 @@ impl PlayerPane {
         &self,
         song: Option<Song>,
         position: f64,
-        album_changed: bool,
+        cover_changed: bool,
         automatic_transition: bool,
     ) {
-        let imp = self.imp();
-        imp.albumart_paintable.set_duration(
-            song.as_ref()
-                .and_then(|song| song.get_info().duration.as_ref())
+        self.imp().albumart_paintable.set_duration(
+            song.and_then(|song| song.get_info().duration)
                 .map_or(0.0, |duration| duration.as_secs_f64()),
         );
-        if !album_changed && automatic_transition {
-            // MPD may advance before GTK updates the disc for the final time, so keep the last
-            // visible angle to avoid a noticeable jump when the same artwork continues
-            let rotation = imp.albumart_paintable.rotation().rem_euclid(360.0);
-            let speed = imp
-                .albumart_paintable
-                .rotation_speed_from(rotation, position);
-            self.restart_album_art_animation(rotation, speed);
-        } else if !automatic_transition && song.is_some() {
-            // Reset the artwork angle on manual song changes
-            let speed = imp.albumart_paintable.rotation_speed_from(0.0, position);
-            self.restart_album_art_animation(0.0, speed);
-        } else if song.is_some() {
-            self.snap_rotation_to_position(position);
+        if !cover_changed && automatic_transition {
+            // MPD may change tracks before GTK draws the disc's final frame. Keep the current
+            // angle to avoid a visible jump when the cover stays the same.
+            self.rebase_album_art_rotation(position);
         } else {
-            self.restart_album_art_animation(0.0, imp.albumart_paintable.rotation_speed());
+            // Ignore subsecond playback progress so new artwork starts upright.
+            self.reset_album_art_rotation(position.floor());
         }
     }
 
-    fn snap_album_art_to_player(&self) {
+    fn album_art_rotation_at(&self, position: f64) -> f64 {
+        let imp = self.imp();
+        (imp.albumart_rotation_offset.get() + position * imp.albumart_rotation_speed.get())
+            .rem_euclid(360.0)
+    }
+
+    /// Sets the angle at a playback position and records the offset later updates work from.
+    fn anchor_album_art_rotation(&self, rotation: f64, position: f64, speed: f64) {
+        let imp = self.imp();
+        imp.albumart_rotation_speed.set(speed);
+        imp.albumart_rotation_offset
+            .set(rotation - position * speed);
+        self.restart_album_art_animation(rotation, speed);
+    }
+
+    /// Starts the track upright, turning a whole number of times over its length.
+    fn reset_album_art_rotation(&self, position: f64) {
+        let speed = self.imp().albumart_paintable.rotation_speed();
+        self.anchor_album_art_rotation((position * speed).rem_euclid(360.0), position, speed);
+    }
+
+    /// Keeps the visible angle and adjusts speed so the track still ends upright.
+    fn rebase_album_art_rotation(&self, position: f64) {
+        let paintable = &self.imp().albumart_paintable;
+        let rotation = paintable.rotation().rem_euclid(360.0);
+        let speed = paintable.rotation_speed_from(rotation, position);
+        self.anchor_album_art_rotation(rotation, position, speed);
+    }
+
+    fn resync_album_art_rotation_to(&self, position: f64) {
+        self.restart_album_art_animation(
+            self.album_art_rotation_at(position),
+            self.imp().albumart_rotation_speed.get(),
+        );
+    }
+
+    fn resync_album_art_rotation(&self) {
         if self.imp().albumart_paintable.circular()
             && let Some(player) = self.imp().player.upgrade()
         {
-            self.snap_rotation_to_position(player.position());
+            self.resync_album_art_rotation_to(player.position());
+        } else {
+            self.sync_album_art_animation();
         }
-    }
-
-    fn snap_rotation_to_position(&self, position: f64) {
-        let paintable = &self.imp().albumart_paintable;
-        let speed = paintable.rotation_speed();
-        self.restart_album_art_animation((position * speed) % 360.0, speed);
     }
 
     fn restart_album_art_animation(&self, rotation: f64, speed: f64) {

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -95,7 +95,9 @@ mod imp {
         pub albumart_paintable: RotatingPaintable,
         pub albumart_animation: OnceCell<adw::TimedAnimation>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
+        pub lyrics_loading_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
+        pub song_changed_id: RefCell<Option<SignalHandlerId>>,
         pub playback_state_id: RefCell<Option<SignalHandlerId>>,
         pub seeked_id: RefCell<Option<SignalHandlerId>>,
     }
@@ -164,7 +166,10 @@ mod imp {
                             if paintable.return_to_starting_angle() {
                                 this.obj().snap_album_art_to_player();
                             } else {
-                                this.obj().restart_album_art_animation(paintable.rotation());
+                                this.obj().restart_album_art_animation(
+                                    paintable.rotation(),
+                                    paintable.rotation_speed(),
+                                );
                             }
                         }
                     ),
@@ -236,7 +241,13 @@ mod imp {
                 if let Some(id) = self.current_lyric_line_id.take() {
                     player.disconnect(id);
                 }
+                if let Some(id) = self.lyrics_loading_id.take() {
+                    player.disconnect(id);
+                }
                 if let Some(id) = self.cover_changed_id.take() {
+                    player.disconnect(id);
+                }
+                if let Some(id) = self.song_changed_id.take() {
                     player.disconnect(id);
                 }
                 if let Some(id) = self.playback_state_id.take() {
@@ -254,7 +265,7 @@ mod imp {
     impl WidgetImpl for PlayerPane {
         fn map(&self) {
             self.parent_map();
-            self.obj().sync_album_art_animation();
+            self.obj().snap_album_art_to_player();
         }
     }
 
@@ -280,9 +291,10 @@ impl PlayerPane {
 
     pub fn update_lyrics_availability(&self, player: &Player) {
         let has_lyrics = player.n_lyric_lines() > 0;
-        self.imp()
-            .lyrics_window
-            .set_visible(has_lyrics && self.imp().show_lyrics.is_active());
+        // Keep the lyrics area visible while loading so the album art does not resize between tracks
+        self.imp().lyrics_window.set_visible(
+            (has_lyrics || player.lyrics_loading()) && self.imp().show_lyrics.is_active(),
+        );
         self.imp().export_lyrics.set_sensitive(has_lyrics);
         self.imp().clear_lyrics.set_sensitive(has_lyrics);
     }
@@ -326,6 +338,30 @@ impl PlayerPane {
     pub fn setup(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
         self.imp().player.set(Some(player));
         self.imp()
+            .song_changed_id
+            .replace(Some(player.connect_closure(
+                "song-changed",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |player: Player, album_changed: bool, automatic_transition: bool| {
+                        this.sync_album_art_animation_for_song(
+                            player.current_song(),
+                            player.position(),
+                            album_changed,
+                            automatic_transition,
+                        );
+                    }
+                ),
+            )));
+        self.sync_album_art_animation_for_song(
+            player.current_song(),
+            player.position(),
+            true,
+            true,
+        );
+        self.imp()
             .playback_state_id
             .replace(Some(player.connect_notify_local(
                 Some("playback-state"),
@@ -354,7 +390,6 @@ impl PlayerPane {
                 ),
             )));
         self.bind_state(player, cache, client_state);
-        self.snap_album_art_to_player();
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
         self.imp().seekbar.setup(player);
@@ -528,6 +563,16 @@ impl PlayerPane {
                 }
             ),
         );
+        self.imp()
+            .lyrics_loading_id
+            .replace(Some(player.connect_notify_local(
+                Some("lyrics-loading"),
+                clone!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |player, _| this.update_lyrics_availability(player)
+                ),
+            )));
 
         // Synced lyrics handling:
         // - Upon loading new lyrics, player controller sets new lyrics object,
@@ -753,12 +798,6 @@ impl PlayerPane {
     }
 
     fn update_album_art(&self, song: Option<Song>, cache: Rc<Cache>) {
-        self.imp().albumart_paintable.set_duration(
-            song.as_ref()
-                .and_then(|song| song.get_info().duration.as_ref())
-                .map_or(0.0, |duration| duration.as_secs_f64()),
-        );
-        self.restart_album_art_animation(0.0);
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -782,6 +821,38 @@ impl PlayerPane {
         ));
     }
 
+    fn sync_album_art_animation_for_song(
+        &self,
+        song: Option<Song>,
+        position: f64,
+        album_changed: bool,
+        automatic_transition: bool,
+    ) {
+        let imp = self.imp();
+        imp.albumart_paintable.set_duration(
+            song.as_ref()
+                .and_then(|song| song.get_info().duration.as_ref())
+                .map_or(0.0, |duration| duration.as_secs_f64()),
+        );
+        if !album_changed && automatic_transition {
+            // MPD may advance before GTK updates the disc for the final time, so keep the last
+            // visible angle to avoid a noticeable jump when the same artwork continues
+            let rotation = imp.albumart_paintable.rotation().rem_euclid(360.0);
+            let speed = imp
+                .albumart_paintable
+                .rotation_speed_from(rotation, position);
+            self.restart_album_art_animation(rotation, speed);
+        } else if !automatic_transition && song.is_some() {
+            // Reset the artwork angle on manual song changes
+            let speed = imp.albumart_paintable.rotation_speed_from(0.0, position);
+            self.restart_album_art_animation(0.0, speed);
+        } else if song.is_some() {
+            self.snap_rotation_to_position(position);
+        } else {
+            self.restart_album_art_animation(0.0, imp.albumart_paintable.rotation_speed());
+        }
+    }
+
     fn snap_album_art_to_player(&self) {
         if self.imp().albumart_paintable.circular()
             && let Some(player) = self.imp().player.upgrade()
@@ -792,18 +863,20 @@ impl PlayerPane {
 
     fn snap_rotation_to_position(&self, position: f64) {
         let paintable = &self.imp().albumart_paintable;
-        self.restart_album_art_animation((position * paintable.rotation_speed()) % 360.0);
+        let speed = paintable.rotation_speed();
+        self.restart_album_art_animation((position * speed) % 360.0, speed);
     }
 
-    fn restart_album_art_animation(&self, rotation: f64) {
+    fn restart_album_art_animation(&self, rotation: f64, speed: f64) {
         let imp = self.imp();
         let animation = imp.albumart_animation.get().unwrap();
-        animation.reset();
-        imp.albumart_paintable.set_rotation(rotation);
+        if animation.state() == adw::AnimationState::Playing {
+            animation.pause();
+        }
         animation.set_value_from(rotation);
         animation.set_value_to(rotation + 360.0);
-        animation
-            .set_duration((360_000.0 / imp.albumart_paintable.rotation_speed()).round() as u32);
+        animation.set_duration((360_000.0 / speed).round() as u32);
+        animation.reset();
         self.sync_album_art_animation();
     }
 

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     cache::{
         Cache,
-        placeholders::{ALBUMART_PLACEHOLDER, EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
+        placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
     },
     client::{ClientState, state::StickersSupportLevel},
     common::{PictureStack, Rating, Song, paintables::RotatingPaintable},
@@ -94,10 +94,10 @@ mod imp {
         pub player: WeakRef<Player>,
         pub albumart_paintable: RotatingPaintable,
         pub albumart_tick_id: RefCell<Option<gtk::TickCallbackId>>,
-        pub albumart_degrees_per_second: Cell<f64>,
         pub current_lyric_line_id: RefCell<Option<SignalHandlerId>>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
         pub playback_state_id: RefCell<Option<SignalHandlerId>>,
+        pub seeked_id: RefCell<Option<SignalHandlerId>>,
     }
 
     // The central trait for subclassing a GObject
@@ -124,40 +124,34 @@ mod imp {
             self.parent_constructed();
             let ui_settings = settings_manager().child("ui");
 
-            self.albumart_paintable
-                .set_paintable(Some(&*ALBUMART_PLACEHOLDER));
-            self.albumart.clear_with(&self.albumart_paintable);
-
-            self.obj()
-                .set_rotate_album_art(ui_settings.boolean("rotate-album-art"));
-            self.albumart_degrees_per_second
-                .set(super::rotation_degrees_per_second(
-                    ui_settings.double("album-art-rotation-speed"),
-                ));
-            ui_settings.connect_changed(
-                Some("rotate-album-art"),
-                clone!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |settings, _| {
-                        this.obj()
-                            .set_rotate_album_art(settings.boolean("rotate-album-art"));
+            self.albumart.install_wrapper(&self.albumart_paintable);
+            self.albumart_paintable.connect_circular_notify(clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |paintable| {
+                    if paintable.circular()
+                        && let Some(player) = this.player.upgrade()
+                    {
+                        this.obj().snap_rotation_to_position(player.position());
                     }
-                ),
-            );
-            ui_settings.connect_changed(
-                Some("album-art-rotation-speed"),
-                clone!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |settings, _| {
-                        this.albumart_degrees_per_second
-                            .set(super::rotation_degrees_per_second(
-                                settings.double("album-art-rotation-speed"),
-                            ));
-                    }
-                ),
-            );
+                    this.obj().sync_album_art_animation();
+                }
+            ));
+            ui_settings
+                .bind(
+                    "album-art-rotation-speed",
+                    &self.albumart_paintable,
+                    "degrees-per-second",
+                )
+                .get_only()
+                .mapping(|v: &Variant, _| {
+                    Some(super::rotation_degrees_per_second(v.get::<f64>().unwrap()).to_value())
+                })
+                .build();
+            ui_settings
+                .bind("rotate-album-art", &self.albumart_paintable, "circular")
+                .get_only()
+                .build();
             let knob = self.vol_knob.get();
             ui_settings
                 .bind("vol-knob-unit", &knob, "use-dbfs")
@@ -205,6 +199,9 @@ mod imp {
                     player.disconnect(id);
                 }
                 if let Some(id) = self.playback_state_id.take() {
+                    player.disconnect(id);
+                }
+                if let Some(id) = self.seeked_id.take() {
                     player.disconnect(id);
                 }
             }
@@ -297,25 +294,25 @@ impl PlayerPane {
                 ),
             )));
         self.sync_album_art_animation();
+        self.imp()
+            .seeked_id
+            .replace(Some(player.connect_closure(
+                "seeked",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: Player, position: f64| {
+                        if this.imp().albumart_paintable.circular() {
+                            this.snap_rotation_to_position(position);
+                        }
+                    }
+                ),
+            )));
         self.bind_state(player, cache, client_state);
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
         self.imp().seekbar.setup(player);
-        self.imp().seekbar.connect_closure(
-            "seeked",
-            false,
-            closure_local!(
-                #[weak(rename_to = this)]
-                self,
-                move |_: Seekbar, position: f64| {
-                    if this.imp().albumart_paintable.is_circular() {
-                        this.imp()
-                            .albumart_paintable
-                            .set_rotation(position * this.imp().albumart_degrees_per_second.get());
-                    }
-                }
-            ),
-        );
     }
 
     fn bind_state(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
@@ -721,45 +718,23 @@ impl PlayerPane {
                 if let Some(song) = song {
                     this.imp().albumart.show_spinner();
                     match cache.get_song_cover(song.get_info(), false).await {
-                        Ok(Some(tex)) => {
-                            this.imp().albumart_paintable.set_paintable(Some(&tex));
-                            this.imp().albumart.show(&this.imp().albumart_paintable);
-                        }
-                        Ok(None) => this.clear_album_art(),
+                        Ok(Some(tex)) => this.imp().albumart.show(&tex),
+                        Ok(None) => this.imp().albumart.clear(),
                         Err(e) => {
-                            this.clear_album_art();
+                            this.imp().albumart.clear();
                             dbg!(e);
                         }
                     }
                 } else {
-                    this.clear_album_art();
+                    this.imp().albumart.clear();
                 }
             }
         ));
     }
 
-    fn clear_album_art(&self) {
-        self.imp()
-            .albumart_paintable
-            .set_paintable(Some(&*ALBUMART_PLACEHOLDER));
-        self.imp()
-            .albumart
-            .clear_with(&self.imp().albumart_paintable);
-    }
-
-    fn set_rotate_album_art(&self, enabled: bool) {
-        self.imp().albumart_paintable.set_circular(enabled);
-        if enabled && let Some(player) = self.imp().player.upgrade() {
-            self.imp()
-                .albumart_paintable
-                .set_rotation(player.position() * self.imp().albumart_degrees_per_second.get());
-        }
-        self.imp().albumart.set_content_fit(if enabled {
-            gtk::ContentFit::Contain
-        } else {
-            gtk::ContentFit::Cover
-        });
-        self.sync_album_art_animation();
+    fn snap_rotation_to_position(&self, position: f64) {
+        let paintable = &self.imp().albumart_paintable;
+        paintable.set_rotation((position * paintable.degrees_per_second()) % 360.0);
     }
 
     fn sync_album_art_animation(&self) {
@@ -771,13 +746,10 @@ impl PlayerPane {
             .unwrap_or(PlaybackState::Stopped);
 
         let should_rotate =
-            self.imp().albumart_paintable.is_circular() && state == PlaybackState::Playing;
+            self.imp().albumart_paintable.circular() && state == PlaybackState::Playing;
         if !should_rotate {
             if let Some(id) = self.imp().albumart_tick_id.take() {
                 id.remove();
-            }
-            if !self.imp().albumart_paintable.is_circular() {
-                self.imp().albumart_paintable.set_rotation(0.0);
             }
             return;
         }
@@ -791,12 +763,12 @@ impl PlayerPane {
             self,
             #[upgrade_or]
             glib::ControlFlow::Break,
-            move |_, _| {
-                let now = glib::monotonic_time();
+            move |_, clock| {
+                let now = clock.frame_time();
                 let elapsed = (now - last_frame_time.replace(now)) as f64 / 1_000_000.0;
-                this.imp().albumart_paintable.set_rotation(
-                    this.imp().albumart_paintable.rotation()
-                        + elapsed * this.imp().albumart_degrees_per_second.get(),
+                let paintable = &this.imp().albumart_paintable;
+                paintable.set_rotation(
+                    (paintable.rotation() + elapsed * paintable.degrees_per_second()) % 360.0,
                 );
                 glib::ControlFlow::Continue
             }
@@ -805,10 +777,7 @@ impl PlayerPane {
     }
 }
 
+// Slider values 0, 1, and 2 mean 30, 20, and 10 seconds per rotation respectively.
 fn rotation_degrees_per_second(setting: f64) -> f64 {
-    if setting <= 1.0 {
-        12.0 + setting * 6.0 // Slow to medium: 30 to 20 seconds per revolution
-    } else {
-        18.0 + (setting - 1.0) * 18.0 // Medium to fast: 20 to 10 seconds per revolution
-    }
+    360.0 / (30.0 - setting * 10.0)
 }

--- a/src/player/seekbar2.rs
+++ b/src/player/seekbar2.rs
@@ -1,9 +1,6 @@
 use crate::{common::QualityGrade, utils};
 use adw::prelude::*;
-use glib::{
-    Object, ParamSpec, ParamSpecDouble, ParamSpecObject, SignalHandlerId, WeakRef, clone,
-    subclass::Signal,
-};
+use glib::{Object, ParamSpec, ParamSpecDouble, ParamSpecObject, SignalHandlerId, WeakRef, clone};
 use gtk::{CompositeTemplate, gdk, glib, graphene, gsk, subclass::prelude::*};
 use once_cell::sync::Lazy;
 use std::cell::{Cell, OnceCell, RefCell};
@@ -119,9 +116,8 @@ mod imp {
                     if this.seekbar_clicked.get() {
                         this.seekbar_clicked.set(false);
                         this.translate_to_adjustment(x, true);
-                        let new_pos = this.adjustment.value();
-                        this.obj().emit_by_name::<()>("seeked", &[&new_pos]);
                         if let Some(player) = this.player.upgrade() {
+                            let new_pos = this.adjustment.value();
                             glib::spawn_future_local(async move {
                                 if let Err(e) = player.send_seek(new_pos).await {
                                     dbg!(e);
@@ -163,17 +159,6 @@ mod imp {
                 ]
             });
             PROPERTIES.as_ref()
-        }
-
-        fn signals() -> &'static [Signal] {
-            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
-                vec![
-                    Signal::builder("seeked")
-                        .param_types([f64::static_type()])
-                        .build(),
-                ]
-            });
-            SIGNALS.as_ref()
         }
 
         fn property(&self, _id: usize, pspec: &ParamSpec) -> glib::Value {

--- a/src/player/seekbar2.rs
+++ b/src/player/seekbar2.rs
@@ -6,7 +6,6 @@ use once_cell::sync::Lazy;
 use std::cell::{Cell, OnceCell, RefCell};
 
 use super::Player;
-use crate::player::PlaybackState;
 
 mod imp {
     use super::*;
@@ -406,19 +405,7 @@ impl Seekbar {
 
     pub fn animate(&self) {
         if let Some(anim) = self.imp().wave_anim.get() {
-            let state = self
-                .imp()
-                .player
-                .upgrade()
-                .map(|p| p.state())
-                .unwrap_or(PlaybackState::Stopped);
-            if state == PlaybackState::Playing {
-                match anim.state() {
-                    adw::AnimationState::Finished | adw::AnimationState::Idle => anim.play(),
-                    adw::AnimationState::Paused => anim.resume(),
-                    _ => {}
-                };
-            } else if anim.state() == adw::AnimationState::Playing { anim.pause() }
+            super::sync_animation(anim, super::player_is_playing(&self.imp().player));
         }
     }
 }

--- a/src/player/seekbar2.rs
+++ b/src/player/seekbar2.rs
@@ -1,6 +1,9 @@
 use crate::{common::QualityGrade, utils};
 use adw::prelude::*;
-use glib::{Object, ParamSpec, ParamSpecDouble, ParamSpecObject, SignalHandlerId, WeakRef, clone};
+use glib::{
+    Object, ParamSpec, ParamSpecDouble, ParamSpecObject, SignalHandlerId, WeakRef, clone,
+    subclass::Signal,
+};
 use gtk::{CompositeTemplate, gdk, glib, graphene, gsk, subclass::prelude::*};
 use once_cell::sync::Lazy;
 use std::cell::{Cell, OnceCell, RefCell};
@@ -116,8 +119,9 @@ mod imp {
                     if this.seekbar_clicked.get() {
                         this.seekbar_clicked.set(false);
                         this.translate_to_adjustment(x, true);
+                        let new_pos = this.adjustment.value();
+                        this.obj().emit_by_name::<()>("seeked", &[&new_pos]);
                         if let Some(player) = this.player.upgrade() {
-                            let new_pos = this.adjustment.value();
                             glib::spawn_future_local(async move {
                                 if let Err(e) = player.send_seek(new_pos).await {
                                     dbg!(e);
@@ -159,6 +163,17 @@ mod imp {
                 ]
             });
             PROPERTIES.as_ref()
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
+                vec![
+                    Signal::builder("seeked")
+                        .param_types([f64::static_type()])
+                        .build(),
+                ]
+            });
+            SIGNALS.as_ref()
         }
 
         fn property(&self, _id: usize, pspec: &ParamSpec) -> glib::Value {

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -20,6 +20,12 @@ mod imp {
         #[template_child]
         pub auto_accent: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub rotate_album_art: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub album_art_rotation_speed_row: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub album_art_rotation_speed: TemplateChild<gtk::Scale>,
+        #[template_child]
         pub use_hires_for_album_cells: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub title_wrap_mode: TemplateChild<adw::ComboRow>,
@@ -126,6 +132,27 @@ impl UIPreferences {
         let auto_accent = imp.auto_accent.get();
         ui_settings
             .bind("auto-accent", &auto_accent, "active")
+            .build();
+        let rotate_album_art = imp.rotate_album_art.get();
+        ui_settings
+            .bind("rotate-album-art", &rotate_album_art, "active")
+            .build();
+        rotate_album_art
+            .bind_property(
+                "active",
+                &imp.album_art_rotation_speed_row.get(),
+                "sensitive",
+            )
+            .sync_create()
+            .build();
+        let album_art_rotation_speed = imp.album_art_rotation_speed.get();
+        ui_settings
+            .bind(
+                "album-art-rotation-speed",
+                &album_art_rotation_speed.adjustment(),
+                "value",
+            )
+            .set()
             .build();
         let use_hires_for_album_cells = imp.use_hires_for_album_cells.get();
         ui_settings

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -152,7 +152,6 @@ impl UIPreferences {
                 &album_art_rotation_speed.adjustment(),
                 "value",
             )
-            .set()
             .build();
         let use_hires_for_album_cells = imp.use_hires_for_album_cells.get();
         ui_settings

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -20,11 +20,9 @@ mod imp {
         #[template_child]
         pub auto_accent: TemplateChild<adw::SwitchRow>,
         #[template_child]
-        pub rotate_album_art: TemplateChild<adw::SwitchRow>,
+        pub rotate_album_art: TemplateChild<adw::ExpanderRow>,
         #[template_child]
         pub return_to_starting_angle: TemplateChild<adw::SwitchRow>,
-        #[template_child]
-        pub album_art_rotation_speed_row: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub album_art_rotation_speed: TemplateChild<gtk::Scale>,
         #[template_child]
@@ -135,35 +133,24 @@ impl UIPreferences {
         ui_settings
             .bind("auto-accent", &auto_accent, "active")
             .build();
-        let rotate_album_art = imp.rotate_album_art.get();
         ui_settings
-            .bind("rotate-album-art", &rotate_album_art, "active")
+            .bind(
+                "rotate-album-art",
+                &imp.rotate_album_art.get(),
+                "enable-expansion",
+            )
             .build();
-        let return_to_starting_angle = imp.return_to_starting_angle.get();
         ui_settings
             .bind(
                 "return-to-starting-angle",
-                &return_to_starting_angle,
+                &imp.return_to_starting_angle.get(),
                 "active",
             )
             .build();
-        rotate_album_art
-            .bind_property("active", &return_to_starting_angle, "sensitive")
-            .sync_create()
-            .build();
-        rotate_album_art
-            .bind_property(
-                "active",
-                &imp.album_art_rotation_speed_row.get(),
-                "sensitive",
-            )
-            .sync_create()
-            .build();
-        let album_art_rotation_speed = imp.album_art_rotation_speed.get();
         ui_settings
             .bind(
                 "album-art-rotation-speed",
-                &album_art_rotation_speed.adjustment(),
+                &imp.album_art_rotation_speed.get().adjustment(),
                 "value",
             )
             .build();

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -22,6 +22,8 @@ mod imp {
         #[template_child]
         pub rotate_album_art: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub return_to_starting_angle: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub album_art_rotation_speed_row: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub album_art_rotation_speed: TemplateChild<gtk::Scale>,
@@ -136,6 +138,18 @@ impl UIPreferences {
         let rotate_album_art = imp.rotate_album_art.get();
         ui_settings
             .bind("rotate-album-art", &rotate_album_art, "active")
+            .build();
+        let return_to_starting_angle = imp.return_to_starting_angle.get();
+        ui_settings
+            .bind(
+                "return-to-starting-angle",
+                &return_to_starting_angle,
+                "active",
+            )
+            .build();
+        rotate_album_art
+            .bind_property("active", &return_to_starting_angle, "sensitive")
+            .sync_create()
             .build();
         rotate_album_art
             .bind_property(


### PR DESCRIPTION
Closes #113

Adds an optional rotating album cover to the Now Playing view:
- Keeps rotation synchronized even when seeking or enabling it mid-track
- Rotation speed slider
- Return to starting angle toggle