### PR TITLE
fix: long artist names widen the artist-cell

### DIFF
--- a/src/gtk/library/artist-cell.ui
+++ b/src/gtk/library/artist-cell.ui
@@ -59,9 +59,9 @@
 		
 		<child>
 			<object class="GtkLabel" id="name">
-				<property name="wrap">true</property>
+				<property name="wrap">false</property>
 				<property name="ellipsize">3</property>
-				<property name="lines">2</property>
+				<property name="lines">1</property>
 				<style>
 					<class name="caption-heading"/>
 				</style>


### PR DESCRIPTION
This restores the behaviour of v0.99.5, with long artist names trimming and getting an ellipsis at the end. Apparently a regression introduced by 7fec701.

before:
<img width="443" height="240" alt="Screenshot From 2026-08-12 07-06-07" src="https://github.com/user-attachments/assets/df10e6f0-381d-4690-9008-4675fc6dd163" />
after:
<img width="430" height="226" alt="image" src="https://github.com/user-attachments/assets/7764b400-c071-482e-a7e9-0bd41171468f" />

