### PR TITLE
Various bugfixes

### DIFF
--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -167,11 +167,6 @@
 			<summary>Maximum resolution for cached images</summary>
 		</key>
 
-		<key name="use-hires-backlog-threshold" type="u">
-			<default>10</default>
-			<summary>Number of pending cover load tasks at which hires album art loading is deferred in favor of thumbnails</summary>
-		</key>
-
 		<key name="n-image-threads" type="u">
 			<default>4</default>
 			<summary>Number of threads for image processing operations</summary>

--- a/data/io.github.htkhiem.Euphonica.gschema.xml
+++ b/data/io.github.htkhiem.Euphonica.gschema.xml
@@ -39,6 +39,18 @@
 		<value nick="stop-and-clear" value="3"/>
 	</enum>
 
+	<!-- Order matches combobox in Preferences/UI tab, while nick matches stackpage name. -->
+	<enum id="io.github.htkhiem.Euphonica.view">
+		<value nick="last" value="0"/>
+		<value nick="recent" value="1"/>
+		<value nick="albums" value="2"/>
+		<value nick="artists" value="3"/>
+		<value nick="folders" value="4"/>
+		<value nick="playlists" value="5"/>
+		<value nick="dyn-playlists" value="6"/>
+		<value nick="queue" value="7"/>
+	</enum>
+
 	<!-- Unused, but kept for compatibility -->
 	<enum id="io.github.htkhiem.Euphonica.imageformat">
 		<value nick="jpeg" value="0"/>
@@ -160,6 +172,12 @@
 
 		<key name="store-lossless-images" type="b">
 			<default>false</default>
+		</key>
+
+		<!-- No longer used but kept for compatibility -->
+		<key name="use-hires-backlog-threshold" type="u">
+			<default>10</default>
+			<summary>Number of pending cover load tasks at which hires album art loading is deferred in favor of thumbnails</summary>
 		</key>
 
 		<key name="max-image-resolution" type="u">
@@ -396,6 +414,13 @@
 		</key>
 		<key name="last-window-height" type="i">
 			<default>400</default>
+		</key>
+		<key name="last-view" enum='io.github.htkhiem.Euphonica.view'>
+			<summary>Must never be set to 'last'</summary>
+			<default>'recent'</default>
+		</key>
+		<key name="startup-view" enum='io.github.htkhiem.Euphonica.view'>
+			<default>'last'</default>
 		</key>
 
 		<!-- Background & autostart -->

--- a/src/application.rs
+++ b/src/application.rs
@@ -724,6 +724,9 @@ impl EuphonicaApplication {
     /// Quit Euphonica. Useful for when run-in-background is true. Otherwise just close the window.
     pub fn quit_app(&self) {
         self.imp().hold_guard.take();
+        if let Some(win) = self.active_window().and_downcast::<EuphonicaWindow>() {
+            win.save_state();
+        }
         self.quit();
     }
 }

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -1109,19 +1109,22 @@ impl Cache {
         &self,
         song: &SongInfo,
         external: bool,
+        overwrite: bool,   // only effective when external == true
         window: Option<&EuphonicaWindow>,
     ) -> Result<Option<Lyrics>> {
         let uri = song.uri.to_owned();
-        match self.local.call(move |_| sqlite::find_lyrics(&uri)).await {
-            Ok(Some(lyrics)) => {
-                return Ok(Some(lyrics));
-            }
-            Ok(None) => {
-                // Nothing found (haven't tried) => allow function to continue
-            }
-            Err(e) => {
-                // Includes the "do not retry case". Caller of get_lyrics() should display a "re-fetch" button.
-                return Err(Error::Sqlite(e));
+        if !overwrite & !external {
+            match self.local.call(move |_| sqlite::find_lyrics(&uri)).await {
+                Ok(Some(lyrics)) => {
+                    return Ok(Some(lyrics));
+                }
+                Ok(None) => {
+                    // Nothing found (haven't tried) => allow function to continue
+                }
+                Err(e) => {
+                    // Includes the "do not retry case". Caller of get_lyrics() should display a "re-fetch" button.
+                    return Err(Error::Sqlite(e));
+                }
             }
         }
 

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -666,7 +666,7 @@ impl Cache {
                     let title = album.title.to_owned();
                     let mbid = album.mbid.clone();
                     let artist = album.get_artist_tag().map(String::from);
-                    
+
                     self.pool
                         .push_future(move || {
                             sqlite::get_album_meta(&title, mbid.as_deref(), artist.as_deref())
@@ -801,17 +801,16 @@ impl Cache {
             return Err(Error::AlreadyExists);
         }
         self.mpd_client
-            .set_meta::<AlbumMeta>(
-                "filter",
-                filter_expr,
-                meta,
-                new_last_modified,
-            )
+            .set_meta::<AlbumMeta>("filter", filter_expr, meta, new_last_modified)
             .await
             .map_err(Error::Client)
     }
 
-    pub fn set_album_meta(&self, album: &AlbumInfo, meta: &models::AlbumMeta) -> Result<OffsetDateTime> {
+    pub fn set_album_meta(
+        &self,
+        album: &AlbumInfo,
+        meta: &models::AlbumMeta,
+    ) -> Result<OffsetDateTime> {
         sqlite::write_album_meta(album, meta, None).map_err(Error::Sqlite)
     }
 
@@ -845,9 +844,7 @@ impl Cache {
         }
 
         if external && artist.mbid.is_some() {
-            if !overwrite
-                && let Ok(Some(local_res)) = self.get_local_artist_meta(artist).await
-            {
+            if !overwrite && let Ok(Some(local_res)) = self.get_local_artist_meta(artist).await {
                 return Ok(Some(local_res));
             }
             if let Some(meta) = self
@@ -897,12 +894,7 @@ impl Cache {
             return Err(Error::AlreadyExists);
         }
         self.mpd_client
-            .set_meta::<models::ArtistMeta>(
-                "filter",
-                filter_expr,
-                meta,
-                new_last_modified,
-            )
+            .set_meta::<models::ArtistMeta>("filter", filter_expr, meta, new_last_modified)
             .await
             .map_err(Error::Client)
     }
@@ -940,9 +932,7 @@ impl Cache {
                     let name = artist.name.to_owned();
                     let mbid = artist.mbid.clone();
                     self.pool
-                        .push_future(move || {
-                            sqlite::get_artist_meta(&name, mbid.as_deref())
-                        })
+                        .push_future(move || sqlite::get_artist_meta(&name, mbid.as_deref()))
                         .expect("get_local_artist_meta: threadpool error")
                         .await
                         .expect("get_local_artist_meta: threadpool error")
@@ -963,9 +953,7 @@ impl Cache {
                         let artist = artist.to_owned();
                         if let Err(e) = self
                             .local
-                            .call(move |_| {
-                                sqlite::write_artist_meta(&artist, &to_local)
-                            })
+                            .call(move |_| sqlite::write_artist_meta(&artist, &to_local))
                             .await
                         {
                             dbg!(e);
@@ -978,9 +966,7 @@ impl Cache {
                     let name = artist.name.to_owned();
                     let mbid = artist.mbid.clone();
                     self.pool
-                        .push_future(move || {
-                            sqlite::get_artist_meta(&name, mbid.as_deref())
-                        })
+                        .push_future(move || sqlite::get_artist_meta(&name, mbid.as_deref()))
                         .expect("get_local_artist_meta: threadpool error")
                         .await
                         .expect("get_local_artist_meta: threadpool error")
@@ -992,7 +978,11 @@ impl Cache {
         }
     }
 
-    pub fn set_artist_meta(&self, artist: &ArtistInfo, meta: &models::ArtistMeta) -> Result<OffsetDateTime> {
+    pub fn set_artist_meta(
+        &self,
+        artist: &ArtistInfo,
+        meta: &models::ArtistMeta,
+    ) -> Result<OffsetDateTime> {
         sqlite::write_artist_meta(artist, meta).map_err(Error::Sqlite)
     }
 
@@ -1120,17 +1110,22 @@ impl Cache {
         window: Option<&EuphonicaWindow>,
     ) -> Result<Option<Lyrics>> {
         let uri = song.uri.to_owned();
-        let local = self
-            .local
-            .call(move |_| sqlite::find_lyrics(&uri))
-            .await
-            .map_err(Error::Sqlite)?;
-        if local.is_some() {
-            return Ok(local);
+        match self.local.call(move |_| sqlite::find_lyrics(&uri)).await {
+            Ok(Some(lyrics)) => {
+                return Ok(Some(lyrics));
+            }
+            Ok(None) => {
+                // Nothing found (haven't tried) => allow function to continue
+            }
+            Err(e) => {
+                // Includes the "do not retry case". Caller of get_lyrics() should display a "re-fetch" button.
+                return Err(Error::Sqlite(e));
+            }
         }
 
         if external {
             let song = song.to_owned();
+            println!("Fetching new lyrics...");
             let res = self.meta_providers.get_lyrics(song.clone(), window).await;
             sqlite::write_lyrics(&song, res.as_ref()).map_err(Error::Sqlite)?;
             Ok(res)

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -702,7 +702,7 @@ impl Cache {
                                 info.mbid = mbid;
                                 // Use mpd_ts such that future comparisons between this local copy and the MPD sticker version
                                 // will be exactly equal (2c).
-                                sqlite::write_album_meta(&info, &to_local, mpd_ts)
+                                sqlite::write_album_meta(&info, &to_local, mpd_ts, true)
                             })
                             .await
                         {
@@ -753,7 +753,7 @@ impl Cache {
                 .get_album_meta(album.clone(), None, window)
                 .await
             {
-                let ts = sqlite::write_album_meta(album, &meta, None).map_err(Error::Sqlite)?;
+                let ts = sqlite::write_album_meta(album, &meta, None, true).map_err(Error::Sqlite)?;
                 Ok(Some((meta, ts, models::MetaSource::External)))
             } else {
                 // Push an empty AlbumMeta to block further calls for this album.
@@ -761,7 +761,7 @@ impl Cache {
                     "No album meta could be found for {}. Pushing empty document...",
                     &album.folder_uri
                 );
-                sqlite::write_album_meta(album, &models::AlbumMeta::from_key(album), None)
+                sqlite::write_album_meta(album, &models::AlbumMeta::from_key(album), None, false)
                     .map_err(Error::Sqlite)?;
                 Ok(None)
             }
@@ -810,8 +810,9 @@ impl Cache {
         &self,
         album: &AlbumInfo,
         meta: &models::AlbumMeta,
+        update_tags: bool
     ) -> Result<OffsetDateTime> {
-        sqlite::write_album_meta(album, meta, None).map_err(Error::Sqlite)
+        sqlite::write_album_meta(album, meta, None, update_tags).map_err(Error::Sqlite)
     }
 
     pub fn set_album_tags(&self, folder_uri: &str, tags: &[models::Tag]) -> Result<()> {
@@ -852,7 +853,7 @@ impl Cache {
                 .get_artist_meta(artist.clone(), None, window)
                 .await
             {
-                let ts = sqlite::write_artist_meta(artist, &meta).map_err(Error::Sqlite)?;
+                let ts = sqlite::write_artist_meta(artist, &meta, true).map_err(Error::Sqlite)?;
                 Ok(Some((meta, ts, models::MetaSource::External)))
             } else {
                 // Push an empty ArtistMeta to block further calls for this artist.
@@ -860,7 +861,7 @@ impl Cache {
                     "No artist meta could be found for {}. Pushing empty document...",
                     &artist.name
                 );
-                sqlite::write_artist_meta(artist, &models::ArtistMeta::from_key(artist))
+                sqlite::write_artist_meta(artist, &models::ArtistMeta::from_key(artist), false)
                     .map_err(Error::Sqlite)?;
                 Ok(None)
             }
@@ -953,7 +954,7 @@ impl Cache {
                         let artist = artist.to_owned();
                         if let Err(e) = self
                             .local
-                            .call(move |_| sqlite::write_artist_meta(&artist, &to_local))
+                            .call(move |_| sqlite::write_artist_meta(&artist, &to_local, true))
                             .await
                         {
                             dbg!(e);
@@ -982,8 +983,9 @@ impl Cache {
         &self,
         artist: &ArtistInfo,
         meta: &models::ArtistMeta,
+        update_tags: bool
     ) -> Result<OffsetDateTime> {
-        sqlite::write_artist_meta(artist, meta).map_err(Error::Sqlite)
+        sqlite::write_artist_meta(artist, meta, update_tags).map_err(Error::Sqlite)
     }
 
     pub fn set_artist_tags(&self, name: &str, tags: &[models::Tag]) -> Result<()> {

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -15,7 +15,6 @@ use gtk::{
 use image::ImageReader;
 use lru::LruCache;
 use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{cmp, num::NonZeroUsize};
 use std::{fmt, fs::create_dir_all, rc::Rc, result, sync::Mutex};
 use time::OffsetDateTime;
@@ -243,16 +242,6 @@ fn download_image_from_provider(
 static IMAGE_CACHE: Lazy<Mutex<LruCache<String, Texture>>> =
     Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(1024).unwrap())));
 
-/// Threshold for deferring hires album art loading. When the pending task count
-/// reaches this value, new album art requests fall back to thumbnails.
-pub static BACKLOG_THRESHOLD: Lazy<usize> = Lazy::new(|| {
-    settings_manager()
-        .child("library")
-        .uint("use-hires-backlog-threshold")
-        .try_into()
-        .unwrap_or(10)
-});
-
 // We use an Asyncified container to queue tasks, such that two requests for the
 // same texture are never run concurrently. This allows one request to cache the
 // texture in-memory for all subsequent requests.
@@ -268,9 +257,7 @@ pub struct Cache {
     // Thread pool for parallelisable operations such as texture read from disk and resizing ops.
     pool: glib::ThreadPool,
     // Cache state object for emitting signals.
-    state: CacheState,
-    // Tracks in-flight get_cover requests for backpressure-aware hires loading.
-    pending_tasks: AtomicUsize,
+    state: CacheState
 }
 
 impl fmt::Debug for Cache {
@@ -313,8 +300,7 @@ impl Cache {
                 settings_manager().child("library").uint("n-image-threads"),
             ))
             .expect("Unable to start threadpool for cache operations"),
-            state: CacheState::default(),
-            pending_tasks: AtomicUsize::new(0),
+            state: CacheState::default()
         };
 
         Rc::new(cache)
@@ -322,11 +308,6 @@ impl Cache {
 
     pub fn get_cache_state(&self) -> CacheState {
         self.state.clone()
-    }
-
-    /// Returns the number of pending cover lookup tasks.
-    pub fn backlog(&self) -> usize {
-        self.pending_tasks.load(Ordering::Relaxed)
     }
 
     /// Try to get a cover image for the given song. This prioritises the folder-level
@@ -339,15 +320,12 @@ impl Cache {
         song: &SongInfo,
         thumbnail: bool,
     ) -> Result<Option<Texture>> {
-        // Track pending tasks for backpressure-aware hires loading.
-        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
         let folder_uri = strip_filename_linux(&song.uri).to_owned();
         let album = song.album.as_ref().cloned();
         let res = self
             .clone()
             .get_cover_internal(&folder_uri, &song.uri, thumbnail, album)
             .await;
-        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
         res
     }
 
@@ -361,8 +339,6 @@ impl Cache {
         album: &AlbumInfo,
         thumbnail: bool,
     ) -> Result<Option<Texture>> {
-        // Track pending tasks for backpressure-aware hires loading.
-        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
         let res = self
             .clone()
             .get_cover_internal(
@@ -372,7 +348,6 @@ impl Cache {
                 Some(album.to_owned()),
             )
             .await;
-        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
         res
     }
 
@@ -384,8 +359,6 @@ impl Cache {
         example_uri: &str,
         thumbnail: bool,
     ) -> Result<Option<Texture>> {
-        // Track pending tasks for backpressure-aware hires loading.
-        self.pending_tasks.fetch_add(1, Ordering::Relaxed);
         let res = self
             .clone()
             .get_cover_internal(
@@ -395,7 +368,6 @@ impl Cache {
                 None,
             )
             .await;
-        self.pending_tasks.fetch_sub(1, Ordering::Relaxed);
         res
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -5,7 +5,6 @@ mod state;
 pub use state::CacheState;
 pub mod placeholders;
 
-pub use controller::BACKLOG_THRESHOLD;
 pub use controller::Cache;
 pub use controller::Error;
 pub use controller::ImageAction;

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -417,6 +417,7 @@ pub enum Error {
     InsufficientKey,
     KeyAlreadyExists,
     Filesystem,
+    DoNotRetry  // Empty placeholder found, don't do it again
 }
 
 #[derive(Debug, Copy, Clone, Default)]
@@ -894,7 +895,7 @@ pub fn find_lyrics(uri: &str) -> Result<Option<Lyrics>, Error> {
                 let res = row.try_into().map_err(|_| Error::DocToObject)?;
                 Ok(Some(res))
             } else {
-                Ok(None)
+                Err(Error::DoNotRetry)
             }
         }
         Err(SqliteError::QueryReturnedNoRows) => Ok(None),

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -636,7 +636,7 @@ pub fn get_artist_meta_last_modified(name: &str, mbid: Option<&str>) -> Result<O
     }
 }
 
-pub fn write_album_meta(album: &AlbumInfo, meta: &AlbumMeta, last_modified: Option<OffsetDateTime>) -> Result<OffsetDateTime, Error> {
+pub fn write_album_meta(album: &AlbumInfo, meta: &AlbumMeta, last_modified: Option<OffsetDateTime>, update_tags: bool) -> Result<OffsetDateTime, Error> {
     let conn = SQLITE_POOL.get().unwrap();
     let last_modified = last_modified.unwrap_or(OffsetDateTime::now_utc());  // sqlite CURRENT_TIMESTAMP also defaults to UTC
     conn.execute(
@@ -659,15 +659,19 @@ pub fn write_album_meta(album: &AlbumInfo, meta: &AlbumMeta, last_modified: Opti
         ]
     ).map_err(Error::Db)?;
     // When populating tag lists with metadata-supplied tags, take care not to remove user-set tags.
-    write_album_tags(
-        &album.folder_uri,
-        &meta.tags,
-        TagsInsertMode::DelsertMetaSupplied,
-    )?;
+    // Also, when saving user edits to the doc, don't overwrite the tags table.
+    if update_tags {
+        write_album_tags(
+            &album.folder_uri,
+            &meta.tags,
+            TagsInsertMode::DelsertMetaSupplied,
+        )?;
+    }
+    
     Ok(last_modified)
 }
 
-pub fn write_artist_meta(artist: &ArtistInfo, meta: &ArtistMeta) -> Result<OffsetDateTime, Error> {
+pub fn write_artist_meta(artist: &ArtistInfo, meta: &ArtistMeta, update_tags: bool) -> Result<OffsetDateTime, Error> {
     let conn = SQLITE_POOL.get().unwrap();
     let ts = OffsetDateTime::now_utc();
     conn.execute(
@@ -686,11 +690,13 @@ pub fn write_artist_meta(artist: &ArtistInfo, meta: &ArtistMeta) -> Result<Offse
     )
     .map_err(Error::Db)?;
     // When populating tag lists with metadata-supplied tags, take care not to remove user-set tags.
-    write_artist_tags(
-        &artist.name,
-        &meta.tags,
-        TagsInsertMode::DelsertMetaSupplied,
-    )?;
+    if update_tags {
+        write_artist_tags(
+            &artist.name,
+            &meta.tags,
+            TagsInsertMode::DelsertMetaSupplied,
+        )?;
+    }
     Ok(ts)
 }
 

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -74,6 +74,39 @@ static META_STICKER_PAGE_SIZE: usize = 4096;
 // code (as the cache can now simply await cover art requests sent to the MPD
 // wrapper directly).
 
+/// RAII guard that decrements the fg/bg task counters exactly once, whether
+/// the future it lives in completes normally or is aborted (dropped) mid-flight.
+/// Without it, aborted calls would never decrement and the counters would leak.
+struct TaskGuard {
+    state: ClientState,
+    bg: bool,
+}
+
+impl TaskGuard {
+    fn new(state: ClientState, bg: bool) -> Self {
+        let res = Self {
+            state,
+            bg
+        };
+        if bg {
+            res.state.inc_bg();
+        } else {
+            res.state.inc_fg();
+        }
+        res
+    }
+}
+
+impl Drop for TaskGuard {
+    fn drop(&mut self) {
+        if self.bg {
+            self.state.dec_bg();
+        } else {
+            self.state.dec_fg();
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct MpdWrapper {
     // Handles return bool to indicate whether the threads stopped due to an error
@@ -350,13 +383,15 @@ impl MpdWrapper {
         task: Task,
         receiver: oneshot::Receiver<ClientResult<T>>,
     ) -> ClientResult<T> {
-        self.state.inc_fg();
+        // Decrement when this function returns OR when the future is dropped
+        // (aborted by a view navigating away), exactly once in both cases.
+        let _guard = TaskGuard {
+            state: self.state.clone(),
+            bg: false,
+        };
         self.fg_sender.send(task).await.expect("Broken FG sender");
-        let res = self
-            .handle_error(receiver.await.expect("Broken oneshot receiver"))
-            .await;
-        self.state.dec_fg();
-        res
+        self.handle_error(receiver.await.expect("Broken oneshot receiver"))
+            .await
     }
 
     async fn background<T>(
@@ -364,7 +399,12 @@ impl MpdWrapper {
         task: Task,
         receiver: oneshot::Receiver<ClientResult<T>>,
     ) -> ClientResult<T> {
-        self.state.inc_bg();
+        // Decrement when this function returns OR when the future is dropped
+        // (aborted by a view navigating away), exactly once in both cases.
+        let _guard = TaskGuard {
+            state: self.state.clone(),
+            bg: true,
+        };
         self.bg_sender.send(task).await.expect("Broken BG sender");
         // Wake background thread
         let (s, r) = oneshot::channel();
@@ -372,11 +412,8 @@ impl MpdWrapper {
         let _ = self
             .foreground(Task::SendMessage(String::from("wake"), s), r)
             .await;
-        let res = self
-            .handle_error(receiver.await.expect("Broken oneshot receiver"))
-            .await;
-        self.state.dec_bg();
-        res
+        self.handle_error(receiver.await.expect("Broken oneshot receiver"))
+            .await
     }
 
     pub async fn get_volume(&self) -> ClientResult<i8> {

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -1049,11 +1049,12 @@ impl MpdWrapper {
                             chunk,
                             Some(vec![
                                 tags::ALBUM,
+                                tags::ARTIST,  // as fallback
                                 tags::ALBUMARTIST,
                                 tags::ALBUMARTISTSORT,
                                 tags::ALBUMARTIST_MBID,
                                 tags::ALBUM_MBID,
-                                tags::ORIGINAL_DATE,
+                                tags::ORIGINAL_DATE,  // as fallback
                                 tags::DATE,
                                 tags::GENRE,
                             ]),

--- a/src/common/album.rs
+++ b/src/common/album.rs
@@ -231,7 +231,7 @@ mod imp {
                 "uri" => obj.get_folder_uri().to_value(),
                 "title" => obj.get_title().to_value(),
                 "sortable-title" => obj.get_sortable_title().to_value(),
-                "artist" => obj.get_artist_str().to_value(),
+                "artist" => obj.get_artist_tag().to_value(),
                 "rating" => obj.get_rating().unwrap_or(-1).to_value(),
                 "release-date" => glib::BoxedAnyObject::new(obj.get_release_date()).to_value(),
                 "quality-grade" => obj.get_quality_grade().to_icon_name().to_value(),
@@ -290,13 +290,6 @@ impl Album {
 
     pub fn get_genres(&self) -> &FxHashSet<String> {
         &self.get_info().genres
-    }
-
-    /// Get albumartist names separated by commas. If the first artist listed is a composer,
-    /// the next separator will be a semicolon instead. The quality of this output depends
-    /// on whether all delimiters are specified by the user.
-    pub fn get_artist_str(&self) -> Option<String> {
-        artists_to_string(&self.get_info().artists)
     }
 
     /// Get the original albumartist tag before any parsing.

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -50,6 +50,6 @@ pub enum ImageState {
 }
 
 // For use with GridViews.
-// As soon as a cell comes within this close of the render area, treat it as
-// visible & load album art early to avoid showing loading spinners.
-pub static WING_DEPTH: f64 = 384.0;
+pub static WING_DEPTH: f64 = 128.0;
+pub static FIRST_ATTEMPT_INTERVAL_MS: core::time::Duration = core::time::Duration::from_millis(50);
+pub static RE_ATTEMPT_INTERVAL_MS: core::time::Duration = core::time::Duration::from_millis(250);

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -27,6 +27,7 @@ pub use genre::split_genre_tag;
 pub use content_stack::ContentStack;
 pub use content_view::ContentView;
 pub use dynamic_playlist::DynamicPlaylist;
+use gtk::glib;
 pub use image_stack::ImageStack;
 pub use inode::{INode, INodeType};
 pub use marquee::Marquee;
@@ -51,3 +52,83 @@ pub enum ImageState {
 
 // For use with GridViews.
 pub static TEXTURE_LOAD_DELAY_MS: core::time::Duration = core::time::Duration::from_millis(50);
+
+#[derive(Default, Clone, Copy, Debug, glib::Enum, glib::Variant, Eq, PartialEq)]
+#[enum_type(name = "EuphonicaView")]
+pub enum View {
+    #[default]
+    Recents,
+    Albums,
+    Artists,
+    Folders,
+    Playlists,
+    DynamicPlaylists,
+    Queue,
+    Last  // special value, not a view
+}
+
+impl TryFrom<&str> for View {
+    type Error = ();
+    /// For mapping from GSettings
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "recent" => Ok(Self::Recents),
+            "albums" => Ok(Self::Albums),
+            "artists" => Ok(Self::Artists),
+            "folders" => Ok(Self::Folders),
+            "playlists" => Ok(Self::Playlists),
+            "dyn-playlists" => Ok(Self::DynamicPlaylists),
+            "queue" => Ok(Self::Queue),
+            "last" => Ok(Self::Last),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<u32> for View {
+    type Error = ();
+    /// For mapping from UI selection
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Recents),
+            2 => Ok(Self::Albums),
+            3 => Ok(Self::Artists),
+            4 => Ok(Self::Folders),
+            5 => Ok(Self::Playlists),
+            6 => Ok(Self::DynamicPlaylists),
+            7 => Ok(Self::Queue),
+            0 => Ok(Self::Last),
+            _ => Err(()),
+        }
+    }
+}
+
+impl View {
+    /// For setting into GSettings
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Recents => "recents",
+            Self::Albums => "albums",
+            Self::Artists => "artists",
+            Self::Folders => "folders",
+            Self::Playlists => "playlists",
+            Self::DynamicPlaylists => "dyn-playlists",
+            Self::Queue => "queue",
+            Self::Last => "last"
+        }
+    }
+
+    /// For mapping to UI menu selection
+    pub fn as_idx(&self) -> u32 {
+        match self {
+            Self::Recents => 1,
+            Self::Albums => 2,
+            Self::Artists => 3,
+            Self::Folders => 4,
+            Self::Playlists => 5,
+            Self::DynamicPlaylists => 6,
+            Self::Queue => 7,
+            Self::Last => 0
+        }
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -50,6 +50,4 @@ pub enum ImageState {
 }
 
 // For use with GridViews.
-pub static WING_DEPTH: f64 = 128.0;
-pub static FIRST_ATTEMPT_INTERVAL_MS: core::time::Duration = core::time::Duration::from_millis(50);
-pub static RE_ATTEMPT_INTERVAL_MS: core::time::Duration = core::time::Duration::from_millis(250);
+pub static TEXTURE_LOAD_DELAY_MS: core::time::Duration = core::time::Duration::from_millis(50);

--- a/src/common/song.rs
+++ b/src/common/song.rs
@@ -635,7 +635,7 @@ impl From<mpd::song::Song> for SongInfo {
 
         if let Some(album) = res.album.as_mut() {
             album.mbid = album_mbid;
-            album.albumsort = albumsort;
+            album.albumsort = albumsort;//.or_else(|| {res.artist_tag.clone()});
             album.albumartistsort = albumartistsort;
             album.release_date = res.release_date;
             album.date_tag = date_tag;
@@ -643,7 +643,7 @@ impl From<mpd::song::Song> for SongInfo {
                 album.add_genres_from_tags(&genre_tags);
             }
             // Assume the albumartist IDs are given in the same order as the albumartist tags
-            if let Some(album_artist_str) = albumartist.as_ref() {
+            if let Some(album_artist_str) = albumartist.as_ref().or_else(|| {res.artist_tag.as_ref()}) {
                 album.add_artists_from_string(album_artist_str);
             }
             album.albumartist = albumartist;

--- a/src/count-sloc.sh
+++ b/src/count-sloc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Check if a directory was provided, otherwise default to the current directory
+TARGET_DIR="${1:-.}"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "Error: Directory '$TARGET_DIR' does not exist."
+    exit 1
+fi
+
+echo "Counting lines of code in: $(realpath "$TARGET_DIR")"
+echo "----------------------------------------"
+
+find "$TARGET_DIR" -type f \( -name "*.rs" -o -name "*.ui" -o -name ".xml" \) -print0 | wc -l --files0-from=-

--- a/src/gtk/library/recent-view.ui
+++ b/src/gtk/library/recent-view.ui
@@ -202,7 +202,7 @@
                                           <object class="GtkStackPage">
                                             <property name="name">content</property>
                                             <property name="child">
-                                              <object class="GtkScrolledWindow">
+                                              <object class="GtkScrolledWindow" id="artist_window">
                                                 <property name="hscrollbar-policy">automatic</property>
                                                 <property name="vscrollbar-policy">never</property>
                                                 <property name="propagate-natural-width">true</property>

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -157,6 +157,16 @@
             </object>
           </child>
           <child>
+            <object class="GtkButton" id="refetch_lyrics">
+              <property name="label" translate="true">Search for lyrics</property>
+              <property name="visible">false</property>
+              <property name="hexpand">true</property>
+              <style>
+                <class name="suggested-action"/>
+              </style>
+            </object>
+          </child>
+          <child>
             <object class="GtkBox">
               <property name="spacing">6</property>
               <child>

--- a/src/gtk/player/pane.ui
+++ b/src/gtk/player/pane.ui
@@ -158,7 +158,7 @@
           </child>
           <child>
             <object class="GtkButton" id="refetch_lyrics">
-              <property name="label" translate="true">Search for lyrics</property>
+              <property name="label" translatable="true">Search for lyrics</property>
               <property name="visible">false</property>
               <property name="hexpand">true</property>
               <style>

--- a/src/gtk/preferences/ui.ui
+++ b/src/gtk/preferences/ui.ui
@@ -9,6 +9,26 @@
       <object class="AdwPreferencesGroup">
         <property name="title" translatable="true">General</property>
         <child>
+          <object class="AdwComboRow" id="startup_view">
+            <property name="title" translatable="true">On startup, show</property>
+            <property name="model">
+              <object class="GtkStringList">
+                <items>
+                  <item translatable="true">Last-opened view</item>
+                  <item translatable="true">Recents</item>
+                  <item translatable="true">Albums</item>
+                  <item translatable="true">Artists</item>
+                  <item translatable="true">Folders</item>
+                  <item translatable="true">Playlists</item>
+                  <item translatable="true">Dynamic Playlists</item>
+                  <item translatable="true">Queue</item>
+                </items>
+              </object>
+            </property>
+            <property name="selected">1</property>
+          </object>
+        </child>
+        <child>
           <object class="AdwSpinRow" id="max_columns">
             <property name="title" translatable="true">Maximum number of grid columns</property>
             <property name="subtitle" translatable="true">Higher settings will impact performance.</property>

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -5,6 +5,7 @@ use gtk::{
         self, Object, ParamSpec, ParamSpecBoolean, ParamSpecChar, ParamSpecInt, ParamSpecString,
         WeakRef, clone, closure_local, signal::SignalHandlerId,
     },
+    graphene,
     prelude::*,
     subclass::prelude::*,
 };
@@ -15,15 +16,13 @@ use std::{
 };
 
 use crate::{
-    window::EuphonicaWindow,
-    cache::{BACKLOG_THRESHOLD, Cache, CacheState},
-    cache::placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
+    cache::{BACKLOG_THRESHOLD, Cache, CacheState, placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING}},
     common::{
-        WING_DEPTH,
-        Album, PictureStack, Rating,
+        Album, PictureStack, Rating, WING_DEPTH,
         marquee::{Marquee, MarqueeWrapMode},
     },
-    utils::settings_manager,
+    utils::{rect_centered_at_zero, settings_manager},
+    window::EuphonicaWindow,
 };
 
 mod imp {
@@ -66,7 +65,7 @@ mod imp {
         // Use this to block loading images immediately upon construction when hires
         // is set to true (as that would trigger the setter before a viewport is set)
         pub obj_ready: Cell<bool>,
-        // Set to true when the bind-time visibility check was skipped due to 
+        // Set to true when the bind-time visibility check was skipped due to
         // backpressure.
         pub deferred: Cell<bool>,
         // Set to true when hires was deferred due to high backlog; triggers an
@@ -97,7 +96,9 @@ mod imp {
                 child.unparent();
             }
 
-            if let (Some(handler), Some(window)) = (self.check_visible_handler.take(), self.window.upgrade()) {
+            if let (Some(handler), Some(window)) =
+                (self.check_visible_handler.take(), self.window.upgrade())
+            {
                 window.disconnect(handler);
             }
 
@@ -407,7 +408,7 @@ impl AlbumCell {
                         let was_visible = imp.should_load_texture.replace(is_visible);
 
                         if is_visible {
-                            // Also go through this if visibility status didn't change, 
+                            // Also go through this if visibility status didn't change,
                             // but album art load hasn't been attempted yet.
                             if was_visible != is_visible || imp.deferred.get() {
                                 imp.deferred.set(false);
@@ -441,7 +442,7 @@ impl AlbumCell {
         self.imp().album.upgrade()
     }
 
-  fn update_cover(&self, show_spinner: bool) {
+    fn update_cover(&self, show_spinner: bool) {
         let imp = self.imp();
 
         // If hires is requested, check backlog to decide resolution.
@@ -486,7 +487,12 @@ impl AlbumCell {
                             }
                             Err(e) => {
                                 this.imp().cover.clear();
-                                eprintln!("Failed to read cover for album `{}` (URI `{}`):\n{:?}", album.get_title(), album.get_folder_uri(), e);
+                                eprintln!(
+                                    "Failed to read cover for album `{}` (URI `{}`):\n{:?}",
+                                    album.get_title(),
+                                    album.get_folder_uri(),
+                                    e
+                                );
                             }
                         }
                     }
@@ -515,27 +521,32 @@ impl AlbumCell {
         match self.imp().viewport.upgrade() {
             Some(vp) => {
                 if let Some(bounds) = self.compute_bounds(&vp) {
-                    let cell_x = bounds.x() as f64;
-                    let cell_y = bounds.y() as f64;
-                    let cell_w = bounds.width() as f64;
-                    let cell_h = bounds.height() as f64;
-                    if cell_w == 0.0 && cell_h == 0.0 {
-                        // If the bounds are the zero rectangle then we can bail early.
-                        return false;
+                    if rect_centered_at_zero(&bounds) {
+                        false
+                    } else {
+                        // eprintln!(
+                        //     "bounds: X {} Y {} W {} H {}",
+                        //     bounds.x(),
+                        //     bounds.y(),
+                        //     bounds.width(),
+                        //     bounds.height()
+                        // );
+
+                        let viewport_rect = graphene::Rect::new(
+                            -WING_DEPTH as f32,
+                            -WING_DEPTH as f32,
+                            vp.width() as f32 + WING_DEPTH as f32 * 2.0,
+                            vp.height() as f32 + WING_DEPTH as f32 * 2.0,
+                        );
+                        // eprintln!(
+                        //     "VP: X {} Y {} W {} H {}",
+                        //     viewport_rect.x(),
+                        //     viewport_rect.y(),
+                        //     viewport_rect.width(),
+                        //     viewport_rect.height()
+                        // );
+                        bounds.intersection(&viewport_rect).is_some()
                     }
-                    let vis_w = vp.width().max(0) as f64;
-                    let vis_h = vp.height().max(0) as f64;
-                    // Note: compute_bounds() on a viewport-like widget will return coordinates
-                    // in a rather weird way: always by the viewport's location within the window,
-                    // with scrolling affecting the positions of the widgets therein. In other words,
-                    // within this coordinate system, the rendered area's top left corner is always at
-                    // (0, 0) and the AlbumCell's location might be in the negative.
-                    ((cell_x <= vis_w + WING_DEPTH && cell_x >= -WING_DEPTH)
-                        || (cell_x + cell_w <= vis_w + WING_DEPTH
-                            && cell_x + cell_w >= -WING_DEPTH))
-                        && ((cell_y <= vis_h + WING_DEPTH && cell_y >= -WING_DEPTH)
-                            || (cell_y + cell_h <= vis_h + WING_DEPTH
-                                && cell_y + cell_h >= -WING_DEPTH))
                 } else {
                     false // we're in a GridView; don't load until given a bound
                 }
@@ -558,7 +569,6 @@ impl AlbumCell {
         } else {
             imp.deferred.set(true);
         }
-        
     }
 
     pub fn unbind(&self) {
@@ -590,7 +600,7 @@ impl AlbumCell {
             self.notify("hires");
             if new {
                 self.imp().deferred_hires.set(false);
-          if self.should_load_texture() {
+                if self.should_load_texture() {
                     self.update_cover(true);
                 }
             } else {

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -286,11 +286,7 @@ impl AlbumCell {
             .chain_property::<Album>("artist")
             .chain_closure::<String>(closure_local!(
                 |_: Option<glib::Object>, artist: Option<&str>| {
-                    String::from(if artist.is_none_or(|a| a.is_empty()) {
-                        *EMPTY_ARTIST_STRING
-                    } else {
-                        artist.unwrap()
-                    })
+                    artist.map(|s| s.to_owned()).unwrap_or(String::from(*EMPTY_ARTIST_STRING))
                 }
             ))
             .bind(&res, "artist", gtk::Widget::NONE);

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -5,7 +5,6 @@ use gtk::{
         self, Object, ParamSpec, ParamSpecBoolean, ParamSpecChar, ParamSpecInt, ParamSpecString,
         WeakRef, clone, closure_local, signal::SignalHandlerId,
     },
-    graphene,
     prelude::*,
     subclass::prelude::*,
 };
@@ -16,13 +15,12 @@ use std::{
 };
 
 use crate::{
-    cache::{BACKLOG_THRESHOLD, Cache, CacheState, placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING}},
+    cache::{Cache, CacheState, placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING}},
     common::{
-        Album, PictureStack, Rating, WING_DEPTH,
+        Album, PictureStack, Rating, TEXTURE_LOAD_DELAY_MS,
         marquee::{Marquee, MarqueeWrapMode},
     },
-    utils::{rect_centered_at_zero, settings_manager},
-    window::EuphonicaWindow,
+    utils::settings_manager,
 };
 
 mod imp {
@@ -53,24 +51,10 @@ mod imp {
         pub cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
         pub cache: OnceCell<Rc<Cache>>,
         pub hires: Cell<bool>,
-        // Stored GridView for visibility checks in bind() and the signal handler.
-        pub viewport: WeakRef<gtk::GridView>,
-        // Weak reference to the window for connecting to the check-visible signal.
-        pub window: WeakRef<EuphonicaWindow>,
-        // Signal handler ID for disconnecting from the window's check-visible signal.
-        pub check_visible_handler: RefCell<Option<SignalHandlerId>>,
-        // Tracks whether the cell is currently within the viewport, used
-        // to detect visibility transitions (entering/exiting the viewport).
-        pub should_load_texture: Cell<bool>,
-        // Use this to block loading images immediately upon construction when hires
-        // is set to true (as that would trigger the setter before a viewport is set)
-        pub obj_ready: Cell<bool>,
-        // Set to true when the bind-time visibility check was skipped due to
-        // backpressure.
-        pub deferred: Cell<bool>,
-        // Set to true when hires was deferred due to high backlog; triggers an
-        // upgrade to hires once the backlog drops below the threshold.
-        pub deferred_hires: Cell<bool>,
+        // Handle to the texture loading process. Can be used to abort early if unmap() is called
+        // in quick succession (such as the case described in the comment block above all this mess,
+        // or during fast scrolling).
+        pub texture_load_handle: RefCell<Option<glib::JoinHandle<()>>>,
     }
 
     // The central trait for subclassing a GObject
@@ -94,12 +78,6 @@ mod imp {
         fn dispose(&self) {
             while let Some(child) = self.obj().first_child() {
                 child.unparent();
-            }
-
-            if let (Some(handler), Some(window)) =
-                (self.check_visible_handler.take(), self.window.upgrade())
-            {
-                window.disconnect(handler);
             }
 
             if let Some((update_id, clear_id)) = self.cover_signal_ids.take() {
@@ -262,8 +240,6 @@ impl AlbumCell {
         item: &gtk::ListItem,
         cache: Rc<Cache>,
         wrap_mode: Option<MarqueeWrapMode>,
-        window: Option<crate::window::EuphonicaWindow>,
-        viewport: Option<gtk::GridView>,
     ) -> Self {
         let res: Self = Object::builder().build();
         let cache_state = cache.get_cache_state();
@@ -386,54 +362,23 @@ impl AlbumCell {
             ),
         )));
 
-        // Set up dynamic texture loading if a GridView is available.
-        if let Some(vp) = viewport {
-            res.imp().viewport.set(Some(&vp));
-        }
+        // Set up dynamic texture loading/unloading.
+        // Prev implementation was painfully clunky. I've since discovered the map() and unmap()
+        // signals. These fire as soon as a widget comes within/out of 10px of the viewport,
+        // i.e. almost ideal for texture loading.
+        // HOWEVER, map() seems to ALWAYS FIRE ONCE upon widget creation (maybe due to every new
+        // widget being created somewhere within the viewport, then moved out? or something to do
+        // with filtering being iterative?). Afterwards for widgets that end up outside of the
+        // viewport, unmap() will be fired. To avoid flooding the cache controller on startup we
+        // add a short delay on the map() signal. If unmap() comes in quick succession then we
+        // can just cancel the load before it happens.
+        res.connect_map(|res| {
+            res.load_textures_with_delay();
+        });
 
-        // Store weak reference to the window for signal connection.
-        res.imp().window.set(window.as_ref());
-
-        // Connect to the window's check-visible signal for visibility checks.
-        if let Some(window) = window {
-            let handler = window.connect_closure(
-                "check-visible",
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    res,
-                    move |_: &EuphonicaWindow| {
-                        let imp = this.imp();
-                        let is_visible = this.should_load_texture();
-                        let was_visible = imp.should_load_texture.replace(is_visible);
-
-                        if is_visible {
-                            // Also go through this if visibility status didn't change,
-                            // but album art load hasn't been attempted yet.
-                            if was_visible != is_visible || imp.deferred.get() {
-                                imp.deferred.set(false);
-                                if imp.album.upgrade().is_some() {
-                                    glib::idle_add_local_once(clone!(
-                                        #[weak]
-                                        this,
-                                        move || {
-                                            this.update_cover(true);
-                                        }
-                                    ));
-                                }
-                            } else if imp.deferred_hires.get() {
-                                this.try_upgrade_hires();
-                            }
-                        } else if was_visible != is_visible {
-                            imp.cover.clear();
-                        }
-                    }
-                ),
-            );
-            res.imp().check_visible_handler.replace(Some(handler));
-        }
-
-        res.imp().obj_ready.set(true);
+        res.connect_unmap(|res| {
+            res.unload_textures();
+        });
 
         res
     }
@@ -442,140 +387,69 @@ impl AlbumCell {
         self.imp().album.upgrade()
     }
 
-    fn update_cover(&self, show_spinner: bool) {
+    #[inline]
+    fn unload_textures(&self) {
         let imp = self.imp();
-
-        // If hires is requested, check backlog to decide resolution.
-        if imp.hires.get() {
-            let backlog = imp.cache.get().unwrap().backlog();
-            if backlog >= *BACKLOG_THRESHOLD {
-                // Too many pending tasks; defer hires and load thumbnail instead.
-                imp.deferred_hires.set(true);
-            }
-        } else {
-            imp.deferred_hires.set(false);
+        if let Some(handle) = imp.texture_load_handle.take() {
+            handle.abort();
         }
+        imp.cover.clear();
+    }
 
-        let thumbnail_for_fetch = !imp.hires.get() || imp.deferred_hires.get();
-        if show_spinner {
-            imp.cover.show_spinner();
-        }
-        glib::spawn_future_local(clone!(
-            #[weak(rename_to = this)]
-            self,
-            async move {
-                if let Some(album) = this.album() {
-                    let res = this
-                        .imp()
-                        .cache
-                        .get()
-                        .unwrap()
-                        .clone()
-                        .get_album_cover(album.get_info(), thumbnail_for_fetch)
-                        .await;
-                    // Check again as cell might have been bound to a different album
-                    // while awaiting
-                    if this.album().is_some_and(|a| {
-                        a.get_info().get_comp_id() == album.get_info().get_comp_id()
-                    }) {
-                        match res {
-                            Ok(Some(tex)) => {
-                                this.imp().cover.show(&tex);
-                            }
-                            Ok(None) => {
-                                this.imp().cover.clear();
-                            }
-                            Err(e) => {
-                                this.imp().cover.clear();
-                                eprintln!(
-                                    "Failed to read cover for album `{}` (URI `{}`):\n{:?}",
-                                    album.get_title(),
-                                    album.get_folder_uri(),
-                                    e
-                                );
-                            }
-                        }
+    #[inline]
+    async fn load_textures(&self, use_thumbnail: bool) {
+        if let Some(album) = self.album() {
+            let cache = self.imp().cache.get().unwrap();
+            self.imp().cover.show_spinner();
+            let res = cache.clone().get_album_cover(album.get_info(), use_thumbnail).await;
+            // Check again as cell might have been bound to a different album
+            // while awaiting
+            if self.album().is_some_and(|a| a.get_info().get_comp_id() == album.get_info().get_comp_id()) {
+                match res {
+                    Ok(Some(tex)) => {
+                        self.imp().cover.show(&tex);
                     }
-                }
-            }
-        ));
-    }
-
-    fn try_upgrade_hires(&self) {
-        let imp = self.imp();
-        if imp.deferred_hires.get() && self.should_load_texture() {
-            let backlog = imp.cache.get().unwrap().backlog();
-            if backlog < *BACKLOG_THRESHOLD {
-                imp.deferred_hires.set(false);
-                self.update_cover(false);
-            }
-        }
-    }
-
-    fn should_load_texture(&self) -> bool {
-        if !self.imp().obj_ready.get() {
-            return false;
-        }
-        // The road to this whole mess lies undocumented in the GTK source code.
-        // Nice use of my 2 evenings.
-        match self.imp().viewport.upgrade() {
-            Some(vp) => {
-                if let Some(bounds) = self.compute_bounds(&vp) {
-                    if rect_centered_at_zero(&bounds) {
-                        false
-                    } else {
-                        // eprintln!(
-                        //     "bounds: X {} Y {} W {} H {}",
-                        //     bounds.x(),
-                        //     bounds.y(),
-                        //     bounds.width(),
-                        //     bounds.height()
-                        // );
-
-                        let viewport_rect = graphene::Rect::new(
-                            -WING_DEPTH as f32,
-                            -WING_DEPTH as f32,
-                            vp.width() as f32 + WING_DEPTH as f32 * 2.0,
-                            vp.height() as f32 + WING_DEPTH as f32 * 2.0,
+                    Ok(None) => {
+                        self.imp().cover.clear();
+                    }
+                    Err(e) => {
+                        self.imp().cover.clear();
+                        eprintln!(
+                            "Failed to read cover for album `{}` (URI `{}`):\n{:?}",
+                            album.get_title(),
+                            album.get_folder_uri(),
+                            e
                         );
-                        // eprintln!(
-                        //     "VP: X {} Y {} W {} H {}",
-                        //     viewport_rect.x(),
-                        //     viewport_rect.y(),
-                        //     viewport_rect.width(),
-                        //     viewport_rect.height()
-                        // );
-                        bounds.intersection(&viewport_rect).is_some()
                     }
-                } else {
-                    false // we're in a GridView; don't load until given a bound
                 }
             }
-            None => true,
         }
+    }
+
+    /// Load with a delay to allow early cancel
+    fn load_textures_with_delay(&self) {
+        if let Some(handle) = self.imp().texture_load_handle.take() {
+            handle.abort();
+        }
+        let this = self.clone();
+        let _ = self
+            .imp()
+            .texture_load_handle
+            .replace(Some(glib::spawn_future_local(async move {
+                // Wait first to give unmap() a chance to cancel this outright
+                glib::timeout_future(TEXTURE_LOAD_DELAY_MS).await;
+                this.load_textures(!this.imp().hires.get()).await;
+            })));
     }
 
     pub fn bind(&self, album: &Album) {
         let imp = self.imp();
         imp.album.set(Some(album));
-        imp.deferred.set(false);
-        imp.deferred_hires.set(false);
-        // Only check this eagerly if backpressure is low
-        let backlog = imp.cache.get().unwrap().backlog();
-        if backlog < *BACKLOG_THRESHOLD {
-            if self.should_load_texture() {
-                self.update_cover(true);
-            }
-        } else {
-            imp.deferred.set(true);
-        }
     }
 
     pub fn unbind(&self) {
-        self.imp().cover.clear();
+        self.unload_textures();
         self.imp().album.set(None);
-        self.imp().deferred.set(false);
-        self.imp().deferred_hires.set(false);
     }
 
     pub fn image_size(&self) -> i32 {
@@ -598,14 +472,8 @@ impl AlbumCell {
         if old != new {
             self.imp().cover.set_is_thumbnail(!new);
             self.notify("hires");
-            if new {
-                self.imp().deferred_hires.set(false);
-                if self.should_load_texture() {
-                    self.update_cover(true);
-                }
-            } else {
-                self.imp().deferred_hires.set(false);
-            }
+
+            self.load_textures_with_delay()
         }
     }
 }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -135,6 +135,7 @@ mod imp {
         pub cover_signal_id: RefCell<Option<SignalHandlerId>>,
         pub cover_set_id: RefCell<Option<SignalHandlerId>>,
         pub cover_cleared_id: RefCell<Option<SignalHandlerId>>,
+        pub update_meta_handle: RefCell<Option<glib::JoinHandle<()>>>,
         pub cache: OnceCell<Rc<Cache>>,
         pub meta: RefCell<Option<AlbumMeta>>,
         // For sync conflict resolution
@@ -293,9 +294,9 @@ mod imp {
                                         this,
                                         async move {
                                             this.obj().backup_meta(false).await;
-                                            this.obj().update_meta(false).await;
                                         }
                                     ));
+                                    this.obj().update_meta_guarded(false);
                                 }
                             }
                             Err(e) => {
@@ -494,10 +495,10 @@ mod imp {
                             #[weak]
                             obj,
                             async move {
-                                obj.update_meta(true).await;
                                 obj.schedule_cover(true).await;
                             }
                         ));
+                        obj.update_meta_guarded(false);
                     }
                 ))
                 .build();
@@ -740,7 +741,10 @@ impl AlbumContentView {
             }
             Err(e) => {
                 if let Some(win) = self.imp().window.upgrade() {
-                    win.send_simple_toast(&format!("Couldn't back up metadata: {}", e.message()), 3);
+                    win.send_simple_toast(
+                        &format!("Couldn't back up metadata: {}", e.message()),
+                        3,
+                    );
                 }
             }
         }
@@ -770,6 +774,24 @@ impl AlbumContentView {
         }
     }
 
+    /// Wraps around update_meta, ensuring no concurrent requests (else latecomer requests will override current metadata)
+    fn update_meta_guarded(&self, overwrite: bool) {
+        if let Some(handle) = self.imp().update_meta_handle.take() {
+            handle.abort();
+        }
+        let _ = self
+            .imp()
+            .update_meta_handle
+            .replace(Some(glib::spawn_future_local(clone!(
+                #[weak(rename_to = this)]
+                self,
+                async move {
+                    this.update_meta(overwrite).await;
+                }
+            ))));
+    }
+
+    #[inline]
     async fn update_meta(&self, overwrite: bool) {
         if let Some(album) = self.album() {
             // If the current album is the "untitled" one (i.e. for songs without an album tag),
@@ -866,7 +888,10 @@ impl AlbumContentView {
 
                         // Show last-modified
                         self.imp().meta_last_updated.set_visible(true);
-                        self.imp().meta_last_updated.set_label(&format!("Last updated {}", format_datetime_local_tz(last_modified)));
+                        self.imp().meta_last_updated.set_label(&format!(
+                            "Last updated {}",
+                            format_datetime_local_tz(last_modified)
+                        ));
                     }
                     Ok(None) => {
                         self.imp().wiki_stack.show_placeholder();
@@ -1251,12 +1276,17 @@ impl AlbumContentView {
                 ));
                 // The extra fluff later
                 this.schedule_cover(false).await;
-                this.update_meta(false).await;
+                // Runs in its own async closure
+                this.update_meta_guarded(false);
             }
         ));
     }
 
     pub fn unbind(&self) {
+        if let Some(handle) = self.imp().update_meta_handle.take() {
+            handle.abort();
+        }
+        
         for binding in self.imp().bindings.take().into_iter() {
             binding.unbind();
         }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -279,7 +279,7 @@ mod imp {
                             new_meta.mbid = Some(mbid.to_string());
                         }
                         // Might want to make this async?
-                        match cache.set_album_meta(album.get_info(), &new_meta) {
+                        match cache.set_album_meta(album.get_info(), &new_meta, false) {
                             Ok(ts) => {
                                 let _ = this.meta.replace(Some(new_meta));
                                 let _ = this.new_last_modified.replace(Some(dbg!(ts)));

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -318,7 +318,7 @@ mod imp {
                             // Match either album title or AlbumArtist (not artist tag)
                             g_search_substr(Some(album.get_title()), &search_term, case_sensitive)
                                 || g_search_substr(
-                                    album.get_artist_str().as_deref(),
+                                    album.get_artist_tag(),
                                     &search_term,
                                     case_sensitive,
                                 )
@@ -330,7 +330,7 @@ mod imp {
                         2 => {
                             // Match only AlbumArtist (albums without such tag will never match)
                             g_search_substr(
-                                album.get_artist_str().as_deref(),
+                                album.get_artist_tag(),
                                 &search_term,
                                 case_sensitive,
                             )

--- a/src/library/album_view.rs
+++ b/src/library/album_view.rs
@@ -452,7 +452,7 @@ impl AlbumView {
             .window
             .set(weak)
             .expect("AlbumView window already set");
-        self.setup_gridview(cache.clone(), window);
+        self.setup_gridview(cache.clone());
 
         // Set up genres and tags filters
         self.imp().genres_filter_widget.setup(
@@ -525,7 +525,7 @@ impl AlbumView {
         }
     }
 
-    fn setup_gridview(&self, cache: Rc<Cache>, window: &EuphonicaWindow) {
+    fn setup_gridview(&self, cache: Rc<Cache>) {
         let settings = settings_manager().child("ui");
         // Setup search bar
         let album_list = self.imp().library.upgrade().unwrap().albums();
@@ -575,15 +575,11 @@ impl AlbumView {
         factory.connect_setup(clone!(
             #[weak]
             cache,
-            #[weak]
-            grid_view,
-            #[weak]
-            window,
             move |_, list_item| {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
-                let album_cell = AlbumCell::new(item, cache, None, Some(window.clone()), Some(grid_view));
+                let album_cell = AlbumCell::new(item, cache, None);
                 item.set_child(Some(&album_cell));
             }
         ));

--- a/src/library/artist_cell.rs
+++ b/src/library/artist_cell.rs
@@ -1,8 +1,7 @@
 use gtk::{
     CompositeTemplate, gdk,
     glib::{
-        self, Object, ParamSpec, ParamSpecBoolean, ParamSpecString,
-        WeakRef, clone, closure_local, signal::SignalHandlerId,
+        self, Object, ParamSpec, ParamSpecBoolean, ParamSpecString, WeakRef, closure_local,
     },
     prelude::*,
     subclass::prelude::*,
@@ -14,21 +13,22 @@ use std::{
 };
 
 use crate::{
-    cache::{
-        BACKLOG_THRESHOLD, Cache,
-        placeholders::EMPTY_ARTIST_STRING,
-    },
-    common::{
-        WING_DEPTH, Artist,
-    },
+    cache::{BACKLOG_THRESHOLD, Cache, placeholders::EMPTY_ARTIST_STRING},
+    common::{Artist, FIRST_ATTEMPT_INTERVAL_MS, RE_ATTEMPT_INTERVAL_MS},
     utils::settings_manager,
-    window::EuphonicaWindow,
 };
 
-// As soon as a cell comes within this close of the render area, treat it as
-// visible & load album art early to avoid showing loading spinners.
+// Lazy loading - eager unloading logic (RAM price crisis edition):
+// Prev implementation was painfully clunky. I've since discovered the map() and unmap() signals.
+// These fire as soon as a widget comes within/out of 10px of the viewport, i.e. almost ideal
+// for texture loading.
+// HOWEVER, map() seems to ALWAYS FIRE ONCE upon widget creation (maybe due to every new widget
+// being created somewhere within the viewport, then moved out? or something to do with filtering being iterative?).
+// Afterwards for widgets that end up outside of the viewport, unmap() will be fired. To avoid flooding the cache
+// controller on startup we add a 10ms delay on the map() signal. If unmap() comes in quick
+// succession then we can just cancel the load before it happens.
+
 mod imp {
-    
 
     use crate::common::{Artist, CoverFan};
 
@@ -48,24 +48,10 @@ mod imp {
         pub artist: WeakRef<Artist>,
         pub cache: OnceCell<Rc<Cache>>,
         pub hires: Cell<bool>,
-        // Stored GridView for visibility checks in bind() and the signal handler.
-        pub viewport: OnceCell<WeakRef<gtk::GridView>>,
-        // Weak reference to the window for connecting to the check-visible signal.
-        pub window: WeakRef<EuphonicaWindow>,
-        // Signal handler ID for disconnecting from the window's check-visible signal.
-        pub check_visible_handler: RefCell<Option<SignalHandlerId>>,
-        // Tracks whether the cell is currently within the viewport, used
-        // to detect visibility transitions (entering/exiting the viewport).
-        pub should_load_texture: Cell<bool>,
-        // Use this to block loading images immediately upon construction when hires
-        // is set to true (as that would trigger the setter before a viewport is set)
-        pub obj_ready: Cell<bool>,
-        // Set to true when the bind-time visibility check was skipped due to
-        // backpressure.
-        pub deferred: Cell<bool>,
-        // Set to true when hires was deferred due to high backlog; triggers an
-        // upgrade to hires once the backlog drops below the threshold.
-        pub deferred_hires: Cell<bool>,
+        // Handle to the texture loading process. Can be used to abort early if unmap() is called
+        // in quick succession (such as the case described in the comment block above all this mess,
+        // or during fast scrolling).
+        pub texture_load_handle: RefCell<Option<glib::JoinHandle<()>>>,
     }
 
     // The central trait for subclassing a GObject
@@ -89,12 +75,6 @@ mod imp {
         fn dispose(&self) {
             while let Some(child) = self.obj().first_child() {
                 child.unparent();
-            }
-
-            if let (Some(handler), Some(window)) =
-                (self.check_visible_handler.take(), self.window.upgrade())
-            {
-                window.disconnect(handler);
             }
         }
 
@@ -150,8 +130,6 @@ impl ArtistCell {
     pub fn new(
         item: &gtk::ListItem,
         cache: Rc<Cache>,
-        window: Option<crate::window::EuphonicaWindow>,
-        viewport: Option<gtk::GridView>,
     ) -> Self {
         let res: Self = Object::builder().build();
         res.imp()
@@ -176,56 +154,14 @@ impl ArtistCell {
             .get_only()
             .build();
 
-        // Set up dynamic texture loading if a GridView is available.
-        if let Some(vp) = viewport {
-            let weak_vp = WeakRef::new();
-            weak_vp.set(Some(&vp));
-            let _ = res.imp().viewport.set(weak_vp);
-        }
+        // Set up dynamic texture loading/unloading
+        res.connect_map(|res| {
+            res.try_load_textures_with_backlog();
+        });
 
-        // Store weak reference to the window for signal connection.
-        res.imp().window.set(window.as_ref());
-
-        // Connect to the window's check-visible signal for visibility checks.
-        if let Some(window) = window {
-            let handler = window.connect_closure(
-                "check-visible",
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    res,
-                    move |_: &EuphonicaWindow| {
-                        let imp = this.imp();
-                        let is_visible = this.should_load_texture();
-                        let was_visible = imp.should_load_texture.replace(is_visible);
-
-                        if is_visible {
-                            // Also go through this if visibility status didn't change,
-                            // but album art load hasn't been attempted yet.
-                            if was_visible != is_visible || imp.deferred.get() {
-                                imp.deferred.set(false);
-                                if imp.artist.upgrade().is_some() {
-                                    glib::idle_add_local_once(clone!(
-                                        #[weak]
-                                        this,
-                                        move || {
-                                            this.update_textures();
-                                        }
-                                    ));
-                                }
-                            } else if imp.deferred_hires.get() {
-                                this.try_upgrade_hires();
-                            }
-                        } else if was_visible != is_visible {
-                            this.unload_textures();
-                        }
-                    }
-                ),
-            );
-            res.imp().check_visible_handler.replace(Some(handler));
-        }
-
-        res.imp().obj_ready.set(true);
+        res.connect_unmap(|res| {
+            res.unload_textures(!res.imp().hires.get());
+        });
 
         res
     }
@@ -235,13 +171,16 @@ impl ArtistCell {
     }
 
     #[inline]
-    fn unload_textures(&self) {
+    fn unload_textures(&self, use_thumbnail: bool) {
+        eprintln!("Unloading");
         let imp = self.imp();
-        let thumb = !imp.hires.get();
+        if let Some(handle) = imp.texture_load_handle.take() {
+            handle.abort();
+        }
         imp.avatar.set_custom_image(Option::<&gdk::Texture>::None);
-        imp.covers.clear_cover(0, thumb);
-        imp.covers.clear_cover(1, thumb);
-        imp.covers.clear_cover(2, thumb);
+        imp.covers.clear_cover(0, use_thumbnail);
+        imp.covers.clear_cover(1, use_thumbnail);
+        imp.covers.clear_cover(2, use_thumbnail);
     }
 
     #[inline]
@@ -254,130 +193,90 @@ impl ArtistCell {
         }
     }
 
-    /// Unlike AlbumCell, ArtistCells might get quite complex so spinners aren't feasible
-    fn update_textures(&self) {
-        let imp = self.imp();
-
-        // If hires is requested, check backlog to decide resolution.
-        if imp.hires.get() {
-            let backlog = imp.cache.get().unwrap().backlog();
-            if backlog >= *BACKLOG_THRESHOLD {
-                // Too many pending tasks; defer hires and load thumbnail instead.
-                imp.deferred_hires.set(true);
-            }
-        } else {
-            imp.deferred_hires.set(false);
-        }
-
-        let thumbnail_for_fetch = !imp.hires.get() || imp.deferred_hires.get();
-        glib::spawn_future_local(clone!(
-            #[weak(rename_to = this)]
-            self,
-            async move {
-                if let Some(artist) = this.artist() {
-                    let cache = this.imp().cache.get().unwrap();
-                    match cache.clone().get_artist_avatar(
-                        artist.get_info(),
-                        thumbnail_for_fetch,
-                        false,
-                    ).await {
-                        Ok(maybe_tex) => {
-                            this.imp().avatar.set_custom_image(maybe_tex.as_ref());
-                        }
-                        Err(e) => {
-                            dbg!(e);
-                        }
-                    };
-
-                    let example_uris = &artist.get_info().example_uris;
-                    let cover_fan = this.imp().covers.get();
-                    this.set_cover_count(example_uris.len().min(3) as u8);
-                    for (i, uri) in example_uris.iter().take(3).enumerate() {
-                        match cache.clone().get_album_cover_lite(uri, thumbnail_for_fetch).await {
-                            Ok(Some(tex)) => cover_fan.set_cover(i.min(3) as u8, &tex),
-                            _ => cover_fan.clear_cover(i.min(3) as u8, thumbnail_for_fetch)
-                        };
-                    }
+    #[inline]
+    async fn load_textures(&self, use_thumbnail: bool) {
+        // If use_thumbnail and NOT due to backlog, load thumbnail then exit
+        // If use thumbnail DUE TO backlog, load thumbnail then loop
+        if let Some(artist) = self.artist() {
+            let cache = self.imp().cache.get().unwrap();
+            match cache
+                .clone()
+                .get_artist_avatar(artist.get_info(), use_thumbnail, false)
+                .await
+            {
+                Ok(maybe_tex) => {
+                    self.imp().avatar.set_custom_image(maybe_tex.as_ref());
                 }
-            }
-        ));
-    }
+                Err(e) => {
+                    dbg!(e);
+                }
+            };
 
-    fn try_upgrade_hires(&self) {
-        let imp = self.imp();
-        if imp.deferred_hires.get() && self.should_load_texture() {
-            let backlog = imp.cache.get().unwrap().backlog();
-            if backlog < *BACKLOG_THRESHOLD {
-                imp.deferred_hires.set(false);
-                self.update_textures();
+            let example_uris = &artist.get_info().example_uris;
+            let cover_fan = self.imp().covers.get();
+            self.set_cover_count(example_uris.len().min(3) as u8);
+            for (i, uri) in example_uris.iter().take(3).enumerate() {
+                match cache.clone().get_album_cover_lite(uri, use_thumbnail).await {
+                    Ok(Some(tex)) => cover_fan.set_cover(i.min(3) as u8, &tex),
+                    _ => cover_fan.clear_cover(i.min(3) as u8, use_thumbnail),
+                };
             }
         }
     }
 
-    fn should_load_texture(&self) -> bool {
-        if !self.imp().obj_ready.get() {
-            return false;
+    /// Attempt to load textures. If hires is enabled, will load hires ones only if not backlogged.
+    /// If backlogged, will attempt to load again after a short pause.
+    /// Unlike AlbumCell, ArtistCells might get quite complex so spinners aren't feasible.
+    fn try_load_textures_with_backlog(&self) {
+        if let Some(handle) = self.imp().texture_load_handle.take() {
+            handle.abort();
         }
-        // The road to this whole mess lies undocumented in the GTK source code.
-        // Nice use of my 2 evenings.
-        match self.imp().viewport.get().and_then(|w| w.upgrade()) {
-            Some(vp) => {
-                if let Some(bounds) = self.compute_bounds(&vp) {
-                    let cell_x = bounds.x() as f64;
-                    let cell_y = bounds.y() as f64;
-                    let cell_w = bounds.width() as f64;
-                    let cell_h = bounds.height() as f64;
-                    if cell_w == 0.0 && cell_h == 0.0 {
-                        // If the bounds are the zero rectangle then we can bail early.
-                        return false;
-                    }
-                    let vis_w = vp.width().max(0) as f64;
-                    let vis_h = vp.height().max(0) as f64;
-                    // Note: compute_bounds() on a viewport-like widget will return coordinates
-                    // in a rather weird way: always by the viewport's location within the window,
-                    // with scrolling affecting the positions of the widgets therein. In other words,
-                    // within this coordinate system, the rendered area's top left corner is always at
-                    // (0, 0) and the ArtistCell's location might be in the negative.
-                    ((cell_x <= vis_w + WING_DEPTH && cell_x >= -WING_DEPTH)
-                        || (cell_x + cell_w <= vis_w + WING_DEPTH
-                            && cell_x + cell_w >= -WING_DEPTH))
-                        && ((cell_y <= vis_h + WING_DEPTH && cell_y >= -WING_DEPTH)
-                            || (cell_y + cell_h <= vis_h + WING_DEPTH
-                                && cell_y + cell_h >= -WING_DEPTH))
+        let this = self.clone();
+        let _ = self
+            .imp()
+            .texture_load_handle
+            .replace(Some(glib::spawn_future_local(async move {
+                // Wait first to give unmap() a chance to cancel this outright
+                glib::timeout_future(FIRST_ATTEMPT_INTERVAL_MS).await;
+
+                let imp = this.imp();
+                if !imp.hires.get() {
+                    // If hires is disabled: just load thumbnail then bail
+                    this.load_textures(true).await;
                 } else {
-                    false // we're in a GridView; don't load until given a bound
+                    // If hires: loop attempt to load until no longer backlogged
+                    let mut loaded_thumb = false;
+                    loop {
+                        // If hires is requested, check backlog to decide resolution.
+                        if imp.cache.get().unwrap().backlog() >= *BACKLOG_THRESHOLD {
+                            if !loaded_thumb {
+                                this.load_textures(true).await;
+                                eprintln!("Backlogged. Loaded thumbnail");
+                                loaded_thumb = true;
+                            } else {
+                                eprintln!("Backlogged.");
+                            }
+                        } else {
+                            
+                            this.load_textures(false).await;
+                            eprintln!("Loaded hires");
+                            return;
+                        }
+                        // Wait after each turn
+                        glib::timeout_future(RE_ATTEMPT_INTERVAL_MS).await;
+                    }
                 }
-            }
-            None => true,
-        }
+            })));
     }
 
     pub fn bind(&self, artist: &Artist) {
         let imp = self.imp();
         imp.artist.set(Some(artist));
-        imp.deferred.set(false);
-        imp.deferred_hires.set(false);
-        // Only check this eagerly if backpressure is low
-        let backlog = imp.cache.get().unwrap().backlog();
-        if backlog < *BACKLOG_THRESHOLD {
-            // if self.should_load_texture() {
-            //     self.update_cover(true);
-            // }
-        } else {
-            imp.deferred.set(true);
-        }
     }
 
     pub fn unbind(&self) {
-        let cover_fan = self.imp().covers.get();
-        // For unbound (out-of-view) cells we don't need the high res placeholders
-        cover_fan.clear_cover(0, true);
-        cover_fan.clear_cover(1, true);
-        cover_fan.clear_cover(2, true);
+        self.unload_textures(true);
         self.imp().artist.set(None);
-        self.imp().avatar.set_custom_image(Option::<&gdk::Texture>::None);
-        self.imp().deferred.set(false);
-        self.imp().deferred_hires.set(false);
     }
 
     pub fn hires(&self) -> bool {
@@ -388,14 +287,8 @@ impl ArtistCell {
         let old = self.imp().hires.replace(new);
         if old != new {
             self.notify("hires");
-            if new {
-                self.imp().deferred_hires.set(false);
-                if self.should_load_texture() {
-                    self.update_textures();
-                }
-            } else {
-                self.imp().deferred_hires.set(false);
-            }
+
+            self.try_load_textures_with_backlog()
         }
     }
 }

--- a/src/library/artist_cell.rs
+++ b/src/library/artist_cell.rs
@@ -13,8 +13,8 @@ use std::{
 };
 
 use crate::{
-    cache::{BACKLOG_THRESHOLD, Cache, placeholders::EMPTY_ARTIST_STRING},
-    common::{Artist, FIRST_ATTEMPT_INTERVAL_MS, RE_ATTEMPT_INTERVAL_MS},
+    cache::{Cache, placeholders::EMPTY_ARTIST_STRING},
+    common::{Artist, TEXTURE_LOAD_DELAY_MS},
     utils::settings_manager,
 };
 
@@ -156,7 +156,7 @@ impl ArtistCell {
 
         // Set up dynamic texture loading/unloading
         res.connect_map(|res| {
-            res.try_load_textures_with_backlog();
+            res.load_textures_with_delay();
         });
 
         res.connect_unmap(|res| {
@@ -172,7 +172,6 @@ impl ArtistCell {
 
     #[inline]
     fn unload_textures(&self, use_thumbnail: bool) {
-        eprintln!("Unloading");
         let imp = self.imp();
         if let Some(handle) = imp.texture_load_handle.take() {
             handle.abort();
@@ -195,8 +194,6 @@ impl ArtistCell {
 
     #[inline]
     async fn load_textures(&self, use_thumbnail: bool) {
-        // If use_thumbnail and NOT due to backlog, load thumbnail then exit
-        // If use thumbnail DUE TO backlog, load thumbnail then loop
         if let Some(artist) = self.artist() {
             let cache = self.imp().cache.get().unwrap();
             match cache
@@ -224,10 +221,9 @@ impl ArtistCell {
         }
     }
 
-    /// Attempt to load textures. If hires is enabled, will load hires ones only if not backlogged.
-    /// If backlogged, will attempt to load again after a short pause.
+    /// Load textures with a short delay to allow early cancel.
     /// Unlike AlbumCell, ArtistCells might get quite complex so spinners aren't feasible.
-    fn try_load_textures_with_backlog(&self) {
+    fn load_textures_with_delay(&self) {
         if let Some(handle) = self.imp().texture_load_handle.take() {
             handle.abort();
         }
@@ -237,35 +233,8 @@ impl ArtistCell {
             .texture_load_handle
             .replace(Some(glib::spawn_future_local(async move {
                 // Wait first to give unmap() a chance to cancel this outright
-                glib::timeout_future(FIRST_ATTEMPT_INTERVAL_MS).await;
-
-                let imp = this.imp();
-                if !imp.hires.get() {
-                    // If hires is disabled: just load thumbnail then bail
-                    this.load_textures(true).await;
-                } else {
-                    // If hires: loop attempt to load until no longer backlogged
-                    let mut loaded_thumb = false;
-                    loop {
-                        // If hires is requested, check backlog to decide resolution.
-                        if imp.cache.get().unwrap().backlog() >= *BACKLOG_THRESHOLD {
-                            if !loaded_thumb {
-                                this.load_textures(true).await;
-                                eprintln!("Backlogged. Loaded thumbnail");
-                                loaded_thumb = true;
-                            } else {
-                                eprintln!("Backlogged.");
-                            }
-                        } else {
-                            
-                            this.load_textures(false).await;
-                            eprintln!("Loaded hires");
-                            return;
-                        }
-                        // Wait after each turn
-                        glib::timeout_future(RE_ATTEMPT_INTERVAL_MS).await;
-                    }
-                }
+                glib::timeout_future(TEXTURE_LOAD_DELAY_MS).await;
+                this.load_textures(!this.imp().hires.get()).await;
             })));
     }
 
@@ -288,7 +257,7 @@ impl ArtistCell {
         if old != new {
             self.notify("hires");
 
-            self.try_load_textures_with_backlog()
+            self.load_textures_with_delay()
         }
     }
 }

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -157,6 +157,7 @@ mod imp {
         pub avatar_signal_id: RefCell<Option<SignalHandlerId>>,
         pub avatar_set_id: RefCell<Option<SignalHandlerId>>,
         pub avatar_cleared_id: RefCell<Option<SignalHandlerId>>,
+        pub update_meta_handle: RefCell<Option<glib::JoinHandle<()>>>,
         pub cache: OnceCell<Rc<Cache>>,
         #[derivative(Default(value = "Cell::new(true)"))]
         pub selecting_all: Cell<bool>, // Enables queuing all songs from this artist efficiently
@@ -301,9 +302,10 @@ mod imp {
                             #[weak]
                             this,
                             async move {
-                                this.obj().update_meta(false).await;
+                                this.obj().backup_meta(false).await;
                             }
                         ));
+                        this.obj().update_meta_guarded(false);
                     }
                 }
             ));
@@ -514,10 +516,10 @@ mod imp {
                             #[weak]
                             obj,
                             async move {
-                                obj.update_meta(true).await;
                                 obj.schedule_avatar(true).await;
                             }
                         ));
+                        obj.update_meta_guarded(true);
                     }
                 ))
                 .build();
@@ -743,6 +745,24 @@ impl ArtistContentView {
         }
     }
 
+    /// Wraps around update_meta, ensuring no concurrent requests (else latecomer requests will override current metadata)
+    fn update_meta_guarded(&self, overwrite: bool) {
+        if let Some(handle) = self.imp().update_meta_handle.take() {
+            handle.abort();
+        }
+        let _ = self
+            .imp()
+            .update_meta_handle
+            .replace(Some(glib::spawn_future_local(clone!(
+                #[weak(rename_to = this)]
+                self,
+                async move {
+                    this.update_meta(overwrite).await;
+                }
+            ))));
+    }
+
+    #[inline]
     async fn update_meta(&self, overwrite: bool) {
         if let Some(artist) = self.artist() {
             // If the current artist is the "untitled" one (i.e. for songs without an artist tag),
@@ -1386,7 +1406,8 @@ impl ArtistContentView {
 
                     // The extra fluff later
                     this.schedule_avatar(false).await;
-                    this.update_meta(false).await;
+                    // Runs in its own async closure
+                    this.update_meta_guarded(false);
                 } else if let Some(win) = this.imp().window.upgrade() {                    
                     win.send_simple_toast("Unable to fetch artist content", 3);
                 }
@@ -1395,6 +1416,10 @@ impl ArtistContentView {
     }
 
     pub fn unbind(&self) {
+        if let Some(handle) = self.imp().update_meta_handle.take() {
+            handle.abort();
+        }
+
         for binding in self.imp().bindings.take().into_iter() {
             binding.unbind();
         }

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -1339,7 +1339,7 @@ impl ArtistContentView {
                                 .set_label(&release_count.to_string());
                         }
                         discography_stack.show_content();
-                        let vp = this.imp().scrolled_window.get();
+                        let _vp = this.imp().scrolled_window.get();
                         let win = this.imp().window.upgrade();
                         let count_years = albums_by_year.len();
                         // Extract genres first
@@ -1361,8 +1361,7 @@ impl ArtistContentView {
                                 maybe_albums,
                                 this.imp().cache.get().unwrap().clone(),
                                 &library,
-                                win.as_ref(),
-                                Some(&vp),
+                                win.as_ref()
                             ))
                         }
                         // 1 more loop to clear selection highlight (can't do it in the above loop as the insertion position is dictated by sort_func)

--- a/src/library/artist_content_view.rs
+++ b/src/library/artist_content_view.rs
@@ -292,7 +292,7 @@ mod imp {
                         new_meta.bio = Some(bio);
 
                         // Might want to make this async?
-                        if let Err(e) = cache.set_artist_meta(artist.get_info(), &new_meta) {
+                        if let Err(e) = cache.set_artist_meta(artist.get_info(), &new_meta, false) {
                             dbg!(e);
                         }
 

--- a/src/library/artist_view.rs
+++ b/src/library/artist_view.rs
@@ -423,7 +423,7 @@ impl ArtistView {
         }
     }
 
-    fn setup_gridview(&self, cache: Rc<Cache>, window: &EuphonicaWindow) {
+    fn setup_gridview(&self, cache: Rc<Cache>, _window: &EuphonicaWindow) {
         let settings = settings_manager().child("ui");
         // Refresh upon reconnection.
         // User-initiated refreshes will also trigger a reconnection, which will
@@ -476,18 +476,12 @@ impl ArtistView {
         factory.connect_setup(clone!(
             #[weak]
             cache,
-            #[weak]
-            grid_view,
-            #[weak]
-            window,
             move |_, list_item| {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
                 let artist_cell = ArtistCell::new(
-                    item, cache,
-                    Some(window),
-                    Some(grid_view)
+                    item, cache
                 );
                 item.set_child(Some(&artist_cell));
             }

--- a/src/library/discography_album.rs
+++ b/src/library/discography_album.rs
@@ -1,16 +1,18 @@
 use derivative::Derivative;
 use gio::{ActionEntry, Menu, SimpleActionGroup};
-use glib::{Object, SignalHandlerId, WeakRef, clone, closure_local};
+use glib::{Object, WeakRef, clone};
 use gtk::{CompositeTemplate, gio, glib, prelude::*, subclass::prelude::*};
 use std::{
-    cell::{Cell, OnceCell, RefCell},
+    cell::{OnceCell, RefCell},
     rc::Rc,
 };
 
 use crate::{
     EuphonicaWindow,
-    cache::{BACKLOG_THRESHOLD, Cache},
-    common::{Album, ContentStack, ImageStack, RowAddButtons, Song, SongRow, WING_DEPTH},
+    cache::Cache,
+    common::{
+        Album, ContentStack, TEXTURE_LOAD_DELAY_MS, ImageStack, RowAddButtons, Song, SongRow,
+    },
     utils::format_secs_as_duration,
 };
 
@@ -66,21 +68,11 @@ mod imp {
         pub cache: OnceCell<Rc<Cache>>,
         pub library: WeakRef<Library>,
         pub album: OnceCell<Album>,
-        // Stored ref to the ScrolledWindow in artist_content_view for visibility checks.
-        pub viewport: WeakRef<gtk::ScrolledWindow>,
-        // Weak reference to the window for connecting to the check-visible signal.
+        // Handle to the texture loading process. Can be used to abort early if unmap() is called
+        // in quick succession (such as the case described in the comment block above all this mess,
+        // or during fast scrolling).
+        pub texture_load_handle: RefCell<Option<glib::JoinHandle<()>>>,
         pub window: WeakRef<EuphonicaWindow>,
-        // Signal handler ID for disconnecting from the window's check-visible signal.
-        pub check_visible_handler: RefCell<Option<SignalHandlerId>>,
-        // Tracks whether this album content box is currently within the viewport, used
-        // to detect visibility transitions (entering/exiting the viewport).
-        pub should_load_texture: Cell<bool>,
-        // Set to true when the bind-time visibility check was skipped due to
-        // backpressure.
-        pub deferred: Cell<bool>,
-        // Set to true when the construction-time visibility check was skipped due to
-        // backpressure.
-        pub deferred_hires: Cell<bool>,
     }
 
     // The central trait for subclassing a GObject
@@ -217,12 +209,12 @@ impl DiscographyAlbum {
         songs: &[Song],
         cache: Rc<Cache>,
         library: &Library,
-        window: Option<&EuphonicaWindow>,
-        viewport: Option<&gtk::ScrolledWindow>,
+        window: Option<&EuphonicaWindow>
     ) -> Self {
         let res: Self = Object::builder().build();
         let _ = res.imp().cache.set(cache);
         res.imp().library.set(Some(library));
+        res.imp().window.set(window);
         if let Some(album) = album {
             res.imp().title.set_label(album.get_title());
             let _ = res.imp().album.set(album);
@@ -270,51 +262,6 @@ impl DiscographyAlbum {
             }
         ));
 
-        // Set up dynamic texture loading if a GridView is available.
-        res.imp().viewport.set(viewport);
-
-        // Store weak reference to the window for signal connection.
-        res.imp().window.set(window);
-
-        // Connect to the window's check-visible signal for visibility checks.
-        if let Some(window) = window {
-            let handler = window.connect_closure(
-                "check-visible",
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    res,
-                    move |_: &EuphonicaWindow| {
-                        let imp = this.imp();
-                        let is_visible = this.should_load_texture();
-                        let was_visible = imp.should_load_texture.replace(is_visible);
-
-                        if is_visible {
-                            // Also go through this if visibility status didn't change,
-                            // but album art load hasn't been attempted yet.
-                            if was_visible != is_visible || imp.deferred.get() {
-                                imp.deferred.set(false);
-                                if imp.album.get().is_some() {
-                                    glib::idle_add_local_once(clone!(
-                                        #[weak]
-                                        this,
-                                        move || {
-                                            this.update_cover(true);
-                                        }
-                                    ));
-                                }
-                            } else if imp.deferred_hires.get() {
-                                this.try_upgrade_hires();
-                            }
-                        } else if was_visible != is_visible {
-                            imp.cover.clear();
-                        }
-                    }
-                ),
-            );
-            res.imp().check_visible_handler.replace(Some(handler));
-        }
-
         // Set up ListBox — bind directly to song_list (no MultiSelection needed)
         res.imp().content.bind_model(
             Some(&res.imp().song_list),
@@ -349,6 +296,24 @@ impl DiscographyAlbum {
                 }
             ),
         );
+
+        // Set up dynamic texture loading/unloading.
+        // Prev implementation was painfully clunky. I've since discovered the map() and unmap()
+        // signals. These fire as soon as a widget comes within/out of 10px of the viewport,
+        // i.e. almost ideal for texture loading.
+        // HOWEVER, map() seems to ALWAYS FIRE ONCE upon widget creation (maybe due to every new
+        // widget being created somewhere within the viewport, then moved out? or something to do
+        // with filtering being iterative?). Afterwards for widgets that end up outside of the
+        // viewport, unmap() will be fired. To avoid flooding the cache controller on startup we
+        // add a short delay on the map() signal. If unmap() comes in quick succession then we
+        // can just cancel the load before it happens.
+        res.connect_map(|res| {
+            res.load_cover();
+        });
+
+        res.connect_unmap(|res| {
+            res.unload_cover();
+        });
 
         res
     }
@@ -424,132 +389,55 @@ impl DiscographyAlbum {
         }
     }
 
-    fn update_cover(&self, show_spinner: bool) {
-        let imp = self.imp();
-
-        // If hires is requested, check backlog to decide resolution.
-        let backlog = imp.cache.get().unwrap().backlog();
-        if backlog >= *BACKLOG_THRESHOLD {
-            // Too many pending tasks; defer hires and load thumbnail instead.
-            imp.deferred_hires.set(true);
+    fn load_cover(&self) {
+        if let Some(handle) = self.imp().texture_load_handle.take() {
+            handle.abort();
         }
-
-        let fetch_thumbnail_first = imp.deferred_hires.get();
-        if show_spinner {
-            imp.cover.show_spinner();
-        }
-        glib::spawn_future_local(clone!(
-            #[weak(rename_to = this)]
-            self,
-            async move {
+        let this = self.clone();
+        let _ = self
+            .imp()
+            .texture_load_handle
+            .replace(Some(glib::spawn_future_local(async move {
+                // Wait first to give unmap() a chance to cancel this outright
+                glib::timeout_future(TEXTURE_LOAD_DELAY_MS).await;
                 if let Some(album) = this.album() {
-                    let res = this
+                    match this
                         .imp()
                         .cache
                         .get()
                         .unwrap()
                         .clone()
-                        .get_album_cover(album.get_info(), fetch_thumbnail_first)
-                        .await;
-                    // Check again as cell might have been bound to a different album
-                    // while awaiting
-                    if this.album().is_some_and(|a| {
-                        a.get_info().get_comp_id() == album.get_info().get_comp_id()
-                    }) {
-                        match res {
-                            Ok(Some(tex)) => {
-                                this.imp().cover.show(&tex);
-                            }
-                            Ok(None) => {
-                                this.imp().cover.clear();
-                            }
-                            Err(e) => {
-                                this.imp().cover.clear();
-                                eprintln!(
-                                    "Failed to read cover for album `{}` (URI `{}`):\n{:?}",
-                                    album.get_title(),
-                                    album.get_folder_uri(),
-                                    e
-                                );
-                            }
+                        .get_album_cover(album.get_info(), false)
+                        .await
+                    {
+                        Ok(Some(tex)) => {
+                            this.imp().cover.show(&tex);
+                        }
+                        Ok(None) => {
+                            this.imp().cover.clear();
+                        }
+                        Err(e) => {
+                            this.imp().cover.clear();
+                            eprintln!(
+                                "Failed to read cover for album `{}` (URI `{}`):\n{:?}",
+                                album.get_title(),
+                                album.get_folder_uri(),
+                                e
+                            );
                         }
                     }
                 }
-            }
-        ));
-    }
-
-    fn try_upgrade_hires(&self) {
-        let imp = self.imp();
-        if imp.deferred_hires.get() && self.should_load_texture() {
-            let backlog = imp.cache.get().unwrap().backlog();
-            if backlog < *BACKLOG_THRESHOLD {
-                imp.deferred_hires.set(false);
-                self.update_cover(false);
-            }
-        }
-    }
-
-    fn should_load_texture(&self) -> bool {
-        // The road to this whole mess lies undocumented in the GTK source code.
-        // Nice use of my 2 evenings.
-        match self.imp().viewport.upgrade() {
-            Some(vp) => {
-                if let Some(bounds) = self.compute_bounds(&vp) {
-                    let cell_x = bounds.x() as f64;
-                    let cell_y = bounds.y() as f64;
-                    let cell_w = bounds.width() as f64;
-                    let cell_h = bounds.height() as f64;
-                    if cell_w == 0.0 && cell_h == 0.0 {
-                        // If the bounds are the zero rectangle then we can bail early.
-                        return false;
-                    }
-                    let vis_w = vp.width().max(0) as f64;
-                    let vis_h = vp.height().max(0) as f64;
-                    // Note: compute_bounds() on a viewport-like widget will return coordinates
-                    // in a rather weird way: always by the viewport's location within the window,
-                    // with scrolling affecting the positions of the widgets therein. In other words,
-                    // within this coordinate system, the rendered area's top left corner is always at
-                    // (0, 0) and the AlbumCell's location might be in the negative.
-                    ((cell_x <= vis_w + WING_DEPTH && cell_x >= -WING_DEPTH)
-                        || (cell_x + cell_w <= vis_w + WING_DEPTH
-                            && cell_x + cell_w >= -WING_DEPTH))
-                        && ((cell_y <= vis_h + WING_DEPTH && cell_y >= -WING_DEPTH)
-                            || (cell_y + cell_h <= vis_h + WING_DEPTH
-                                && cell_y + cell_h >= -WING_DEPTH))
-                } else {
-                    false // we're in a GridView; don't load until given a bound
-                }
-            }
-            None => true,
-        }
-    }
-
-    /// Actually populate with cover and content.
-    /// Called "load" instead of "bind" as this widget is meant to be used in a ListBox, which doesn't have
-    /// the bind-unbind concept as in ListViews (album info already bound at construction time).
-    pub fn load(&self) {
-        let imp = self.imp();
-        imp.deferred.set(false);
-        imp.deferred_hires.set(false);
-        // Only check this eagerly if backpressure is low
-        let backlog = imp.cache.get().unwrap().backlog();
-        if backlog < *BACKLOG_THRESHOLD {
-            if self.should_load_texture() {
-                self.update_cover(true);
-            }
-        } else {
-            imp.deferred.set(true);
-        }
+            })));
     }
 
     /// Unloads the album art to reduce memory pressure.
     /// Album content stays loaded though as unloading them screws up the content height and thus the scroll pos;
     /// they also don't cost much in perf or memory, unlike the album art.
     pub fn unload_cover(&self) {
-        self.imp().cover.clear();
-        self.imp().deferred.set(false);
-        self.imp().deferred_hires.set(false);
+        if let Some(handle) = self.imp().texture_load_handle.take() {
+            handle.abort();
+        }
+        let _ = self.imp().cover.clear();
     }
 
     pub fn on_selection_changed(&self) {

--- a/src/library/discography_year.rs
+++ b/src/library/discography_year.rs
@@ -108,8 +108,7 @@ impl DiscographyYear {
         albums_with_songs: Vec<(Option<Album>, Vec<Song>)>,
         cache: Rc<Cache>,
         library: &Library,
-        window: Option<&EuphonicaWindow>,
-        viewport: Option<&gtk::ScrolledWindow>,
+        window: Option<&EuphonicaWindow>
     ) -> Self {
         let res: Self = Object::builder().build();
         if let Some(year) = year {
@@ -119,7 +118,7 @@ impl DiscographyYear {
         for (idx, (maybe_album, songs)) in albums_with_songs.into_iter().enumerate() {
             res.imp().albums_box.append(
                 &DiscographyAlbum::new(
-                    maybe_album, &songs, cache.clone(), library, window, viewport
+                    maybe_album, &songs, cache.clone(), library, window
                 )
             );
             res.imp().albums_box.row_at_index(idx as i32).unwrap().set_activatable(false);

--- a/src/library/recent_view.rs
+++ b/src/library/recent_view.rs
@@ -305,21 +305,14 @@ impl RecentView {
             cache,
             #[weak]
             adj,
-            #[weak]
-            window,
-            #[weak(rename_to = this)]
-            self,
             move |_, list_item| {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
-                let album_row = this.imp().album_row.get();
                 let album_cell = AlbumCell::new(
                     item,
                     cache,
                     Some(MarqueeWrapMode::Scroll),
-                    Some(window.clone()),
-                    Some(album_row),
                 );
                 // propagating the tallest cell's height to the revealer if said row wasn't
                 // the first initialised.

--- a/src/library/recent_view.rs
+++ b/src/library/recent_view.rs
@@ -419,17 +419,12 @@ impl RecentView {
             cache,
             #[weak]
             adj,
-            #[weak]
-            artist_row,
-            #[weak]
-            window,
             move |_, list_item| {
                 let item = list_item
                     .downcast_ref::<ListItem>()
                     .expect("Needs to be ListItem");
                 let artist_cell = ArtistCell::new(
-                    item, cache,
-                    Some(window), Some(artist_row)
+                    item, cache
                 );
                 item.set_child(Some(&artist_cell));
                 adj.set_value(0.0);

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1171,7 +1171,7 @@ impl Player {
                                     .cache
                                     .get()
                                     .unwrap()
-                                    .get_lyrics(new_song.get_info(), true, None)
+                                    .get_lyrics(new_song.get_info(), true, false, None)   // overwrite == false means upsert
                                     .await;
                                 if !this.current_song().is_some_and(|song| {
                                     song.get_info().get_comp_id()
@@ -1999,6 +1999,15 @@ impl Player {
             && let Ok(lyrics) = Lyrics::try_from_synced_lrclib_str(text)
                 .or_else(|_| Lyrics::try_from_plain_lrclib_str(text))
         {
+            sqlite::write_lyrics(curr_song.get_info(), Some(&lyrics))
+                .expect("Unable to import lyrics into SQLite DB");
+            self.abort_lyrics_fetch();
+            self.update_lyrics(Some(lyrics));
+        }
+    }
+
+    pub fn import_lyrics_obj(&self, lyrics: Lyrics) {
+        if let Some(curr_song) = self.current_song() {
             sqlite::write_lyrics(curr_song.get_info(), Some(&lyrics))
                 .expect("Unable to import lyrics into SQLite DB");
             self.abort_lyrics_fetch();

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -1166,7 +1166,6 @@ impl Player {
                             #[strong]
                             new_song,
                             async move {
-                                println!("Fetching new lyrics...");
                                 let result = this
                                     .imp()
                                     .cache

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -290,6 +290,7 @@ impl PlayerPane {
 
     pub fn update_lyrics_state(&self, player: &Player) {
         let lyrics_box = self.imp().lyrics_box.get();
+        let lyrics_window = self.imp().lyrics_window.get();
         let n_lyric_lines = player.n_lyric_lines();
         if player.lyrics_are_synced() && self.imp().use_synced_lyrics.is_active() {
             let curr_line_idx = player.current_lyric_line();
@@ -300,19 +301,22 @@ impl PlayerPane {
                     label.set_opacity(if i == curr_line_idx { 1.0 } else { 0.2 });
                 }
             }
-            // Actually focus on several (currently 1) lines after the
-            // current one, such that the next lines are visible too.
-            // TODO: Figure out exactly how many lines ahead to focus
-            // on, based on lyrics box height, such that the current line
-            // is vertically centered.
-            let focus_line = if curr_line_idx == 0 {
-                0
-            } else {
-                (curr_line_idx + 1).min(n_lyric_lines - 1)
+            let v_adjust = lyrics_window.vadjustment();
+            if let Some(row) = lyrics_box.row_at_index(curr_line_idx as i32) {
+                let bounds = row.compute_bounds(&lyrics_box).unwrap();
+
+                // Calculate the target scroll position to center the row.
+                // Specifically, we centre the imaginary "page" within the adjustment at the row.
+                // Even more specifically cuz my future self is always dumber than right now: align
+                // the vertical midpoints of the page and the row.
+                let page_size = v_adjust.page_size() as f32;
+                let row_height = bounds.height();
+                let row_top_left = bounds.top_left();
+                let row_midpoint = row_top_left.y() + row_height / 2.0;
+                let page_top = row_midpoint - page_size / 2.0; // < 0 or > bottom is fine, GtkAdjustments will just clamp to top/bottom
+
+                v_adjust.set_value(page_top as f64);
             };
-            if let Some(row) = lyrics_box.row_at_index(focus_line as i32) {
-                row.grab_focus();
-            }
         } else {
             for i in 0..n_lyric_lines {
                 if let Some(row) = lyrics_box.row_at_index(i as i32)

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -15,13 +15,12 @@ use std::{
 
 use crate::{
     cache::{
-        Cache,
-        placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
+        Cache, placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING}
     },
     client::{ClientState, state::StickersSupportLevel},
     common::{PictureStack, Rating, Song, paintables::RotatingPaintable},
     player::seekbar2::Seekbar,
-    utils::{self, settings_manager, sync_animation},
+    utils::{self, settings_manager, sync_animation}, window::EuphonicaWindow,
 };
 
 use super::{MpdOutput, OutputControls, PlaybackControls, PlaybackState, Player, VolumeKnob};
@@ -77,6 +76,8 @@ mod imp {
         pub show_lyrics: TemplateChild<gtk::Switch>,
         #[template_child]
         pub use_synced_lyrics: TemplateChild<gtk::Switch>,
+        #[template_child]
+        pub refetch_lyrics: TemplateChild<gtk::Button>,
         #[template_child]
         pub import_lyrics: TemplateChild<gtk::Button>,
         #[template_child]
@@ -286,6 +287,7 @@ impl PlayerPane {
             .set_visible(has_lyrics && self.imp().show_lyrics.is_active());
         self.imp().export_lyrics.set_sensitive(has_lyrics);
         self.imp().clear_lyrics.set_sensitive(has_lyrics);
+        self.imp().refetch_lyrics.set_visible(!has_lyrics);
     }
 
     pub fn update_lyrics_state(&self, player: &Player) {
@@ -328,7 +330,7 @@ impl PlayerPane {
         }
     }
 
-    pub fn setup(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
+    pub fn setup(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState, win: &EuphonicaWindow) {
         self.imp().player.set(Some(player));
         self.imp()
             .song_changed_id
@@ -379,13 +381,13 @@ impl PlayerPane {
                 }
             ),
         )));
-        self.bind_state(player, cache, client_state);
+        self.bind_state(player, cache, client_state, win);
         self.imp().playback_controls.setup(player);
         self.imp().output_controls.setup(player);
         self.imp().seekbar.setup(player);
     }
 
-    fn bind_state(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState) {
+    fn bind_state(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState, win: &EuphonicaWindow) {
         let imp = self.imp();
         self.imp().vol_knob.setup(player);
         let rg_btn = self.imp().rg_btn.get();
@@ -652,6 +654,38 @@ impl PlayerPane {
                 }
             ),
         );
+
+        imp.refetch_lyrics.connect_clicked(clone!(
+            #[weak]
+            player,
+            #[weak]
+            cache,
+            #[weak]
+            win,
+            move |btn| {
+                let btn = btn.clone();
+                glib::spawn_future_local(async move {
+                    if let Some(song) = player.current_song() {
+                        btn.set_visible(false);
+                        let res = cache.get_lyrics(song.get_info(), true, true, Some(&win)).await;
+                        btn.set_visible(true);
+                        match res {
+                            Ok(Some(lyrics)) => {
+                                // Write as if user imported it
+                                player.import_lyrics_obj(lyrics);
+                            }
+                            Ok(None) => {
+                                win.send_simple_toast("No lyrics found", 3);
+                            }
+                            Err(e) => {
+                                dbg!(e);
+                                win.send_simple_toast("Could not fetch lyrics (internal error)", 3);
+                            }
+                        }
+                    }
+                });
+            }
+        ));
 
         imp.import_lyrics.connect_clicked(clone!(
             #[weak]

--- a/src/player/queue_view.rs
+++ b/src/player/queue_view.rs
@@ -954,7 +954,7 @@ impl QueueView {
     ) {
         self.imp().window.set(Some(window));
         self.setup_listview(player, cache.clone());
-        self.imp().player_pane.setup(player, cache, client_state);
+        self.imp().player_pane.setup(player, cache, client_state, window);
         self.bind_state(player);
         self.imp().player.set(Some(player));
     }

--- a/src/preferences/ui.rs
+++ b/src/preferences/ui.rs
@@ -5,7 +5,7 @@ use gtk::{
     glib::{self, Value, Variant},
 };
 
-use crate::{common::marquee::MarqueeWrapMode, utils};
+use crate::{common::{View, marquee::MarqueeWrapMode}, utils};
 
 mod imp {
     use super::*;
@@ -13,6 +13,8 @@ mod imp {
     #[derive(Debug, Default, CompositeTemplate)]
     #[template(resource = "/io/github/htkhiem/Euphonica/gtk/preferences/ui.ui")]
     pub struct UIPreferences {
+        #[template_child]
+        pub startup_view: TemplateChild<adw::ComboRow>,
         #[template_child]
         pub recent_playlists_count: TemplateChild<adw::SpinRow>,
         #[template_child]
@@ -118,7 +120,27 @@ impl UIPreferences {
         let settings = utils::settings_manager();
         let player_settings = settings.child("player");
         let ui_settings = settings.child("ui");
+        let state = settings.child("state");
         // Set up UI settings
+        let startup_view = imp.startup_view.get();
+        state
+            .bind("startup-view", &startup_view, "selected")
+            .mapping(|v: &Variant, _| {
+                Some(
+                    View::try_from(v.get::<String>().unwrap().as_str())
+                        .unwrap_or_default()
+                        .as_idx()
+                        .to_value(),
+                )
+            })
+            .set_mapping(|v: &Value, _| {
+                Some(
+                    View::try_from(v.get::<u32>().unwrap())
+                        .unwrap_or_default()
+                        .into(),
+                )
+            })
+            .build();
         let recent_playlists_count = imp.recent_playlists_count.get();
         ui_settings
             .bind("recent-playlists-count", &recent_playlists_count, "value")

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -4,7 +4,7 @@ use gtk::{CompositeTemplate, glib, prelude::*};
 use std::cell::Cell;
 
 use crate::{
-    application::EuphonicaApplication, client::state::StickersSupportLevel, common::INode, utils,
+    application::EuphonicaApplication, client::state::StickersSupportLevel, common::{INode, View}, utils,
     window::EuphonicaWindow,
 };
 
@@ -111,13 +111,12 @@ impl Sidebar {
 
     pub fn setup(&self, win: &EuphonicaWindow, app: &EuphonicaApplication) {
         let settings = utils::settings_manager().child("ui");
+        
         let stack = win.get_stack();
         let split_view = win.get_split_view();
         let player = app.get_player();
         let library = app.get_library();
         let client_state = app.get_client().get_client_state();
-        // Set default view. TODO: remember last view
-        stack.set_visible_child_name("recent");
         stack
             .bind_property("visible-child-name", self, "showing-queue-view")
             .transform_to(|_, name: String| Some(name == "queue"))
@@ -286,7 +285,7 @@ impl Sidebar {
             move |btn| {
                 if btn.is_active() {
                     dyn_playlist_view.pop();
-                    stack.set_visible_child_name("dynamic_playlists");
+                    stack.set_visible_child_name("dyn-playlists");
                 }
             }
         ));
@@ -323,9 +322,9 @@ impl Sidebar {
                                 dyn_playlist_view.on_playlist_clicked(&playlist);
                                 if stack
                                     .visible_child_name()
-                                    .is_none_or(|name| name.as_str() != "dynamic_playlists")
+                                    .is_none_or(|name| name.as_str() != "dyn-playlists")
                                 {
-                                    stack.set_visible_child_name("dynamic_playlists");
+                                    stack.set_visible_child_name("dyn-playlists");
                                 }
                                 split_view.set_show_sidebar(!split_view.is_collapsed());
                             }
@@ -426,6 +425,16 @@ impl Sidebar {
             .transform_to(|_, size: u32| Some(size.to_string()))
             .sync_create()
             .build();
+        // Set startup view.
+        // If playlists or dynamic playlists were selected as startup view or was the last
+        // view but are now not available, that view will still be displayed at first but will
+        // be empty & can't be navigated back to once moved away.
+        let state = utils::settings_manager().child("state");
+        let mut view_to_show = View::try_from(state.enum_("startup-view") as u32).expect("Invalid startup-view setting value");
+        if matches!(view_to_show, View::Last) {
+            view_to_show = View::try_from(state.enum_("last-view") as u32).expect("Invalid last-view setting value");
+        }
+        self.set_view(view_to_show.as_str());
     }
 
     pub fn set_view(&self, view_name: &str) {
@@ -434,7 +443,7 @@ impl Sidebar {
             "artists" => self.imp().artists_btn.set_active(true),
             "folders" => self.imp().folders_btn.set_active(true),
             "playlists" => self.imp().playlists_btn.set_active(true),
-            "dynamic_playlists" => self.imp().dyn_playlists_btn.set_active(true),
+            "dyn-playlists" => self.imp().dyn_playlists_btn.set_active(true),
             "recent" => self.imp().recent_btn.set_active(true),
             "queue" => self.imp().queue_btn.set_active(true),
             _ => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use aho_corasick::AhoCorasick;
 use gtk::{
     Ordering, gdk,
     gio::{self},
-    glib, graphene,
+    glib,
 };
 use image::{DynamicImage, imageops::FilterType};
 use mpd::status::AudioFormat;
@@ -634,11 +634,4 @@ pub fn sync_animation(animation: &adw::TimedAnimation, should_run: bool) {
     } else if animation.state() == adw::AnimationState::Playing {
         animation.pause();
     }
-}
-
-/// Mostly used to detect a delegate being kept alive but not shown (in gridviews)
-#[inline]
-pub fn rect_centered_at_zero(rect: &graphene::Rect) -> bool {
-    (rect.x() as f32 + rect.width() as f32 / 2.0).abs() < 0.5
-        && (rect.y() as f32 + rect.height() as f32 / 2.0).abs() < 0.5
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,11 @@
 use crate::cache::sqlite;
 use crate::config::APPLICATION_ID;
+use adw::prelude::*;
 use aho_corasick::AhoCorasick;
 use gtk::{
     Ordering, gdk,
-    gio::{self, prelude::*},
-    glib,
+    gio::{self},
+    glib, graphene,
 };
 use image::{DynamicImage, imageops::FilterType};
 use mpd::status::AudioFormat;
@@ -26,7 +27,6 @@ use time::error::IndeterminateOffset;
 use time::format_description::{OwnedFormatItem, parse_owned};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
-use adw::prelude::*;
 
 static APP_CACHE_PATH: Lazy<PathBuf> = Lazy::new(|| {
     let mut res = glib::user_cache_dir();
@@ -237,14 +237,16 @@ pub fn resize_convert_image(dyn_img: DynamicImage) -> (DynamicImage, DynamicImag
         )
     };
     (
-        DynamicImage::ImageRgb8(dyn_img
-            .resize(hires_size, hires_size, FilterType::Triangle)
-            .to_rgb8()
+        DynamicImage::ImageRgb8(
+            dyn_img
+                .resize(hires_size, hires_size, FilterType::Triangle)
+                .to_rgb8(),
         ),
-        DynamicImage::ImageRgb8(dyn_img
-            .thumbnail(thumbnail_sizes.0, thumbnail_sizes.1)
-            .to_rgb8()
-        )
+        DynamicImage::ImageRgb8(
+            dyn_img
+                .thumbnail(thumbnail_sizes.0, thumbnail_sizes.1)
+                .to_rgb8(),
+        ),
     )
 }
 
@@ -263,7 +265,7 @@ pub fn save_and_register_single_image(
     if settings.boolean("store-lossless-images") {
         // WebP encoder in rust image crate is lossless
         img.save_with_format(&path, image::ImageFormat::WebP)
-        .unwrap_or_else(|_| panic!("Couldn't save downloaded image to {:?}", &path));
+            .unwrap_or_else(|_| panic!("Couldn't save downloaded image to {:?}", &path));
     } else {
         let encoder = webp::Encoder::from_image(img).unwrap();
         // Default to 90% quality (not sure if this should even be user selectable)
@@ -290,7 +292,9 @@ impl RegisteredImage {
                 .set_height(rgb_image.height() as i32)
                 .set_format(gdk::MemoryFormat::R8g8b8)
                 .set_stride((rgb_image.width() * 3) as usize)
-                .set_bytes(Some(&glib::Bytes::from_owned(rgb_image.to_rgb8().into_raw())))
+                .set_bytes(Some(&glib::Bytes::from_owned(
+                    rgb_image.to_rgb8().into_raw(),
+                )))
                 .build())
         } else {
             let mut res = get_image_cache_path();
@@ -330,7 +334,7 @@ pub fn save_and_register_image(
     dyn_img: DynamicImage,
     key: &str,
     prefix: Option<&'static str>,
-) -> RegisteredImageBundle {    
+) -> RegisteredImageBundle {
     let (hires_img, thumb_img) = resize_convert_image(dyn_img);
     let hires_k = save_and_register_single_image(&hires_img, key, prefix, false);
     let thumb_k = save_and_register_single_image(&thumb_img, key, prefix, true);
@@ -418,7 +422,9 @@ pub async fn new_gtksvg_from_datafile(relpath: &str) -> Option<gtk::Svg> {
     path.push(crate::PKGDATADIR);
     path.push(relpath);
     let file = gio::File::for_path(&path);
-    Some(gtk::Svg::from_bytes(&file.load_bytes_future().await.ok().map(|tup| tup.0)?))
+    Some(gtk::Svg::from_bytes(
+        &file.load_bytes_future().await.ok().map(|tup| tup.0)?,
+    ))
 }
 
 // Build Aho-Corasick automatons only once. In case no delimiter or exception is
@@ -607,15 +613,14 @@ pub fn get_time_ago_desc(past_ts: i64) -> String {
     }
 }
 
-
 /// Serialise MPD argument types into string in their MPD protocol (sans escaping).
 pub fn mpd_args_to_string<T: mpd::ToArguments>(args: T) -> String {
     let mut output = Vec::<String>::new();
     args.to_arguments::<_, ()>(&mut |arg| {
-            output.push(arg.to_string());
-            Ok(())
-        })
-        .unwrap();
+        output.push(arg.to_string());
+        Ok(())
+    })
+    .unwrap();
     output.join(" ")
 }
 
@@ -629,4 +634,11 @@ pub fn sync_animation(animation: &adw::TimedAnimation, should_run: bool) {
     } else if animation.state() == adw::AnimationState::Playing {
         animation.pause();
     }
+}
+
+/// Mostly used to detect a delegate being kept alive but not shown (in gridviews)
+#[inline]
+pub fn rect_centered_at_zero(rect: &graphene::Rect) -> bool {
+    (rect.x() as f32 + rect.width() as f32 / 2.0).abs() < 0.5
+        && (rect.y() as f32 + rect.height() as f32 / 2.0).abs() < 0.5
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -19,10 +19,16 @@
  */
 
 use crate::{
-    application::EuphonicaApplication, client::{ClientState, ConnectionState, Result as ClientResult}, common::{Album, Artist, INode, ThemeSelector, paintables::FadePaintable}, library::{
+    application::EuphonicaApplication,
+    client::{ClientState, ConnectionState, Result as ClientResult},
+    common::{Album, Artist, INode, ThemeSelector, View, paintables::FadePaintable},
+    library::{
         AlbumView, ArtistContentView, ArtistView, DynamicPlaylistEditorView, DynamicPlaylistView,
         FolderView, PlaylistView, RecentView,
-    }, player::{Player, PlayerBar, QueueView}, sidebar::Sidebar, utils::{self, LazyInit, SearchableView, settings_manager},
+    },
+    player::{Player, PlayerBar, QueueView},
+    sidebar::Sidebar,
+    utils::{self, LazyInit, SearchableView, settings_manager},
 };
 use adw::{ColorScheme, StyleManager, prelude::*, subclass::prelude::*};
 use auto_palette::{ImageData, Palette, color::RGB};
@@ -159,6 +165,8 @@ pub enum WindowMessage {
 }
 
 mod imp {
+    use crate::common::View;
+
     use super::*;
 
     #[derive(Debug, Default, Properties, gtk::CompositeTemplate)]
@@ -1591,7 +1599,7 @@ impl EuphonicaWindow {
                 "playlists" => {
                     imp.playlist_view.trigger_search();
                 }
-                "dynamic_playlists" => {
+                "dyn-playlists" => {
                     imp.dyn_playlist_view.trigger_search();
                 }
                 "queue" => {
@@ -1643,7 +1651,7 @@ impl EuphonicaWindow {
 
             imp.dyn_playlist_view
                 .search_bar()
-                .set_key_capture_widget((curr_child == "dynamic_playlists").then_some(self));
+                .set_key_capture_widget((curr_child == "dyn-playlists").then_some(self));
 
             imp.playlist_view
                 .search_bar()
@@ -1706,7 +1714,7 @@ impl EuphonicaWindow {
     }
 
     fn maybe_get_dyn_playlist_editor(&self) -> Option<DynamicPlaylistEditorView> {
-        self.is_in_view("dynamic_playlists")
+        self.is_in_view("dyn-playlists")
             .then(|| self.imp().dyn_playlist_view.maybe_get_editor())
             .flatten()
     }
@@ -1803,7 +1811,7 @@ impl EuphonicaWindow {
             .activate(move |this: &Self, _, _| this.switch_to_view("folders"))
             .build();
         let view_dyn_playlists_action = gio::ActionEntry::builder("view-dynamic-playlists")
-            .activate(move |this: &Self, _, _| this.switch_to_view("dynamic_playlists"))
+            .activate(move |this: &Self, _, _| this.switch_to_view("dyn-playlists"))
             .build();
         let view_playlists_action = gio::ActionEntry::builder("view-playlists")
             .activate(move |this: &Self, _, _| this.switch_to_view("playlists"))
@@ -1841,7 +1849,7 @@ impl EuphonicaWindow {
             view_playlists_action,
             view_queue_action,
             save_action,
-            search_current_view_action
+            search_current_view_action,
         ]);
 
         // To skip having to deal with widget focus we'll define all the actions at the app level.
@@ -2064,19 +2072,26 @@ impl EuphonicaWindow {
         self.update_background_css_classes();
     }
 
+    pub fn save_state(&self) {
+        let size = self.default_size();
+        let width = size.0;
+        let height = size.1;
+        let settings = utils::settings_manager();
+        let state = settings.child("state");
+        state
+            .set_int("last-window-width", width)
+            .expect("Unable to store last-window-width");
+        state
+            .set_int("last-window-height", height)
+            .expect("Unable to stop last-window-height");
+        if let Some(visible_child_name) = self.imp().stack.visible_child_name() {
+            let _ = state.set_enum("last-view", View::try_from(visible_child_name.as_str()).unwrap().as_idx() as i32);
+        }
+    }
+
     fn setup_signals(&self) {
         self.connect_close_request(move |window| {
-            let size = window.default_size();
-            let width = size.0;
-            let height = size.1;
-            let settings = utils::settings_manager();
-            let state = settings.child("state");
-            state
-                .set_int("last-window-width", width)
-                .expect("Unable to store last-window-width");
-            state
-                .set_int("last-window-height", height)
-                .expect("Unable to stop last-window-height");
+            window.save_state();
 
             // Stop everything
             // Tick callback for resizing detection

--- a/src/window.rs
+++ b/src/window.rs
@@ -30,7 +30,7 @@ use glib::WeakRef;
 use gtk::{
     CssProvider, cairo, gdk,
     gio::{self, SimpleActionGroup},
-    glib::{self, BoxedAnyObject, SignalHandlerId, clone, closure_local, subclass::Signal},
+    glib::{self, BoxedAnyObject, SignalHandlerId, clone, closure_local},
     graphene, gsk,
 };
 use image::{DynamicImage, imageops::FilterType};
@@ -39,7 +39,7 @@ use mpd::Subsystem;
 use std::{cell::RefCell, ops::Deref, path::PathBuf, thread, time::Duration};
 use std::{
     cell::{Cell, OnceCell},
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex},
 };
 
 use async_channel::Sender;

--- a/src/window.rs
+++ b/src/window.rs
@@ -254,10 +254,6 @@ mod imp {
         pub accent_color: RefCell<Option<RGB>>,
         pub should_populate_visible: Cell<bool>,
 
-        // Single async loop that emits "check-visible" periodically to drive
-        // visibility checks for all AlbumCell instances
-        pub check_visible_loop: RefCell<Option<glib::JoinHandle<()>>>,
-
         pub provider: CssProvider,
         pub client_state: OnceCell<ClientState>,
 
@@ -297,11 +293,6 @@ mod imp {
 
     #[glib::derived_properties]
     impl ObjectImpl for EuphonicaWindow {
-        fn signals() -> &'static [glib::subclass::Signal] {
-            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
-            SIGNALS.get_or_init(|| vec![Signal::builder("check-visible").build()])
-        }
-
         fn dispose(&self) {
             // Disconnect all signal handlers registered on global/long-lived objects
             if let Some(id) = self.settings_bg_blur_id.take() {
@@ -343,9 +334,6 @@ mod imp {
                 player.disconnect(id);
             }
 
-            // Cancel the check-visible signal loop
-            self.check_visible_loop.take();
-
             // Remove display-level CSS provider
             if let Some(display) = gdk::Display::default() {
                 let provider = &self.provider;
@@ -355,17 +343,6 @@ mod imp {
 
         fn constructed(&self) {
             self.parent_constructed();
-
-            // Spawn a single async loop that emits "check-visible" periodically.
-            // All AlbumCell instances connect to this signal for visibility checks,
-            // replacing the old per-cell tick callback approach.
-            let win = self.obj().clone();
-            *self.check_visible_loop.borrow_mut() = Some(glib::spawn_future_local(async move {
-                loop {
-                    glib::timeout_future(Duration::from_millis(1000)).await;
-                    win.emit_by_name::<()>("check-visible", &[]);
-                }
-            }));
 
             let settings = settings_manager().child("ui");
             let obj_borrow = self.obj();

--- a/src/window.rs
+++ b/src/window.rs
@@ -362,7 +362,7 @@ mod imp {
             let win = self.obj().clone();
             *self.check_visible_loop.borrow_mut() = Some(glib::spawn_future_local(async move {
                 loop {
-                    glib::timeout_future(Duration::from_millis(50)).await;
+                    glib::timeout_future(Duration::from_millis(1000)).await;
                     win.emit_by_name::<()>("check-visible", &[]);
                 }
             }));

--- a/src/window.ui
+++ b/src/window.ui
@@ -262,7 +262,7 @@
                         <child>
                           <object class="GtkStackPage">
                             <property name="title" translatable="true">Dynamic Playlists</property>
-                            <property name="name">dynamic_playlists</property>
+                            <property name="name">dyn-playlists</property>
                             <property name="child">
                               <object class="EuphonicaDynamicPlaylistView" id="dyn_playlist_view">
 															</object>


### PR DESCRIPTION
- Fixes #190 by manually calculating where to scroll to instead of grabbing focus.
- The above also fixes #334 since we no longer perform focus grabbing. Type-to-search now works consistently (at last?). Scroll handles also no longer pop in and out randomly.
- Fixes #335 by aborting async call on unbind() + guarding update_meta() calls.
- Fixes #332 by using a different return style for the do-not-retry case + adding a "Search for lyrics" button in the popover to allow manual re-fetching.
- Fixes #312 (task count now consistently decremented using an RAII guard).
- Vastly improves the viz-check algorithm for album/artist cell texture loading: now using signals (`GtkObject::map` & `unmap`) instead of background polling, no more bounding box intersection checks, way more robust, etc. 
- Resolves #75.
- Resolves #289 by implementing selectable startup view & restore-last-view function (on by default).