### PR TITLE
Add a fallback for when the MPD backend has stickers disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It exists to sate my need for something that's got the bling and the features to
 - Fetch album arts, artist avatars and synced song lyrics from external sources (currently supports Last.fm, MusicBrainz and LRCLIB).
 - myMPD-compatible stickers handling (now with new album stickers standard).
 - Integrated MPRIS client with background run supported. The background instance can be reopened via your shell's MPRIS applet, the "Background applications" section in GNOME's quick settings shade (if installed via Flatpak) or simply by launching Euphonica again.
-- Rate albums (requires MPD 0.24+) and individual songs.
+- Rate albums (requires MPD 0.24+, and stickers enabled in MPD config) and individual songs.
 - Audio quality indicators (lossy, lossless, hi-res, DSD) for individual songs as well as albums & detailed format printout.
 - Asynchronous search for large collections. The app as a whole should work with any library size (tested with up to 30K songs).
 - Configurable multi-artist tag syntax, works with anything you throw at it.

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -690,9 +690,13 @@ impl Library {
             album_model.remove_all();
             let albumartist_model = self.imp().albumartists.clone();
             albumartist_model.remove_all();
+            // Sticker types used for ratings ("filter"/"album") require MPD 0.24+ with the
+            // sticker DB enabled. Only request them when supported, else the whole fetch fails.
+            let fetch_stickers = self.client().get_client_state().stickers_support_level()
+                >= StickersSupportLevel::All;
             let (albums, artists) = self
                 .client()
-                .get_albums_and_albumartists_by_query(Query::new(), true)
+                .get_albums_and_albumartists_by_query(Query::new(), fetch_stickers)
                 .await?;
             album_model.extend_from_slice(&albums);
             albumartist_model.extend_from_slice(&artists);


### PR DESCRIPTION
Currently, if the MPD server doesn't have a `sticker_file` set in the config, the album view and album artist view display a blank page. This is because we unconditionally ask MPD for sticker info and it returns UnknownCmd, which causes the fetch to fail. This PR adds a one-line check to disable fetching sticker info if the MPD server doesn't have stickers enabled.

I also added a note in the readme that ratings require stickers to be enabled in MPD.