### PR TITLE
Show playlist images in sidebar + hotfix song-level stickers not loading

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -964,7 +964,10 @@ impl Connection {
                     }
                     Task::GetCommonStickers(typ, uri, resp) => {
                         self.respond_with_client(
-                            |c| c.get_stickers(typ, &uri, Stickers::COMMON_NAMES).map(Stickers::from_mpd_kv),
+                            |c| {
+                                // FIXME: currently cannot scope down, will just filter post-hoc
+                                c.stickers(typ, &uri).map(Stickers::from_mpd_kv)
+                            },
                             resp,
                         )
                     }

--- a/src/gtk/sidebar-button.ui
+++ b/src/gtk/sidebar-button.ui
@@ -8,10 +8,7 @@
 			<object class="GtkBox">
 				<property name="spacing">12</property>
 				<child>
-					<object class="GtkBox" id="prefix_box">
-					<property name="halign">3</property>
-					<property name="valign">3</property>
-				</object>
+					<object class="GtkBox" id="prefix_box"></object>
 				</child>
 				<child>
 					<object class="GtkLabel" id="label_widget">

--- a/src/gtk/sidebar-button.ui
+++ b/src/gtk/sidebar-button.ui
@@ -8,7 +8,10 @@
 			<object class="GtkBox">
 				<property name="spacing">12</property>
 				<child>
-					<object class="GtkImage" id="icon_widget"></object>
+					<object class="GtkBox" id="prefix_box">
+					<property name="halign">3</property>
+					<property name="valign">3</property>
+				</object>
 				</child>
 				<child>
 					<object class="GtkLabel" id="label_widget">

--- a/src/gtk/sidebar.ui
+++ b/src/gtk/sidebar.ui
@@ -14,6 +14,11 @@
 						<child>
 							<object class="EuphonicaSidebarButton" id="recent_btn">
 								<property name="label" translatable="true">Recent</property>
+								<property name="prefix-child">
+									<object class="GtkImage">
+										<property name="icon-name">recent-symbolic</property>
+									</object>
+								</property>
 							</object>
 						</child>
 						<child>
@@ -23,18 +28,34 @@
 							<object class="EuphonicaSidebarButton" id="albums_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Albums</property>
+								<property name="prefix-child">
+									<object class="GtkImage">
+										<property name="icon-name">library-music-symbolic</property>
+									</object>
+								</property>
 							</object>
 						</child>
 						<child>
 							<object class="EuphonicaSidebarButton" id="artists_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Artists</property>
+								<property name="prefix-child">
+									<object class="GtkImage">
+										<property name="icon-name">music-artist-symbolic</property>
+									</object>
+								</property>
 							</object>
 						</child>
 						<child>
 							<object class="EuphonicaSidebarButton" id="folders_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Folders</property>
+								<property name="prefix-child">
+									<object class="GtkImage">
+										<property name="icon-name">folder-symbolic</property>
+									</object>
+								</property>
+
 							</object>
 						</child>
 
@@ -52,6 +73,11 @@
 									<object class="EuphonicaSidebarButton" id="dyn_playlists_btn">
 										<property name="group">recent_btn</property>
 										<property name="label" translatable="true">Dynamic Playlists</property>
+										<property name="prefix-child">
+											<object class="GtkImage">
+												<property name="icon-name">playlist-symbolic</property>
+											</object>
+										</property>
 									</object>
 								</child>
 
@@ -79,6 +105,11 @@
 									<object class="EuphonicaSidebarButton" id="playlists_btn">
 										<property name="group">recent_btn</property>
 										<property name="label" translatable="true">Saved Playlists</property>
+										<property name="prefix-child">
+											<object class="GtkImage">
+												<property name="icon-name">playlist-symbolic</property>
+											</object>
+										</property>
 									</object>
 								</child>
 

--- a/src/gtk/sidebar.ui
+++ b/src/gtk/sidebar.ui
@@ -14,7 +14,6 @@
 						<child>
 							<object class="EuphonicaSidebarButton" id="recent_btn">
 								<property name="label" translatable="true">Recent</property>
-								<property name="icon_name">recent-symbolic</property>
 							</object>
 						</child>
 						<child>
@@ -24,21 +23,18 @@
 							<object class="EuphonicaSidebarButton" id="albums_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Albums</property>
-								<property name="icon_name">library-music-symbolic</property>
 							</object>
 						</child>
 						<child>
 							<object class="EuphonicaSidebarButton" id="artists_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Artists</property>
-								<property name="icon_name">music-artist-symbolic</property>
 							</object>
 						</child>
 						<child>
 							<object class="EuphonicaSidebarButton" id="folders_btn">
 								<property name="group">recent_btn</property>
 								<property name="label" translatable="true">Folders</property>
-								<property name="icon_name">folder-symbolic</property>
 							</object>
 						</child>
 
@@ -56,7 +52,6 @@
 									<object class="EuphonicaSidebarButton" id="dyn_playlists_btn">
 										<property name="group">recent_btn</property>
 										<property name="label" translatable="true">Dynamic Playlists</property>
-										<property name="icon_name">playlist-symbolic</property>
 									</object>
 								</child>
 
@@ -84,7 +79,6 @@
 									<object class="EuphonicaSidebarButton" id="playlists_btn">
 										<property name="group">recent_btn</property>
 										<property name="label" translatable="true">Saved Playlists</property>
-										<property name="icon_name">playlist-symbolic</property>
 									</object>
 								</child>
 

--- a/src/sidebar/button.rs
+++ b/src/sidebar/button.rs
@@ -1,5 +1,5 @@
 use glib::{Object, Properties};
-use gtk::{CompositeTemplate, Image, Label, glib, prelude::*, subclass::prelude::*};
+use gtk::{CompositeTemplate, Label, glib, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 
 mod imp {
@@ -12,11 +12,9 @@ mod imp {
         #[template_child]
         pub label_widget: TemplateChild<Label>,
         #[template_child]
-        pub icon_widget: TemplateChild<Image>,
+        pub prefix_box: TemplateChild<gtk::Box>,
         #[property(get, set)]
         pub label: RefCell<String>,
-        #[property(get, set)]
-        pub icon_name: RefCell<String>,
     }
 
     #[glib::object_subclass]
@@ -45,10 +43,6 @@ mod imp {
             obj.bind_property("label", &obj.imp().label_widget.get(), "label")
                 .sync_create()
                 .build();
-
-            obj.bind_property("icon_name", &obj.imp().icon_widget.get(), "icon-name")
-                .sync_create()
-                .build();
         }
     }
 
@@ -66,10 +60,17 @@ glib::wrapper! {
 }
 
 impl SidebarButton {
-    pub fn new(label: &str, icon_name: &str) -> Self {
-        Object::builder()
-            .property("label", label)
-            .property("icon_name", icon_name)
-            .build()
+    pub fn new(label: &str) -> Self {
+        Object::builder().property("label", label).build()
+    }
+
+    /// Replace the button's prefix widget with a custom widget
+    /// (e.g. a symbolic icon, a playlist cover, or any other widget)
+    pub fn set_prefix(&self, prefix: &impl IsA<gtk::Widget>) {
+        let prefix_box = self.imp().prefix_box.get();
+        while let Some(child) = prefix_box.first_child() {
+            child.unparent();
+        }
+        prefix_box.append(prefix);
     }
 }

--- a/src/sidebar/button.rs
+++ b/src/sidebar/button.rs
@@ -3,7 +3,9 @@ use gtk::{CompositeTemplate, Label, glib, prelude::*, subclass::prelude::*};
 use std::cell::RefCell;
 
 mod imp {
-    use super::*;
+    use gtk::glib::WeakRef;
+
+use super::*;
 
     #[derive(Properties, Default, CompositeTemplate)]
     #[template(resource = "/io/github/htkhiem/Euphonica/gtk/sidebar-button.ui")]
@@ -15,6 +17,8 @@ mod imp {
         pub prefix_box: TemplateChild<gtk::Box>,
         #[property(get, set)]
         pub label: RefCell<String>,
+        #[property(get = Self::get_prefix_child, set = Self::set_prefix_child)]
+        pub prefix_child: WeakRef<gtk::Widget>
     }
 
     #[glib::object_subclass]
@@ -51,6 +55,21 @@ mod imp {
     impl ButtonImpl for SidebarButton {}
 
     impl ToggleButtonImpl for SidebarButton {}
+
+    impl SidebarButton {
+        fn set_prefix_child(&self, prefix: gtk::Widget) {
+            let prefix_box = self.prefix_box.get();
+            while let Some(child) = prefix_box.first_child() {
+                child.unparent();
+            }
+            prefix_box.append(&prefix);
+            self.prefix_child.set(Some(&prefix));
+        }
+
+        fn get_prefix_child(&self) -> Option<gtk::Widget> {
+            self.prefix_child.upgrade()
+        }
+    }
 }
 
 glib::wrapper! {
@@ -62,15 +81,5 @@ glib::wrapper! {
 impl SidebarButton {
     pub fn new(label: &str) -> Self {
         Object::builder().property("label", label).build()
-    }
-
-    /// Replace the button's prefix widget with a custom widget
-    /// (e.g. a symbolic icon, a playlist cover, or any other widget)
-    pub fn set_prefix(&self, prefix: &impl IsA<gtk::Widget>) {
-        let prefix_box = self.imp().prefix_box.get();
-        while let Some(child) = prefix_box.first_child() {
-            child.unparent();
-        }
-        prefix_box.append(prefix);
     }
 }

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -4,11 +4,53 @@ use gtk::{CompositeTemplate, glib, prelude::*};
 use std::cell::Cell;
 
 use crate::{
-    application::EuphonicaApplication, client::state::StickersSupportLevel, common::{INode, View}, utils,
+    application::EuphonicaApplication,
+    cache::Cache,
+    client::state::StickersSupportLevel,
+    common::{INode, ImageStack, View},
+    utils,
     window::EuphonicaWindow,
 };
+use std::rc::Rc;
 
 use super::SidebarButton;
+
+/// Build the 16px rounded playlist cover ImageStack used as the prefix of
+/// recent playlist buttons in the sidebar
+fn playlist_cover_prefix() -> (ImageStack, gtk::Box) {
+    let cover = ImageStack::new();
+    cover.set_size(16);
+    cover.set_is_thumbnail(true);
+    let rounded_box = gtk::Box::builder()
+        .halign(gtk::Align::Center)
+        .valign(gtk::Align::Center)
+        .overflow(gtk::Overflow::Hidden)
+        .css_classes(["border-radius-6"])
+        .build();
+    rounded_box.append(&cover);
+    (cover, rounded_box)
+}
+
+fn fetch_playlist_cover(cache: &Rc<Cache>, cover: ImageStack, name: &str, is_dynamic: bool) {
+    let name = name.to_string();
+    cover.show_spinner();
+    glib::spawn_future_local(clone!(
+        #[strong]
+        cache,
+        #[strong]
+        cover,
+        async move {
+            match cache.get_playlist_cover(name, is_dynamic, true).await {
+                Ok(Some(tex)) => cover.show(&tex),
+                Ok(None) => cover.clear(),
+                Err(e) => {
+                    dbg!(e);
+                    cover.clear();
+                }
+            }
+        }
+    ));
+}
 
 mod imp {
     use super::*;
@@ -125,6 +167,34 @@ impl Sidebar {
 
         let recent_btn = self.imp().recent_btn.get();
         recent_btn.set_active(true);
+
+        // Prefix icons for the static sidebar buttons
+        recent_btn.set_prefix(&gtk::Image::builder().icon_name("recent-symbolic").build());
+        self.imp().albums_btn.set_prefix(
+            &gtk::Image::builder()
+                .icon_name("library-music-symbolic")
+                .build(),
+        );
+        self.imp().artists_btn.set_prefix(
+            &gtk::Image::builder()
+                .icon_name("music-artist-symbolic")
+                .build(),
+        );
+        self.imp().folders_btn.set_prefix(
+            &gtk::Image::builder()
+                .icon_name("folder-symbolic")
+                .build(),
+        );
+        self.imp().playlists_btn.set_prefix(
+            &gtk::Image::builder()
+                .icon_name("playlist-symbolic")
+                .build(),
+        );
+        self.imp().dyn_playlists_btn.set_prefix(
+            &gtk::Image::builder()
+                .icon_name("playlist-symbolic")
+                .build(),
+        );
         // Hook each button to their respective views
         recent_btn.connect_toggled(clone!(
             #[weak]
@@ -168,6 +238,7 @@ impl Sidebar {
 
         let playlist_view = win.get_playlist_view();
         let playlists = library.playlists();
+        let cache = app.get_cache();
         let recent_playlists_model = gtk::SliceListModel::new(
             Some(gtk::SortListModel::new(
                 Some(playlists.clone()),
@@ -210,6 +281,8 @@ impl Sidebar {
         recent_playlists_widget.bind_model(
             Some(&recent_playlists_model),
             clone!(
+                #[strong]
+                cache,
                 #[weak]
                 stack,
                 #[weak]
@@ -219,10 +292,13 @@ impl Sidebar {
                 #[weak]
                 recent_btn,
                 #[upgrade_or]
-                SidebarButton::new("ERROR", "dot-symbolic").upcast::<gtk::Widget>(),
+                SidebarButton::new("ERROR").upcast::<gtk::Widget>(),
                 move |obj| {
                     let playlist = obj.downcast_ref::<INode>().unwrap();
-                    let btn = SidebarButton::new(playlist.get_uri(), "dot-symbolic");
+                    let btn = SidebarButton::new(playlist.get_uri());
+                    let (cover, cover_box) = playlist_cover_prefix();
+                    fetch_playlist_cover(&cache, cover, playlist.get_uri(), false);
+                    btn.set_prefix(&cover_box);
                     btn.set_group(Some(&recent_btn));
                     btn.connect_toggled(clone!(
                         #[weak]
@@ -294,6 +370,8 @@ impl Sidebar {
         recent_dyn_playlists_widget.bind_model(
             Some(&recent_dyn_playlists_model),
             clone!(
+                #[strong]
+                cache,
                 #[weak]
                 stack,
                 #[weak]
@@ -303,10 +381,13 @@ impl Sidebar {
                 #[weak]
                 recent_btn,
                 #[upgrade_or]
-                SidebarButton::new("ERROR", "dot-symbolic").upcast::<gtk::Widget>(),
+                SidebarButton::new("ERROR").upcast::<gtk::Widget>(),
                 move |obj| {
                     let playlist = obj.downcast_ref::<INode>().unwrap();
-                    let btn = SidebarButton::new(playlist.get_uri(), "dot-symbolic");
+                    let btn = SidebarButton::new(playlist.get_uri());
+                    let (cover, cover_box) = playlist_cover_prefix();
+                    fetch_playlist_cover(&cache, cover, playlist.get_uri(), true);
+                    btn.set_prefix(&cover_box);
                     btn.set_group(Some(&recent_btn));
                     btn.connect_toggled(clone!(
                         #[weak]

--- a/src/sidebar/sidebar.rs
+++ b/src/sidebar/sidebar.rs
@@ -167,34 +167,7 @@ impl Sidebar {
 
         let recent_btn = self.imp().recent_btn.get();
         recent_btn.set_active(true);
-
-        // Prefix icons for the static sidebar buttons
-        recent_btn.set_prefix(&gtk::Image::builder().icon_name("recent-symbolic").build());
-        self.imp().albums_btn.set_prefix(
-            &gtk::Image::builder()
-                .icon_name("library-music-symbolic")
-                .build(),
-        );
-        self.imp().artists_btn.set_prefix(
-            &gtk::Image::builder()
-                .icon_name("music-artist-symbolic")
-                .build(),
-        );
-        self.imp().folders_btn.set_prefix(
-            &gtk::Image::builder()
-                .icon_name("folder-symbolic")
-                .build(),
-        );
-        self.imp().playlists_btn.set_prefix(
-            &gtk::Image::builder()
-                .icon_name("playlist-symbolic")
-                .build(),
-        );
-        self.imp().dyn_playlists_btn.set_prefix(
-            &gtk::Image::builder()
-                .icon_name("playlist-symbolic")
-                .build(),
-        );
+        
         // Hook each button to their respective views
         recent_btn.connect_toggled(clone!(
             #[weak]
@@ -298,7 +271,7 @@ impl Sidebar {
                     let btn = SidebarButton::new(playlist.get_uri());
                     let (cover, cover_box) = playlist_cover_prefix();
                     fetch_playlist_cover(&cache, cover, playlist.get_uri(), false);
-                    btn.set_prefix(&cover_box);
+                    btn.set_prefix_child(cover_box);
                     btn.set_group(Some(&recent_btn));
                     btn.connect_toggled(clone!(
                         #[weak]
@@ -387,7 +360,7 @@ impl Sidebar {
                     let btn = SidebarButton::new(playlist.get_uri());
                     let (cover, cover_box) = playlist_cover_prefix();
                     fetch_playlist_cover(&cache, cover, playlist.get_uri(), true);
-                    btn.set_prefix(&cover_box);
+                    btn.set_prefix_child(cover_box);
                     btn.set_group(Some(&recent_btn));
                     btn.connect_toggled(clone!(
                         #[weak]


### PR DESCRIPTION
This makes them a bit less useless. Other players already do this too.

<img width="291" height="421" alt="image" src="https://github.com/user-attachments/assets/73350c8d-217b-4eb1-87b4-084a6e46d231" />

Also fixes #347.