### PR TITLE
More proper implementation of embedded art priority

### DIFF
--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -98,8 +98,10 @@
       <description>
         <p>New: playlist cover images are now shown in the sidebar.</p>
         <p>Change: per-track embedded art downloading is back and enabled by default but heavily optimised. A new onboarding wizard will help you pick the right mode.</p>
+        <p>Change: editing album art, artist avatars and playlist covers will now propagate to the rest of the app instantly.</p>
         <p>Fix: restore in-memory image cache codepath.</p>
         <p>Fix: song-level stickers not loading, interfering with dynamic playlists.</p>
+        <p>Fix: stickers capability degrading to songs-only in presence of albums with insufficient tagging for sticker query.</p>
       </description>
     </release>
     <release version="0.99.6-beta-1" date="2026-08-20">

--- a/data/io.github.htkhiem.Euphonica.metainfo.xml.in
+++ b/data/io.github.htkhiem.Euphonica.metainfo.xml.in
@@ -97,6 +97,7 @@
       <url type="details">https://github.com/htkhiem/euphonica/releases/tag/v0.99.7-beta</url>
       <description>
         <p>New: playlist cover images are now shown in the sidebar.</p>
+        <p>Change: per-track embedded art downloading is back and enabled by default but heavily optimised. A new onboarding wizard will help you pick the right mode.</p>
         <p>Fix: restore in-memory image cache codepath.</p>
         <p>Fix: song-level stickers not loading, interfering with dynamic playlists.</p>
       </description>

--- a/src/application.rs
+++ b/src/application.rs
@@ -219,7 +219,7 @@ mod imp {
             let player = Player::default();
             player.setup(self.obj().clone(), client.clone(), cache.clone());
             let library = Library::default();
-            library.setup(client.clone(), player.clone());
+            library.setup(client.clone(), player.clone(), cache.clone());
 
             let _ = self.cache.set(cache);
             let _ = self.library.set(library);

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -4,13 +4,13 @@
 // whether from MPD or from Last.fm.
 // - Images are stored as resized WebP files on disk.
 // - Text data is stored as BSON blobs in SQLite.
-use futures::TryFutureExt;
 extern crate bson;
 use asyncified::Asyncified;
 use gio::prelude::*;
 use gtk::{
     gdk::{self, Texture},
-    gio, glib,
+    gio,
+    glib::{self},
 };
 use image::ImageReader;
 use lru::LruCache;
@@ -20,7 +20,7 @@ use std::{fmt, fs::create_dir_all, rc::Rc, result, sync::Mutex};
 use time::OffsetDateTime;
 
 use crate::{
-    client::{Error as ClientError, MpdWrapper},
+    client::{Error as ClientError, ImageHandle, MpdWrapper},
     common::{AlbumInfo, ArtistInfo},
     meta_providers::{
         MetadataChain,
@@ -29,7 +29,7 @@ use crate::{
         utils::get_best_image,
     },
     utils::{
-        get_app_cache_path, get_image_cache_path, register_image_as_failure,
+        RegisteredImageBundle, get_app_cache_path, get_image_cache_path, register_image_as_failure,
         save_and_register_image, settings_manager,
     },
     window::EuphonicaWindow,
@@ -281,7 +281,7 @@ pub struct Cache {
     // Thread pool for parallelisable operations such as texture read from disk and resizing ops.
     pool: glib::ThreadPool,
     // Cache state object for emitting signals.
-    state: CacheState
+    state: CacheState,
 }
 
 impl fmt::Debug for Cache {
@@ -324,7 +324,7 @@ impl Cache {
                 settings_manager().child("library").uint("n-image-threads"),
             ))
             .expect("Unable to start threadpool for cache operations"),
-            state: CacheState::default()
+            state: CacheState::default(),
         };
 
         Rc::new(cache)
@@ -395,9 +395,56 @@ impl Cache {
         res
     }
 
+    #[inline]
+    async fn process_image_handle(
+        &self,
+        handle: ImageHandle,
+        register_key: String,
+        thumbnail: bool,
+    ) -> Result<gdk::Texture> {
+        let bundle = match handle {
+            ImageHandle::Registered(bundle) => bundle,
+            ImageHandle::New(bytes) => {
+                // process in threadpool
+                let bundle = self
+                    .pool
+                    .push_future(move || -> Result<RegisteredImageBundle> {
+                        Ok(save_and_register_image(
+                            image::load_from_memory(&bytes).map_err(|_| Error::UnknownFormat)?,
+                            &register_key,
+                            None,
+                        ))
+                    })
+                    .expect("maybe_register_image_handle: threadpool error")
+                    .await
+                    .expect("maybe_register_image_handle: threadpool error")?;
+                bundle
+            }
+        };
+        let tex = bundle.take_texture(thumbnail)?;
+        IMAGE_CACHE.lock().unwrap().put(
+            if thumbnail {
+                bundle.thumb.name.to_owned()
+            } else {
+                bundle.hires.name.to_owned()
+            },
+            tex.clone(),
+        );
+        Ok(tex)
+    }
+
     /// Shared cover lookup. `folder_key` is the URI used for folder-level images,
     /// `embedded_key` is the URI used for embedded (track-level) images.
     /// If `album` is provided, it is used for external metadata lookups.
+    /// Sequence:
+    /// 1. Check by folder_key in in-mem cache
+    /// 2. If folder-cover optimisation ("optim") is disabled, check by embedded_key too
+    /// 3. Check by folder_key on disk. If hits, cache by folder_key.
+    /// 4. If optim is disabled, check by embedded_key on disk too. If hits, cache by embedded_key.
+    /// 5. Try fetching cover file from MPD. If hits, cache by folder key.
+    /// 6. If optim is disabled, try fetching embedded art from MPD too. If hits, cache by embedded key.
+    /// 7. Try fetching from external sources. If hits, cacahe by folder_key regardless of optim status.
+    /// 8. If we still can't find anything then write a placeholder entry into SQLite then return None.
     #[inline]
     async fn get_cover_internal(
         self: Rc<Self>,
@@ -408,12 +455,23 @@ impl Cache {
     ) -> Result<Option<Texture>> {
         let mut failed_before = false;
 
-        // 1. Check if we have it cached locally. This is parallelisable so we'll use the threadpool.
-        // Covers are always keyed by example_uri while in cache.
-        let cache_key = embedded_key.to_owned();
+        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+
+        let folder_key_owned = folder_key.to_owned();
+        let embedded_key_owned = embedded_key.to_owned();
         match self
             .pool
-            .push_future(move || get_image_internal(&cache_key, None, thumbnail))
+            .push_future(move || {
+                // Steps 1-2
+                get_image_internal(&folder_key_owned, None, thumbnail).or_else(|err| {
+                    if !optimized_load {
+                        // Steps 3-4
+                        get_image_internal(&embedded_key_owned, None, thumbnail)
+                    } else {
+                        Err(err)
+                    }
+                })
+            })
             .expect("get_cover_internal: cache threadpool error")
             .await
             .expect("get_cover_internal: cache threadpool error")
@@ -424,45 +482,59 @@ impl Cache {
             Err(e) => return Err(e),
         }
 
-        // 2. Nope, fall back to downloading fresh
+        // Subsequent steps are only performed if the full flow hasn't failed once before
         if !failed_before {
             if settings_manager()
                 .child("client")
                 .boolean("mpd-download-album-art")
             {
-                // 2a. MPD folder-level cover
-                if let Some(bundle) = self
+                // Step 5
+                match self
                     .mpd_client
-                    .get_folder_cover(embedded_key.to_owned())
-                    .map_err(Error::Client)
-                    .await?
+                    .get_folder_cover(embedded_key.to_owned(), folder_key.to_owned())
+                    .await
                 {
-                    return Ok(bundle.take_texture(thumbnail).map(Some)?);
+                    Err(e) => {
+                        dbg!(e);
+                    }
+                    Ok(None) => {}
+                    Ok(Some(handle)) => {
+                        return self
+                            .process_image_handle(handle, folder_key.to_owned(), thumbnail)
+                            .await
+                            .map(Some);
+                    }
                 }
-                // 2b. MPD embedded cover. When caching we'll key by example_uri, or folder_uri if optimize-embedded-cover-loading is enabled.
-                if let Some(bundle) = self
-                    .mpd_client
-                    .get_embedded_cover(embedded_key.to_owned())
-                    .map_err(Error::Client)
-                    .await?
-                {
-                    return Ok(bundle.take_texture(thumbnail).map(Some)?);
+                // Step 6
+                if !optimized_load {
+                    match self
+                        .mpd_client
+                        .get_embedded_cover(embedded_key.to_owned())
+                        .await
+                    {
+                        Err(e) => {
+                            dbg!(e);
+                        }
+                        Ok(None) => {}
+                        Ok(Some(handle)) => {
+                            return self
+                                .process_image_handle(handle, embedded_key.to_owned(), thumbnail)
+                                .await
+                                .map(Some);
+                        }
+                    }
                 }
             }
 
-            // 2c. Go outside & scream
+            // Step 7: Go outside & scream
             if let Some(album) = album
                 && let Some(meta) = self.get_album_meta(&album, true, false, None).await?
             {
+                let key = folder_key.to_owned();
                 return self
                     .external
                     .call(move |_| {
-                        download_image_from_provider(
-                            &album.folder_uri,
-                            None,
-                            &meta.0.image,
-                            thumbnail,
-                        )
+                        download_image_from_provider(&key, None, &meta.0.image, thumbnail)
                     })
                     .await;
             }
@@ -735,7 +807,8 @@ impl Cache {
                 .get_album_meta(album.clone(), None, window)
                 .await
             {
-                let ts = sqlite::write_album_meta(album, &meta, None, true).map_err(Error::Sqlite)?;
+                let ts =
+                    sqlite::write_album_meta(album, &meta, None, true).map_err(Error::Sqlite)?;
                 Ok(Some((meta, ts, models::MetaSource::External)))
             } else {
                 // Push an empty AlbumMeta to block further calls for this album.
@@ -792,7 +865,7 @@ impl Cache {
         &self,
         album: &AlbumInfo,
         meta: &models::AlbumMeta,
-        update_tags: bool
+        update_tags: bool,
     ) -> Result<OffsetDateTime> {
         sqlite::write_album_meta(album, meta, None, update_tags).map_err(Error::Sqlite)
     }
@@ -965,7 +1038,7 @@ impl Cache {
         &self,
         artist: &ArtistInfo,
         meta: &models::ArtistMeta,
-        update_tags: bool
+        update_tags: bool,
     ) -> Result<OffsetDateTime> {
         sqlite::write_artist_meta(artist, meta, update_tags).map_err(Error::Sqlite)
     }
@@ -1091,7 +1164,7 @@ impl Cache {
         &self,
         song: &SongInfo,
         external: bool,
-        overwrite: bool,   // only effective when external == true
+        overwrite: bool, // only effective when external == true
         window: Option<&EuphonicaWindow>,
     ) -> Result<Option<Lyrics>> {
         let uri = song.uri.to_owned();

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -437,14 +437,15 @@ impl Cache {
     /// `embedded_key` is the URI used for embedded (track-level) images.
     /// If `album` is provided, it is used for external metadata lookups.
     /// Sequence:
-    /// 1. Check by folder_key in in-mem cache
-    /// 2. If folder-cover optimisation ("optim") is disabled, check by embedded_key too
-    /// 3. Check by folder_key on disk. If hits, cache by folder_key.
-    /// 4. If optim is disabled, check by embedded_key on disk too. If hits, cache by embedded_key.
-    /// 5. Try fetching cover file from MPD. If hits, cache by folder key.
-    /// 6. If optim is disabled, try fetching embedded art from MPD too. If hits, cache by embedded key.
-    /// 7. Try fetching from external sources. If hits, cacahe by folder_key regardless of optim status.
-    /// 8. If we still can't find anything then write a placeholder entry into SQLite then return None.
+    // 1. Check by folder_key in in-mem cache.
+    // 2. If not available, check by embedded_key too.
+    // 3. Check by folder_key on disk. If hits, cache by folder_key.
+    // 4. Check by embedded_key on disk too. If hits, cache by embedded_key.
+    // 5. Try fetching cover file from MPD. If hits, cache by folder key.
+    // 6. Try fetching embedded art from MPD too. If hits, cache by folder key **if embedded art optimisation is enabled**, else by embedded key.
+    // 7. Try fetching from external sources. If hits, cache by folder key **if embedded art optimisation is enabled**, else by embedded key.
+    // 8. If we still can't find anything then write a placeholder entry into SQLite & return None.
+
     #[inline]
     async fn get_cover_internal(
         self: Rc<Self>,
@@ -455,7 +456,9 @@ impl Cache {
     ) -> Result<Option<Texture>> {
         let mut failed_before = false;
 
-        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+        let optimized_load = settings_manager()
+            .child("library")
+            .boolean("optimize-embedded-cover-loading");
 
         let folder_key_owned = folder_key.to_owned();
         let embedded_key_owned = embedded_key.to_owned();
@@ -463,14 +466,8 @@ impl Cache {
             .pool
             .push_future(move || {
                 // Steps 1-2
-                get_image_internal(&folder_key_owned, None, thumbnail).or_else(|err| {
-                    if !optimized_load {
-                        // Steps 3-4
-                        get_image_internal(&embedded_key_owned, None, thumbnail)
-                    } else {
-                        Err(err)
-                    }
-                })
+                get_image_internal(&folder_key_owned, None, thumbnail)
+                    .or_else(|_| get_image_internal(&embedded_key_owned, None, thumbnail))
             })
             .expect("get_cover_internal: cache threadpool error")
             .await
@@ -506,22 +503,28 @@ impl Cache {
                     }
                 }
                 // Step 6
-                if !optimized_load {
-                    match self
-                        .mpd_client
-                        .get_embedded_cover(embedded_key.to_owned())
-                        .await
-                    {
-                        Err(e) => {
-                            dbg!(e);
-                        }
-                        Ok(None) => {}
-                        Ok(Some(handle)) => {
-                            return self
-                                .process_image_handle(handle, embedded_key.to_owned(), thumbnail)
-                                .await
-                                .map(Some);
-                        }
+                match self
+                    .mpd_client
+                    .get_embedded_cover(embedded_key.to_owned())
+                    .await
+                {
+                    Err(e) => {
+                        dbg!(e);
+                    }
+                    Ok(None) => {}
+                    Ok(Some(handle)) => {
+                        return self
+                            .process_image_handle(
+                                handle,
+                                if optimized_load {
+                                    folder_key.to_owned()
+                                } else {
+                                    embedded_key.to_owned()
+                                },
+                                thumbnail,
+                            )
+                            .await
+                            .map(Some);
                     }
                 }
             }
@@ -530,11 +533,21 @@ impl Cache {
             if let Some(album) = album
                 && let Some(meta) = self.get_album_meta(&album, true, false, None).await?
             {
-                let key = folder_key.to_owned();
+                let folder_key_owned = folder_key.to_owned();
+                let embedded_key_owned = embedded_key.to_owned();
                 return self
                     .external
                     .call(move |_| {
-                        download_image_from_provider(&key, None, &meta.0.image, thumbnail)
+                        download_image_from_provider(
+                            if optimized_load {
+                                &folder_key_owned
+                            } else {
+                                &embedded_key_owned
+                            },
+                            None,
+                            &meta.0.image,
+                            thumbnail,
+                        )
                     })
                     .await;
             }
@@ -548,7 +561,7 @@ impl Cache {
         &self,
         key: String,
         key_prefix: Option<&'static str>,
-        path: &str
+        path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
         // Assume ashpd always return filesystem spec
         let filepath = String::from(
@@ -573,11 +586,7 @@ impl Cache {
     /// Evict the image from cache and delete from cache folder on disk.
     /// This does not by itself yeet the image from memory (UI elements will still hold refs to it).
     /// We'll need to signal to these elements to clear themselves.
-    pub async fn clear_image(
-        &self,
-        key: String,
-        key_prefix: Option<&'static str>
-    ) -> Result<()> {
+    pub async fn clear_image(&self, key: String, key_prefix: Option<&'static str>) -> Result<()> {
         // Assume ashpd always return filesystem spec
         let cloned_key = key.clone();
         self.local
@@ -601,7 +610,9 @@ impl Cache {
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+        let optimized_load = settings_manager()
+            .child("library")
+            .boolean("optimize-embedded-cover-loading");
         let key = if optimized_load {
             &album.folder_uri
         } else {
@@ -609,13 +620,8 @@ impl Cache {
             self.clear_image(album.folder_uri.to_owned(), None).await?;
             &album.example_uri
         };
-        
-        let res = self.set_image(
-            key.to_owned(),
-            None,
-            path
-        )
-        .await;
+
+        let res = self.set_image(key.to_owned(), None, path).await;
 
         if let (Ok(texs), true) = (res.as_ref(), notify) {
             // For updates, still notify via signals to update all widgets wherever they are.
@@ -628,20 +634,19 @@ impl Cache {
 
     ///
     pub async fn clear_cover(&self, album: &AlbumInfo, notify: bool) -> Result<()> {
-        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+        let optimized_load = settings_manager()
+            .child("library")
+            .boolean("optimize-embedded-cover-loading");
         let key = if optimized_load {
             &album.folder_uri
         } else {
             &album.example_uri
         };
-        let res = self.clear_image(
-            key.to_owned(),
-            None,
-        )
-        .await;
-        
+        let res = self.clear_image(key.to_owned(), None).await;
+
         if let (Ok(_), true) = (res.as_ref(), notify) {
-            self.get_cache_state().emit_with_param("album-cover-cleared", &key);
+            self.get_cache_state()
+                .emit_with_param("album-cover-cleared", &key);
         }
 
         res
@@ -653,12 +658,7 @@ impl Cache {
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        let res = self.set_image(
-            tag.clone(),
-            Some("avatar"),
-            path
-        )
-        .await;
+        let res = self.set_image(tag.clone(), Some("avatar"), path).await;
 
         if let (Ok(texs), true) = (res.as_ref(), notify) {
             // For updates, still notify via signals to update all widgets wherever they are.
@@ -670,14 +670,11 @@ impl Cache {
     }
 
     pub async fn clear_artist_avatar(&self, tag: String, notify: bool) -> Result<()> {
-        let res = self.clear_image(
-            tag.clone(),
-            Some("avatar")
-        )
-        .await;
-        
+        let res = self.clear_image(tag.clone(), Some("avatar")).await;
+
         if let (Ok(_), true) = (res.as_ref(), notify) {
-            self.get_cache_state().emit_with_param("artist-avatar-cleared", &tag);
+            self.get_cache_state()
+                .emit_with_param("artist-avatar-cleared", &tag);
         }
 
         res
@@ -688,13 +685,11 @@ impl Cache {
         playlist_name: String,
         path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        self.set_image(playlist_name, Some("playlist"), path)
-            .await
+        self.set_image(playlist_name, Some("playlist"), path).await
     }
 
     pub async fn clear_playlist_cover(&self, playlist_name: String) -> Result<()> {
-        self.clear_image(playlist_name, Some("playlist"))
-            .await
+        self.clear_image(playlist_name, Some("playlist")).await
     }
 
     /// Function for getting & caching the latest album meta from local sources.

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -685,11 +685,25 @@ impl Cache {
         playlist_name: String,
         path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        self.set_image(playlist_name, Some("playlist"), path).await
+        let res = self.set_image(playlist_name.clone(), Some("playlist"), path).await;
+
+        if let Ok(texs) = res.as_ref() {
+            self.get_cache_state()
+                .emit_texture("playlist-cover-set", &playlist_name, &texs.0, &texs.1);
+        }
+
+        res
     }
 
     pub async fn clear_playlist_cover(&self, playlist_name: String) -> Result<()> {
-        self.clear_image(playlist_name, Some("playlist")).await
+        let res = self.clear_image(playlist_name.clone(), Some("playlist")).await;
+
+        if res.is_ok() {
+            self.get_cache_state()
+                .emit_with_param("playlist-cover-cleared", &playlist_name);
+        }
+
+        res
     }
 
     /// Function for getting & caching the latest album meta from local sources.
@@ -1144,19 +1158,25 @@ impl Cache {
         cover_action: ImageAction,
         overwrite_name: Option<String>,
     ) -> Result<()> {
-        self.local
-            .call(move |_| {
+        let new_name = dp.name.to_owned();
+        let current_cover_key = overwrite_name.clone().unwrap_or_else(|| new_name.clone());
+        let is_clear = matches!(cover_action, ImageAction::Clear);
+        let cover_action = cover_action.clone();
+        let res = self
+            .local
+            .call(move |_| -> Result<Option<(Texture, Texture)>> {
                 // If updating an existing DP, use old name first. SQLite code will migrate it for us.
                 let should_overwrite = overwrite_name.is_some();
                 let current_cover_key = overwrite_name.unwrap_or_else(|| dp.name.to_owned());
-                match cover_action {
+                let new_cover_result: Option<(Texture, Texture)> = match cover_action {
                     ImageAction::Clear => {
                         clear_image_internal(&current_cover_key, Some("dynamic_playlist"))?;
+                        None
                     }
                     ImageAction::New(path) => {
-                        set_image_internal(&current_cover_key, Some("dynamic_playlist"), &path)?;
+                        Some(set_image_internal(&current_cover_key, Some("dynamic_playlist"), &path)?)
                     }
-                    _ => {}
+                    _ => None,
                 };
 
                 sqlite::insert_dynamic_playlist(
@@ -1167,9 +1187,23 @@ impl Cache {
                         None
                     },
                 )
-                .map_err(Error::Sqlite)
+                .map_err(Error::Sqlite)?;
+
+                Ok(new_cover_result)
             })
-            .await
+            .await?;
+
+        if let Some(texs) = res {
+            // After sqlite::insert_dynamic_playlist, the cover key is always dp.name
+            // (the migration renames old_key -> new_key). Emit under the new name.
+            self.get_cache_state()
+                .emit_texture("dynamic-playlist-cover-set", &new_name, &texs.0, &texs.1);
+        } else if is_clear {
+            self.get_cache_state()
+                .emit_with_param("dynamic-playlist-cover-cleared", &current_cover_key);
+        }
+
+        Ok(())
     }
 
     pub async fn get_lyrics(

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -44,6 +44,7 @@ use super::{CacheState, sqlite};
 
 #[derive(Debug)]
 pub enum Error {
+    EmptyInput,
     Download(String),
     Io,
     NotFound,
@@ -60,6 +61,7 @@ pub enum Error {
 impl Error {
     pub fn message(&self) -> String {
         match self {
+            Self::EmptyInput => "empty input".to_owned(),
             Self::Download(msg) => msg.to_owned(),
             Self::Io => "I/O error".into(),
             Self::NotFound => "resource not found".into(),
@@ -125,6 +127,7 @@ pub enum ImageAction {
 fn set_image_internal(
     key: &str,
     key_prefix: Option<&'static str>,
+    additional_keys: Option<Vec<String>>,
     filepath: &str,
 ) -> Result<(Texture, Texture)> {
     let dyn_img = ImageReader::open(filepath)
@@ -132,7 +135,7 @@ fn set_image_internal(
         .decode()
         .map_err(|_| Error::UnknownFormat)?;
 
-    let bundle = save_and_register_image(dyn_img, key, key_prefix);
+    let bundle = save_and_register_image(dyn_img, key, key_prefix, additional_keys);
     let hires_tex = bundle.hires.take_texture()?;
     let thumb_tex = bundle.thumb.take_texture()?;
 
@@ -230,6 +233,7 @@ fn download_image_from_provider(
     prefix: Option<&'static str>,
     fallback_images: &[models::ImageMeta],
     thumbnail: bool,
+    additional_keys: Option<Vec<String>>,
 ) -> Result<Option<Texture>> {
     // Always check with our DB first as a prior call might have downloaded the
     // necessary image for us.
@@ -239,7 +243,7 @@ fn download_image_from_provider(
     } else {
         match get_best_image(fallback_images) {
             Ok(dyn_img) => {
-                let bundle = save_and_register_image(dyn_img, key, prefix);
+                let bundle = save_and_register_image(dyn_img, key, prefix, additional_keys);
                 Ok(bundle.take_texture(thumbnail).map(Some)?)
             }
             Err(e) => {
@@ -400,6 +404,7 @@ impl Cache {
         &self,
         handle: ImageHandle,
         register_key: String,
+        additional_keys: Option<Vec<String>>,
         thumbnail: bool,
     ) -> Result<gdk::Texture> {
         let bundle = match handle {
@@ -413,6 +418,7 @@ impl Cache {
                             image::load_from_memory(&bytes).map_err(|_| Error::UnknownFormat)?,
                             &register_key,
                             None,
+                            additional_keys,
                         ))
                     })
                     .expect("maybe_register_image_handle: threadpool error")
@@ -497,7 +503,7 @@ impl Cache {
                     Ok(None) => {}
                     Ok(Some(handle)) => {
                         return self
-                            .process_image_handle(handle, folder_key.to_owned(), thumbnail)
+                            .process_image_handle(handle, folder_key.to_owned(), None, thumbnail)
                             .await
                             .map(Some);
                     }
@@ -521,6 +527,7 @@ impl Cache {
                                 } else {
                                     embedded_key.to_owned()
                                 },
+                                None,
                                 thumbnail,
                             )
                             .await
@@ -547,6 +554,7 @@ impl Cache {
                             None,
                             &meta.0.image,
                             thumbnail,
+                            None,
                         )
                     })
                     .await;
@@ -561,6 +569,7 @@ impl Cache {
         &self,
         key: String,
         key_prefix: Option<&'static str>,
+        additional_keys: Option<Vec<String>>,
         path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
         // Assume ashpd always return filesystem spec
@@ -576,7 +585,8 @@ impl Cache {
         let res = self
             .local
             .call(move |_| {
-                let (hires, thumb) = set_image_internal(&cloned_key, key_prefix, &filepath)?;
+                let (hires, thumb) =
+                    set_image_internal(&cloned_key, key_prefix, additional_keys, &filepath)?;
                 Ok((hires, thumb))
             })
             .await;
@@ -598,58 +608,92 @@ impl Cache {
         Ok(())
     }
 
-    /// Sets folder cover using embedded key.
-    /// This will CLEAR any existing folder_key'd version from the cache such that the newly
-    /// user-set version can take precedence. The user-set version must use the full URI for
-    /// its key to have correct behaviour in mixed-layout libraries (i.e. setting one album's
-    /// cover art doesn't also replace the cover arts of other albums whose tracks are in the
-    /// same folder server-side).
-    pub async fn set_cover(
+    /// Sets folder cover using folder-level URI.
+    pub async fn set_folder_cover(
         &self,
-        album: &AlbumInfo,
+        folder_uri: &str,
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        let optimized_load = settings_manager()
-            .child("library")
-            .boolean("optimize-embedded-cover-loading");
-        let key = if optimized_load {
-            &album.folder_uri
-        } else {
-            // Need to clear this one out first
-            self.clear_image(album.folder_uri.to_owned(), None).await?;
-            &album.example_uri
-        };
-
-        let res = self.set_image(key.to_owned(), None, path).await;
+        let res = self
+            .set_image(folder_uri.to_owned(), None, None, path)
+            .await;
 
         if let (Ok(texs), true) = (res.as_ref(), notify) {
             // For updates, still notify via signals to update all widgets wherever they are.
             self.get_cache_state()
-                .emit_texture("album-cover-set", &key, &texs.0, &texs.1);
+                .emit_texture("album-cover-set", &folder_uri, &texs.0, &texs.1);
         }
 
         res
     }
 
-    ///
-    pub async fn clear_cover(&self, album: &AlbumInfo, notify: bool) -> Result<()> {
-        let optimized_load = settings_manager()
-            .child("library")
-            .boolean("optimize-embedded-cover-loading");
-        let key = if optimized_load {
-            &album.folder_uri
-        } else {
-            &album.example_uri
-        };
-        let res = self.clear_image(key.to_owned(), None).await;
+    /// This will CLEAR any existing folder_key'd version from the cache such that the newly
+    /// user-set version can take precedence. The same image file must be mapped to each URI
+    /// individually for correctness in  mixed-layout libraries (i.e. setting one album's
+    /// cover art doesn't also replace the cover arts of other albums whose tracks are in the
+    /// same folder server-side).
+    pub async fn set_track_cover(
+        &self,
+        apply_uris: Vec<String>,
+        path: &str,
+        notify: bool,
+    ) -> Result<(gdk::Texture, gdk::Texture)> {
+        if !apply_uris.is_empty() {
+            let folder_uri = strip_filename_linux(apply_uris[0].as_str());
+            self.clear_image(folder_uri.to_owned(), None).await?;
+            let res = self
+                .set_image(
+                    apply_uris[0].to_owned(),
+                    None,
+                    Some(
+                        apply_uris
+                            .iter()
+                            .skip(1)
+                            .map(|s| s.to_owned())
+                            .collect::<Vec<String>>(),
+                    ),
+                    path,
+                )
+                .await;
 
-        if let (Ok(_), true) = (res.as_ref(), notify) {
-            self.get_cache_state()
-                .emit_with_param("album-cover-cleared", &key);
+            if let (Ok(texs), true) = (res.as_ref(), notify) {
+                // Fire once per key
+                for uri in apply_uris {
+                    self.get_cache_state()
+                        .emit_texture("album-cover-set", &uri, &texs.0, &texs.1);
+                }
+            }
+
+            res
+        } else {
+            Err(Error::EmptyInput)
+        }
+    }
+
+    /// Clear both folder and per-track cover entries.
+    pub async fn clear_album_cover(
+        &self,
+        folder_uri: &str,
+        track_uris: Vec<String>,
+        notify: bool,
+    ) -> Result<()> {
+        if let Ok(_) = self.clear_image(folder_uri.to_owned(), None).await {
+            if notify {
+                self.get_cache_state()
+                    .emit_with_param("album-cover-cleared", &folder_uri);
+            }
         }
 
-        res
+        for uri in track_uris {
+            if let Ok(_) = self.clear_image(uri.clone(), None).await {
+                if notify {
+                    self.get_cache_state()
+                        .emit_with_param("album-cover-cleared", &uri);
+                }
+            }
+        }
+        Ok(())
     }
 
     pub async fn set_artist_avatar(
@@ -658,7 +702,9 @@ impl Cache {
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        let res = self.set_image(tag.clone(), Some("avatar"), path).await;
+        let res = self
+            .set_image(tag.clone(), Some("avatar"), None, path)
+            .await;
 
         if let (Ok(texs), true) = (res.as_ref(), notify) {
             // For updates, still notify via signals to update all widgets wherever they are.
@@ -685,18 +731,26 @@ impl Cache {
         playlist_name: String,
         path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        let res = self.set_image(playlist_name.clone(), Some("playlist"), path).await;
+        let res = self
+            .set_image(playlist_name.clone(), Some("playlist"), None, path)
+            .await;
 
         if let Ok(texs) = res.as_ref() {
-            self.get_cache_state()
-                .emit_texture("playlist-cover-set", &playlist_name, &texs.0, &texs.1);
+            self.get_cache_state().emit_texture(
+                "playlist-cover-set",
+                &playlist_name,
+                &texs.0,
+                &texs.1,
+            );
         }
 
         res
     }
 
     pub async fn clear_playlist_cover(&self, playlist_name: String) -> Result<()> {
-        let res = self.clear_image(playlist_name.clone(), Some("playlist")).await;
+        let res = self
+            .clear_image(playlist_name.clone(), Some("playlist"))
+            .await;
 
         if res.is_ok() {
             self.get_cache_state()
@@ -1124,6 +1178,7 @@ impl Cache {
                         Some("avatar"),
                         &meta.image,
                         thumbnail,
+                        None,
                     )
                 })
                 .await;
@@ -1173,9 +1228,12 @@ impl Cache {
                         clear_image_internal(&current_cover_key, Some("dynamic_playlist"))?;
                         None
                     }
-                    ImageAction::New(path) => {
-                        Some(set_image_internal(&current_cover_key, Some("dynamic_playlist"), &path)?)
-                    }
+                    ImageAction::New(path) => Some(set_image_internal(
+                        &current_cover_key,
+                        Some("dynamic_playlist"),
+                        None,
+                        &path,
+                    )?),
                     _ => None,
                 };
 
@@ -1196,8 +1254,12 @@ impl Cache {
         if let Some(texs) = res {
             // After sqlite::insert_dynamic_playlist, the cover key is always dp.name
             // (the migration renames old_key -> new_key). Emit under the new name.
-            self.get_cache_state()
-                .emit_texture("dynamic-playlist-cover-set", &new_name, &texs.0, &texs.1);
+            self.get_cache_state().emit_texture(
+                "dynamic-playlist-cover-set",
+                &new_name,
+                &texs.0,
+                &texs.1,
+            );
         } else if is_clear {
             self.get_cache_state()
                 .emit_with_param("dynamic-playlist-cover-cleared", &current_cover_key);

--- a/src/cache/controller.rs
+++ b/src/cache/controller.rs
@@ -548,8 +548,7 @@ impl Cache {
         &self,
         key: String,
         key_prefix: Option<&'static str>,
-        path: &str,
-        notify_signal: Option<&'static str>,
+        path: &str
     ) -> Result<(gdk::Texture, gdk::Texture)> {
         // Assume ashpd always return filesystem spec
         let filepath = String::from(
@@ -568,12 +567,6 @@ impl Cache {
                 Ok((hires, thumb))
             })
             .await;
-
-        if let (Ok(texs), Some(signal)) = (res.as_ref(), notify_signal) {
-            // For updates, still notify via signals to update all widgets wherever they are.
-            self.get_cache_state()
-                .emit_texture(signal, &key, &texs.0, &texs.1);
-        }
         res
     }
 
@@ -583,11 +576,9 @@ impl Cache {
     pub async fn clear_image(
         &self,
         key: String,
-        key_prefix: Option<&'static str>,
-        notify_signal: Option<&'static str>,
+        key_prefix: Option<&'static str>
     ) -> Result<()> {
         // Assume ashpd always return filesystem spec
-        let state = self.get_cache_state();
         let cloned_key = key.clone();
         self.local
             .call(move |_| {
@@ -595,43 +586,65 @@ impl Cache {
                 Ok::<(), Error>(())
             })
             .await?;
-        // For updates, still notify via signals to update all widgets wherever they are.
-        if let Some(signal) = notify_signal {
-            state.emit_with_param(signal, &key);
-        }
         Ok(())
     }
 
+    /// Sets folder cover using embedded key.
+    /// This will CLEAR any existing folder_key'd version from the cache such that the newly
+    /// user-set version can take precedence. The user-set version must use the full URI for
+    /// its key to have correct behaviour in mixed-layout libraries (i.e. setting one album's
+    /// cover art doesn't also replace the cover arts of other albums whose tracks are in the
+    /// same folder server-side).
     pub async fn set_cover(
         &self,
-        folder_uri: String,
+        album: &AlbumInfo,
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        self.set_image(
-            folder_uri,
+        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+        let key = if optimized_load {
+            &album.folder_uri
+        } else {
+            // Need to clear this one out first
+            self.clear_image(album.folder_uri.to_owned(), None).await?;
+            &album.example_uri
+        };
+        
+        let res = self.set_image(
+            key.to_owned(),
             None,
-            path,
-            if notify {
-                Some("folder-cover-set")
-            } else {
-                None
-            },
+            path
         )
-        .await
+        .await;
+
+        if let (Ok(texs), true) = (res.as_ref(), notify) {
+            // For updates, still notify via signals to update all widgets wherever they are.
+            self.get_cache_state()
+                .emit_texture("album-cover-set", &key, &texs.0, &texs.1);
+        }
+
+        res
     }
 
-    pub async fn clear_cover(&self, folder_uri: String, notify: bool) -> Result<()> {
-        self.clear_image(
-            folder_uri,
+    ///
+    pub async fn clear_cover(&self, album: &AlbumInfo, notify: bool) -> Result<()> {
+        let optimized_load = settings_manager().child("library").boolean("optimize-embedded-cover-loading");
+        let key = if optimized_load {
+            &album.folder_uri
+        } else {
+            &album.example_uri
+        };
+        let res = self.clear_image(
+            key.to_owned(),
             None,
-            if notify {
-                Some("folder-cover-cleared")
-            } else {
-                None
-            },
         )
-        .await
+        .await;
+        
+        if let (Ok(_), true) = (res.as_ref(), notify) {
+            self.get_cache_state().emit_with_param("album-cover-cleared", &key);
+        }
+
+        res
     }
 
     pub async fn set_artist_avatar(
@@ -640,30 +653,34 @@ impl Cache {
         path: &str,
         notify: bool,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        self.set_image(
-            tag,
+        let res = self.set_image(
+            tag.clone(),
             Some("avatar"),
-            path,
-            if notify {
-                Some("artist-avatar-set")
-            } else {
-                None
-            },
+            path
         )
-        .await
+        .await;
+
+        if let (Ok(texs), true) = (res.as_ref(), notify) {
+            // For updates, still notify via signals to update all widgets wherever they are.
+            self.get_cache_state()
+                .emit_texture("artist-avatar-set", &tag, &texs.0, &texs.1);
+        }
+
+        res
     }
 
     pub async fn clear_artist_avatar(&self, tag: String, notify: bool) -> Result<()> {
-        self.clear_image(
-            tag,
-            Some("avatar"),
-            if notify {
-                Some("artist-avatar-cleared")
-            } else {
-                None
-            },
+        let res = self.clear_image(
+            tag.clone(),
+            Some("avatar")
         )
-        .await
+        .await;
+        
+        if let (Ok(_), true) = (res.as_ref(), notify) {
+            self.get_cache_state().emit_with_param("artist-avatar-cleared", &tag);
+        }
+
+        res
     }
 
     pub async fn set_playlist_cover(
@@ -671,12 +688,12 @@ impl Cache {
         playlist_name: String,
         path: &str,
     ) -> Result<(gdk::Texture, gdk::Texture)> {
-        self.set_image(playlist_name, Some("playlist"), path, None)
+        self.set_image(playlist_name, Some("playlist"), path)
             .await
     }
 
     pub async fn clear_playlist_cover(&self, playlist_name: String) -> Result<()> {
-        self.clear_image(playlist_name, Some("playlist"), None)
+        self.clear_image(playlist_name, Some("playlist"))
             .await
     }
 

--- a/src/cache/sqlite.rs
+++ b/src/cache/sqlite.rs
@@ -1205,8 +1205,8 @@ pub fn insert_dynamic_playlist(
             && let Err(db_err) = tx.execute(
                 "update images set key = ?1 where key = ?2",
                 params![
-                    &format!("dynamic_playlist:{to_overwrite}"),
                     &format!("dynamic_playlist:{}", dp.name),
+                    &format!("dynamic_playlist:{to_overwrite}"),
                 ],
             )
         {

--- a/src/cache/state.rs
+++ b/src/cache/state.rs
@@ -46,19 +46,30 @@ mod imp {
                             String::static_type(), // Artist name (may be part of a tag)
                         ])
                         .build(),
-                    // Signal::builder("playlist-cover-downloaded")
-                    //     .param_types([
-                    //         String::static_type(), // playlist name
-                    //         bool::static_type(),   // is_thumbnail
-                    //         gdk::Texture::static_type()
-                    //     ])
-                    //     .build(),
-                    // Signal::builder("playlist-cover-cleared")
-                    //     .param_types([
-                    //         String::static_type(), // playlist name
-                    //     ])
-                    //     .build(),
-                    // Dynamic playlists are local & changes would require refreshing the outer list anyway.
+                    Signal::builder("playlist-cover-set")
+                        .param_types([
+                            String::static_type(), // playlist name
+                            gdk::Texture::static_type(), // handle to hires texture
+                            gdk::Texture::static_type(), // handle to thumbnail texture
+                        ])
+                        .build(),
+                    Signal::builder("dynamic-playlist-cover-set")
+                        .param_types([
+                            String::static_type(), // dynamic playlist name
+                            gdk::Texture::static_type(), // handle to hires texture
+                            gdk::Texture::static_type(), // handle to thumbnail texture
+                        ])
+                        .build(),
+                    Signal::builder("playlist-cover-cleared")
+                        .param_types([
+                            String::static_type(), // playlist name
+                        ])
+                        .build(),
+                    Signal::builder("dynamic-playlist-cover-cleared")
+                        .param_types([
+                            String::static_type(), // dynamic playlist name
+                        ])
+                        .build(),
                 ]
             })
         }

--- a/src/cache/state.rs
+++ b/src/cache/state.rs
@@ -22,14 +22,14 @@ mod imp {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
                 vec![
-                    Signal::builder("folder-cover-set")
+                    Signal::builder("album-cover-set")
                         .param_types([
-                            String::static_type(),       // folder URI
+                            String::static_type(),       // URI
                             gdk::Texture::static_type(), // handle to hires texture
                             gdk::Texture::static_type(), // handle to thumbnail texture
                         ])
                         .build(),
-                    Signal::builder("folder-cover-cleared")
+                    Signal::builder("album-cover-cleared")
                         .param_types([
                             String::static_type(), // folder URI
                         ])

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -29,7 +29,7 @@ use crate::{
         inode::INodeInfo,
     },
     player::PlaybackFlow,
-    utils::{self, settings_manager},
+    utils,
 };
 
 use super::StickerSetMode;
@@ -174,7 +174,7 @@ pub type Responder<T> = OneShotSender<Result<T>>;
 /// thread & avoid blocking this one.
 pub enum ImageHandle {
     Registered(utils::RegisteredImageBundle),
-    New(Vec<u8>, String), // bytes and key to register as
+    New(Vec<u8>), // image bytes in some format
 }
 
 /// The successor to BackgroundTask.
@@ -340,6 +340,8 @@ pub enum Task {
     GetEmbeddedCover(
         /// URI to song file
         String,
+        /// Cache key to check before requesting. If None, will use the above URI.
+        Option<String>,
         /// Full paths to high-resolution and low-resolution file, respectively
         Responder<Option<ImageHandle>>,
     ),
@@ -348,6 +350,8 @@ pub enum Task {
     GetFolderCover(
         /// URI to folder with trailing slash
         String,
+        /// Cache key to check before requesting. If null, will use the above URI.
+        Option<String>,
         /// Full paths to high-resolution and low-resolution file, respectively
         Responder<Option<ImageHandle>>,
     ),
@@ -646,7 +650,7 @@ impl Connection {
             self.respond_with_client(
                 |c| {
                     match download_func(c, &example_uri) {
-                        Ok(bytes) => Ok(Some(ImageHandle::New(bytes, key.to_owned()))),
+                        Ok(bytes) => Ok(Some(ImageHandle::New(bytes))),
                         Err(MpdError::Proto(ProtoError::NotPair)) => {
                             // Empty output. Treat as not available.
                             Ok(None)
@@ -1114,26 +1118,19 @@ impl Connection {
                         self.respond_with_client(|c| c.changesposid(since, window), resp)
                     }
                     Task::UpdateDb(resp) => self.respond_with_client(|c| c.update(), resp),
-                    Task::GetEmbeddedCover(uri, resp) => {
-                        // Assume the URI is track-level.
-                        let settings = settings_manager().child("library");
-                        let key: Option<String> = if settings.boolean("optimize-embedded-cover-loading") {
-                            Some(utils::strip_filename_linux(&uri).to_owned())
-                        } else {
-                            None
-                        };
+                    Task::GetEmbeddedCover(uri, cache_key, resp) => {
                         self.maybe_download_image(
                             uri,
                             |client, uri| client.readpicture(uri),
-                            key,
+                            cache_key,
                             resp,
                         )
                     }
-                    Task::GetFolderCover(example_uri, resp) => {
+                    Task::GetFolderCover(example_uri, cache_key, resp) => {
                         self.maybe_download_image(
                         example_uri,
                         |client, uri| client.albumart(uri),
-                        None,  // Always store by example_uri
+                        cache_key,  // Always store by example_uri
                         resp,
                     )},
                     Task::List(term, query, groupby, resp) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,6 +12,7 @@ pub use wrapper::MpdWrapper;
 
 pub use connection::Error;
 pub use connection::Result;
+pub use connection::ImageHandle;
 
 #[derive(Debug, Clone, Copy)]
 pub enum StickerSetMode {

--- a/src/client/state.rs
+++ b/src/client/state.rs
@@ -120,9 +120,7 @@ impl ClientState {
             self.imp().has_pending.set(false);
             self.notify("has-pending");
         } else {
-            // Only start showing the popover when there are more than 3 queued tasks,
-            // else the thing will look strobey.
-            let new = total >= 3;
+            let new = total > 1;
             self.imp().has_pending.set(new);
             if old != new {
                 self.notify("has-pending");

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -340,7 +340,7 @@ impl MpdWrapper {
 
         // Figure out stickers support early as we need to decide whether we should show the Dynamic Playlists page.
         // Set to maximum supported level first by MPD version.
-        if version.1 < 24 {
+        if version.0 < 1 && version.1 < 24 {
             self.state
                 .set_stickers_support_level(StickersSupportLevel::SongsOnly);
         } else {
@@ -433,10 +433,12 @@ impl MpdWrapper {
                     self.state
                         .set_stickers_support_level(StickersSupportLevel::Disabled);
                 }
-                MpdErrorCode::Argument => {
-                    self.state
-                        .set_stickers_support_level(StickersSupportLevel::SongsOnly);
-                }
+                // FIXME: this interferes with album queries that don't have enough tags.
+                // MpdErrorCode::Argument => {
+                //     dbg!(e);
+                //     self.state
+                //         .set_stickers_support_level(StickersSupportLevel::SongsOnly);
+                // }
                 _ => {}
             }
         }

--- a/src/client/wrapper.rs
+++ b/src/client/wrapper.rs
@@ -3,7 +3,7 @@ use asyncified::Asyncified;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use futures::executor;
-use glib::{ThreadPool, clone};
+use glib::clone;
 use gtk::gio::prelude::*;
 use gtk::{gio, glib};
 use itertools::Itertools;
@@ -114,7 +114,6 @@ pub struct MpdWrapper {
     _fg_handle: thread::JoinHandle<bool>,
     _bg_handle: thread::JoinHandle<bool>,
     // For heavy but parallelisable local tasks.
-    pool: ThreadPool,
     state: ClientState,
     fg_sender: Sender<Task>, // For sending tasks to the interactive client
     bg_sender: Sender<Task>, // For sending tasks to the background client
@@ -148,10 +147,6 @@ impl MpdWrapper {
                     .run()
                     .is_err()
             }),
-            pool: ThreadPool::shared(Some(
-                settings_manager().child("library").uint("n-image-threads"),
-            ))
-            .expect("Unable to start MpdWrapper threadpool"),
             state: ClientState::default(),
             fg_sender,
             bg_sender,
@@ -385,10 +380,7 @@ impl MpdWrapper {
     ) -> ClientResult<T> {
         // Decrement when this function returns OR when the future is dropped
         // (aborted by a view navigating away), exactly once in both cases.
-        let _guard = TaskGuard {
-            state: self.state.clone(),
-            bg: false,
-        };
+        let _guard = TaskGuard::new(self.state.clone(), false);
         self.fg_sender.send(task).await.expect("Broken FG sender");
         self.handle_error(receiver.await.expect("Broken oneshot receiver"))
             .await
@@ -401,10 +393,7 @@ impl MpdWrapper {
     ) -> ClientResult<T> {
         // Decrement when this function returns OR when the future is dropped
         // (aborted by a view navigating away), exactly once in both cases.
-        let _guard = TaskGuard {
-            state: self.state.clone(),
-            bg: true,
-        };
+        let _guard = TaskGuard::new(self.state.clone(), true);
         self.bg_sender.send(task).await.expect("Broken BG sender");
         // Wake background thread
         let (s, r) = oneshot::channel();
@@ -911,71 +900,23 @@ impl MpdWrapper {
     pub async fn get_embedded_cover(
         &self,
         uri: String,
-    ) -> ClientResult<Option<utils::RegisteredImageBundle>> {
+    ) -> ClientResult<Option<ImageHandle>> {
         // Leave downloading to the background connection thread, but local operations
         // (resizing, transcoding, writing to disk) will be done with a threadpool, whose
         // handle is held by the this thread (the main one).
         let (s, r) = oneshot::channel();
-        match self.background(Task::GetEmbeddedCover(uri, s), r).await {
-            Err(e) => Err(e),
-            Ok(None) => Ok(None),
-            Ok(Some(handle)) => {
-                match handle {
-                    ImageHandle::Registered(bundle) => Ok(Some(bundle)),
-                    ImageHandle::New(bytes, key) => {
-                        // process in threadpool
-                        self.pool
-                            .push_future(move || {
-                                Ok(utils::save_and_register_image(
-                                    image::load_from_memory(&bytes)?,
-                                    &key,
-                                    None,
-                                ))
-                            })
-                            .expect("get_embedded_cover: threadpool error")
-                            .await
-                            .expect("get_embedded_cover: threadpool error")
-                            .map_err(ClientError::Image)
-                            .map(Some)
-                    }
-                }
-            }
-        }
+        self.background(Task::GetEmbeddedCover(uri, None, s), r).await
     }
 
     pub async fn get_folder_cover(
         &self,
         example_uri: String,
-    ) -> ClientResult<Option<utils::RegisteredImageBundle>> {
+        folder_uri: String,
+    ) -> ClientResult<Option<ImageHandle>> {
         let (s, r) = oneshot::channel();
-        match self
-            .background(Task::GetFolderCover(example_uri, s), r)
+        self
+            .background(Task::GetFolderCover(example_uri, Some(folder_uri), s), r)
             .await
-        {
-            Err(e) => Err(e),
-            Ok(None) => Ok(None),
-            Ok(Some(handle)) => {
-                match handle {
-                    ImageHandle::Registered(bundle) => Ok(Some(bundle)),
-                    ImageHandle::New(bytes, key) => {
-                        // process in threadpool
-                        self.pool
-                            .push_future(move || {
-                                Ok(utils::save_and_register_image(
-                                    image::load_from_memory(&bytes)?,
-                                    &key,
-                                    None,
-                                ))
-                            })
-                            .expect("get_folder_cover: threadpool error")
-                            .await
-                            .expect("get_folder_cover: threadpool error")
-                            .map_err(ClientError::Image)
-                            .map(Some)
-                    }
-                }
-            }
-        }
     }
 
     /// Fetch albums and albumartists together for efficiency.

--- a/src/common/song_row.rs
+++ b/src/common/song_row.rs
@@ -243,21 +243,20 @@ impl SongRow {
             let _ = res.imp().cache.set(cache);
             let _ = res.imp().thumbnail_signal_ids.replace(Some((
                 cache_state.connect_closure(
-                    "folder-cover-set",
+                    "album-cover-set",
                     false,
                     closure_local!(
                         #[weak]
                         res,
                         move |_: CacheState, uri: String, _: gdk::Texture, thumb: gdk::Texture| {
                             // This signal is only emitted when an album cover is set manually.
-                            // This only affects folder-level arts, so only use them when we currently
-                            // don't have any art.
+                            // The URI can be folder-level or track-level depending on the embedded art optimisation setting.
                             if res.imp().thumbnail.get_state() == ImageState::Empty
                                 && res
                                     .imp()
                                     .song
                                     .upgrade()
-                                    .is_some_and(|s| s.get_folder_uri() == uri)
+                                    .is_some_and(|s| s.get_folder_uri() == uri || s.get_uri() == uri)
                             {
                                 res.imp().thumbnail.show(&thumb);
                             }
@@ -265,7 +264,7 @@ impl SongRow {
                     ),
                 ),
                 cache_state.connect_closure(
-                    "folder-cover-cleared",
+                    "album-cover-cleared",
                     false,
                     closure_local!(
                         #[weak]
@@ -275,7 +274,7 @@ impl SongRow {
                                 .imp()
                                 .song
                                 .upgrade()
-                                .is_some_and(|s| s.get_folder_uri() == uri)
+                                .is_some_and(|s| s.get_folder_uri() == uri || s.get_uri() == uri)
                             {
                                 res.imp().thumbnail.clear();
                             }

--- a/src/gtk/onboarding-window.ui
+++ b/src/gtk/onboarding-window.ui
@@ -38,6 +38,17 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="true">This helps Euphonica determine the most efficient way to load album arts.</property>
+                        <property name="wrap">true</property>
+                        <property name="justify">center</property>
+                        <property name="margin-top">6</property>
+                        <!-- <style>
+                          <class name="body"/>
+                        </style> -->
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkImage" id="library_mode_illustration">
                         <property name="pixel-size">256</property>
                         <style>
@@ -53,8 +64,8 @@
                         </style>
                         <child>
                           <object class="AdwActionRow">
-                            <property name="title" translatable="true">One album/release per folder</property>
-                            <property name="subtitle" translatable="true">All tracks within the same folder use the same cover art. This is either a dedicated &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; file, or the first embedded art found.</property>
+                            <property name="title" translatable="true">Each album/release has its own folder</property>
+                            <!-- <property name="subtitle" translatable="true">All tracks within the same folder use the same cover art. This is either a dedicated &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; file, or the first embedded art found.</property> -->
                             <child type="prefix">
                               <object class="GtkCheckButton" id="release_folder_library_mode">
                                 <property name="active">true</property>
@@ -64,8 +75,8 @@
                         </child>
                         <child>
                           <object class="AdwActionRow">
-                            <property name="title" translatable="true">Some or all folders are mixed</property>
-                            <property name="subtitle" translatable="true">Embedded art will be downloaded per-track, but &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; files still take priority. For folders that are indeed single-release, these files help prevent duplicate downloads. For other folders, clear them out to force fallback to per-track embedded art.</property>
+                            <property name="title" translatable="true">Other/mixed</property>
+                            <!-- <property name="subtitle" translatable="true">Embedded art will be downloaded per-track, but &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; files still take priority. For folders that are indeed single-release, these files help prevent duplicate downloads. For other folders, clear them out to force fallback to per-track embedded art.</property> -->
                             <child type="prefix">
                               <object class="GtkCheckButton" id="mixed_library_mode">
                                 <property name="group">release_folder_library_mode</property>

--- a/src/gtk/onboarding-window.ui
+++ b/src/gtk/onboarding-window.ui
@@ -54,7 +54,7 @@
                         <child>
                           <object class="AdwActionRow">
                             <property name="title" translatable="true">One album/release per folder</property>
-                            <property name="subtitle" translatable="true">Optimise resource usage by loading only one representative cover art per folder. This is either a dedicated &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; file, or the first embedded art found.</property>
+                            <property name="subtitle" translatable="true">All tracks within the same folder use the same cover art. This is either a dedicated &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; file, or the first embedded art found.</property>
                             <child type="prefix">
                               <object class="GtkCheckButton" id="release_folder_library_mode">
                                 <property name="active">true</property>
@@ -64,8 +64,8 @@
                         </child>
                         <child>
                           <object class="AdwActionRow">
-                            <property name="title" translatable="true">Mixed</property>
-                            <property name="subtitle" translatable="true">Prioritise per-track embedded art for correctness. Might load the same cover art multiple times if every track contains embedded art.</property>
+                            <property name="title" translatable="true">Some or all folders are mixed</property>
+                            <property name="subtitle" translatable="true">Embedded art will be downloaded per-track, but &lt;tt&gt;cover.{png,webp,jpg}&lt;/tt&gt; files still take priority. For folders that are indeed single-release, these files help prevent duplicate downloads. For other folders, clear them out to force fallback to per-track embedded art.</property>
                             <child type="prefix">
                               <object class="GtkCheckButton" id="mixed_library_mode">
                                 <property name="group">release_folder_library_mode</property>

--- a/src/library/album_cell.rs
+++ b/src/library/album_cell.rs
@@ -321,7 +321,7 @@ impl AlbumCell {
         res.add_controller(hover_ctl);
         let _ = res.imp().cover_signal_ids.replace(Some((
             cache_state.connect_closure(
-                "folder-cover-set",
+                "album-cover-set",
                 false,
                 closure_local!(
                     #[weak(rename_to = this)]
@@ -331,7 +331,7 @@ impl AlbumCell {
                             .imp()
                             .album
                             .upgrade()
-                            .is_some_and(|a| a.get_folder_uri() == uri)
+                            .is_some_and(|a| a.get_folder_uri() == uri || a.get_example_uri() == uri)
                         {
                             this.imp().cover.show(&thumb);
                         }
@@ -339,7 +339,7 @@ impl AlbumCell {
                 ),
             ),
             cache_state.connect_closure(
-                "folder-cover-cleared",
+                "album-cover-cleared",
                 false,
                 closure_local!(
                     #[weak(rename_to = this)]
@@ -349,7 +349,7 @@ impl AlbumCell {
                             .imp()
                             .album
                             .upgrade()
-                            .is_some_and(|a| a.get_folder_uri() == uri)
+                            .is_some_and(|a| a.get_folder_uri() == uri || a.get_example_uri() == uri)
                         {
                             this.imp().cover.clear();
                         }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -475,7 +475,7 @@ mod imp {
                                 if let (Some(album), Some(cache)) =
                                     (obj.imp().album.borrow().as_ref(), obj.imp().cache.get())
                                     && let Err(e) = cache
-                                        .clear_cover(album.get_folder_uri().to_owned(), true)
+                                        .clear_cover(album.get_info(), true)
                                         .await
                                 {
                                     obj.show_cache_error("Couldn't clear cover", e);
@@ -913,7 +913,7 @@ impl AlbumContentView {
     pub async fn set_cover(&self, path: &str) {
         if let (Some(album), Some(cache)) = (self.album(), self.imp().cache.get())
             && let Err(e) = cache
-                .set_cover(album.get_example_uri().to_owned(), path, true)
+                .set_cover(album.get_info(), path, true)
                 .await
         {
             self.show_cache_error("Couldn't set cover", e);
@@ -1114,7 +1114,7 @@ impl AlbumContentView {
             // Remove existing entry in SQLite, which might be an empty "do not retry" placeholder.
             if overwrite {
                 // Don't notify, else we'd interrupt the spinner
-                if let Err(e) = cache.clear_cover(info.example_uri.to_owned(), false).await {
+                if let Err(e) = cache.clear_cover(info, false).await {
                     self.show_cache_error("Couldn't clear cover", e);
                 }
             }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -913,7 +913,7 @@ impl AlbumContentView {
     pub async fn set_cover(&self, path: &str) {
         if let (Some(album), Some(cache)) = (self.album(), self.imp().cache.get())
             && let Err(e) = cache
-                .set_cover(album.get_folder_uri().to_owned(), path, true)
+                .set_cover(album.get_example_uri().to_owned(), path, true)
                 .await
         {
             self.show_cache_error("Couldn't set cover", e);
@@ -949,13 +949,13 @@ impl AlbumContentView {
         self.imp()
             .cover_set_id
             .replace(Some(cache_state.connect_closure(
-                "folder-cover-set",
+                "album-cover-set",
                 false,
                 closure_local!(
                     #[weak(rename_to = this)]
                     self,
                     move |_: CacheState, uri: String, hires: gdk::Texture, _: gdk::Texture| {
-                        if this.album().is_some_and(|a| a.get_folder_uri() == uri) {
+                        if this.album().is_some_and(|a| a.get_example_uri() == uri || a.get_folder_uri() == uri) {
                             this.update_cover(hires);
                         }
                     }
@@ -964,13 +964,13 @@ impl AlbumContentView {
         self.imp()
             .cover_cleared_id
             .replace(Some(cache_state.connect_closure(
-                "folder-cover-cleared",
+                "album-cover-cleared",
                 false,
                 closure_local!(
                     #[weak(rename_to = this)]
                     self,
                     move |_: CacheState, uri: String| {
-                        if this.album().is_some_and(|a| a.get_folder_uri() == uri) {
+                        if this.album().is_some_and(|a| a.get_example_uri() == uri || a.get_folder_uri() == uri) {
                             this.clear_cover();
                         }
                     }
@@ -1114,7 +1114,7 @@ impl AlbumContentView {
             // Remove existing entry in SQLite, which might be an empty "do not retry" placeholder.
             if overwrite {
                 // Don't notify, else we'd interrupt the spinner
-                if let Err(e) = cache.clear_cover(info.folder_uri.to_owned(), false).await {
+                if let Err(e) = cache.clear_cover(info.example_uri.to_owned(), false).await {
                     self.show_cache_error("Couldn't clear cover", e);
                 }
             }

--- a/src/library/album_content_view.rs
+++ b/src/library/album_content_view.rs
@@ -474,11 +474,13 @@ mod imp {
                             async move {
                                 if let (Some(album), Some(cache)) =
                                     (obj.imp().album.borrow().as_ref(), obj.imp().cache.get())
-                                    && let Err(e) = cache
-                                        .clear_cover(album.get_info(), true)
-                                        .await
                                 {
-                                    obj.show_cache_error("Couldn't clear cover", e);
+                                    // Always clear both regardless of optimisation enablement
+                                    if let Err(e) =
+                                        cache.clear_album_cover(album.get_folder_uri(), obj.uris(), true).await
+                                    {
+                                        obj.show_cache_error("Couldn't clear cover", e);
+                                    }
                                 }
                             }
                         ));
@@ -909,14 +911,35 @@ impl AlbumContentView {
         }
     }
 
+    fn uris(&self) -> Vec<String> {
+        let song_list = &self.imp().song_list;
+        let mut res = Vec::with_capacity(song_list.n_items() as usize);
+        for elem in song_list.iter::<Song>() {
+            if let Ok(song) = elem {
+                res.push(song.get_uri().to_owned());
+            } else {
+                break; // mutated during scan - just set covers for what we have
+            }
+        }
+        res
+    }
+
     /// Set a user-selected path as the new local cover.
     pub async fn set_cover(&self, path: &str) {
-        if let (Some(album), Some(cache)) = (self.album(), self.imp().cache.get())
-            && let Err(e) = cache
-                .set_cover(album.get_info(), path, true)
-                .await
-        {
-            self.show_cache_error("Couldn't set cover", e);
+        if let (Some(album), Some(cache)) = (self.album(), self.imp().cache.get()) {
+            if settings_manager()
+                .child("library")
+                .boolean("optimize-embedded-cover-loading")
+            {
+                if let Err(e) = cache.set_folder_cover(album.get_folder_uri(), path, true).await {
+                    self.show_cache_error("Couldn't set cover", e);
+                }
+            } else {
+                eprintln!("Setting album art per track");
+                if let Err(e) = cache.set_track_cover(self.uris(), path, true).await {
+                    self.show_cache_error("Couldn't set cover", e);
+                }
+            }
         }
     }
 
@@ -955,7 +978,9 @@ impl AlbumContentView {
                     #[weak(rename_to = this)]
                     self,
                     move |_: CacheState, uri: String, hires: gdk::Texture, _: gdk::Texture| {
-                        if this.album().is_some_and(|a| a.get_example_uri() == uri || a.get_folder_uri() == uri) {
+                        if this.album().is_some_and(|a| {
+                            a.get_example_uri() == uri || a.get_folder_uri() == uri
+                        }) {
                             this.update_cover(hires);
                         }
                     }
@@ -970,7 +995,9 @@ impl AlbumContentView {
                     #[weak(rename_to = this)]
                     self,
                     move |_: CacheState, uri: String| {
-                        if this.album().is_some_and(|a| a.get_example_uri() == uri || a.get_folder_uri() == uri) {
+                        if this.album().is_some_and(|a| {
+                            a.get_example_uri() == uri || a.get_folder_uri() == uri
+                        }) {
                             this.clear_cover();
                         }
                     }
@@ -1114,7 +1141,7 @@ impl AlbumContentView {
             // Remove existing entry in SQLite, which might be an empty "do not retry" placeholder.
             if overwrite {
                 // Don't notify, else we'd interrupt the spinner
-                if let Err(e) = cache.clear_cover(info, false).await {
+                if let Err(e) = cache.clear_album_cover(&info.folder_uri, self.uris(), false).await {
                     self.show_cache_error("Couldn't clear cover", e);
                 }
             }
@@ -1286,7 +1313,7 @@ impl AlbumContentView {
         if let Some(handle) = self.imp().update_meta_handle.take() {
             handle.abort();
         }
-        
+
         for binding in self.imp().bindings.take().into_iter() {
             binding.unbind();
         }

--- a/src/library/artist_cell.rs
+++ b/src/library/artist_cell.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use crate::{
-    cache::{Cache, placeholders::EMPTY_ARTIST_STRING},
+    cache::{Cache, CacheState, placeholders::EMPTY_ARTIST_STRING},
     common::{Artist, TEXTURE_LOAD_DELAY_MS},
     utils::settings_manager,
 };
@@ -52,6 +52,8 @@ mod imp {
         // in quick succession (such as the case described in the comment block above all this mess,
         // or during fast scrolling).
         pub texture_load_handle: RefCell<Option<glib::JoinHandle<()>>>,
+        pub cover_signal_ids: RefCell<Option<(glib::SignalHandlerId, glib::SignalHandlerId, glib::SignalHandlerId, glib::SignalHandlerId)>>,
+        pub cache_state: WeakRef<CacheState>,
     }
 
     // The central trait for subclassing a GObject
@@ -75,6 +77,14 @@ mod imp {
         fn dispose(&self) {
             while let Some(child) = self.obj().first_child() {
                 child.unparent();
+            }
+            if let Some((avatar_set_id, avatar_cleared_id, cover_set_id, cover_cleared_id)) = self.cover_signal_ids.take()
+                && let Some(state) = self.cache_state.upgrade()
+            {
+                state.disconnect(avatar_set_id);
+                state.disconnect(avatar_cleared_id);
+                state.disconnect(cover_set_id);
+                state.disconnect(cover_cleared_id);
             }
         }
 
@@ -132,6 +142,7 @@ impl ArtistCell {
         cache: Rc<Cache>,
     ) -> Self {
         let res: Self = Object::builder().build();
+        let cache_state = cache.get_cache_state();
         res.imp()
             .cache
             .set(cache)
@@ -162,6 +173,81 @@ impl ArtistCell {
         res.connect_unmap(|res| {
             res.unload_textures(!res.imp().hires.get());
         });
+
+        // Update avatar and album covers live when set/cleared.
+        let state = cache_state;
+        let (avatar_set_id, avatar_cleared_id, cover_set_id, cover_cleared_id) = (
+            state.connect_closure(
+                "artist-avatar-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    res,
+                    move |_: CacheState, name: String, hires: gdk::Texture, thumb: gdk::Texture| {
+                        let use_hires = this.imp().hires.get();
+                        if this.artist().is_some_and(|a| a.get_info().name == name) {
+                            this.imp().avatar.set_custom_image(Some(if use_hires { &hires } else { &thumb }));
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "artist-avatar-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    res,
+                    move |_: CacheState, name: String| {
+                        if this.artist().is_some_and(|a| a.get_info().name == name) {
+                            this.imp().avatar.set_custom_image(Option::<&gdk::Texture>::None);
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "album-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    res,
+                    move |_: CacheState, uri: String, hires: gdk::Texture, thumb: gdk::Texture| {
+                        let use_hires = this.imp().hires.get();
+                        if this.artist().is_some_and(|a| {
+                            !a.get_info().example_uris.is_empty()
+                        }) {
+                            let cover_fan = this.imp().covers.get();
+                            for (i, example_uri) in this.artist().unwrap().get_info().example_uris.iter().take(3).enumerate() {
+                                if *example_uri == uri {
+                                    cover_fan.set_cover(i as u8, if use_hires { &hires } else { &thumb });
+                                }
+                            }
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "album-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    res,
+                    move |_: CacheState, uri: String| {
+                        if this.artist().is_some_and(|a| {
+                            !a.get_info().example_uris.is_empty()
+                        }) {
+                            let cover_fan = this.imp().covers.get();
+                            for (i, example_uri) in this.artist().unwrap().get_info().example_uris.iter().take(3).enumerate() {
+                                if *example_uri == uri {
+                                    cover_fan.clear_cover(i as u8, this.imp().hires.get());
+                                }
+                            }
+                        }
+                    }
+                ),
+            ),
+        );
+        let _ = res.imp().cache_state.set(Some(&state));
+        let _ = res.imp().cover_signal_ids.replace(Some((avatar_set_id, avatar_cleared_id, cover_set_id, cover_cleared_id)));
 
         res
     }

--- a/src/library/controller.rs
+++ b/src/library/controller.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cache::{Cache, sqlite},
+    cache::{Cache, CacheState, sqlite},
     client::{
         Error as ClientError, MpdWrapper, Result as ClientResult, StickerSetMode,
         state::StickersSupportLevel,
@@ -11,8 +11,7 @@ use crate::{
 };
 use chrono::Local;
 use derivative::Derivative;
-use glib::subclass::Signal;
-use gtk::{gio, glib, prelude::*};
+use gtk::{gdk, gio, glib::{self, SignalHandlerId, WeakRef, closure_local, subclass::Signal}, prelude::*};
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use std::{borrow::Cow, cell::OnceCell, rc::Rc, sync::OnceLock, vec::Vec};
@@ -29,7 +28,6 @@ use adw::subclass::prelude::*;
 use mpd::{EditAction, Query, SaveMode, Term, search::Operation as QueryOperation};
 
 mod imp {
-
     use super::*;
 
     #[derive(Debug, Derivative)]
@@ -72,8 +70,10 @@ mod imp {
         #[derivative(Default(value = "gio::ListStore::new::<INode>()"))]
         pub folder_inodes: gio::ListStore,
         pub folder_inodes_initialized: Cell<bool>,
+        pub playlist_cover_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
+        pub dyn_playlist_cover_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
 
-        pub cache: OnceCell<Rc<Cache>>,
+        pub cache_state: WeakRef<CacheState>,
         pub player: OnceCell<Player>,
     }
 
@@ -88,6 +88,18 @@ mod imp {
     }
 
     impl ObjectImpl for Library {
+        fn dispose(&self) {
+            if let (Some(state), Some((set_id, cleared_id)), Some((dyn_set_id, dyn_cleared_id))) = (
+                self.cache_state.upgrade(),
+                self.playlist_cover_ids.take(),
+                self.dyn_playlist_cover_ids.take(),
+            ) {
+                state.disconnect(set_id);
+                state.disconnect(cleared_id);
+                state.disconnect(dyn_set_id);
+                state.disconnect(dyn_cleared_id);
+            }
+        }
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
                 vec![
@@ -137,9 +149,68 @@ impl Default for Library {
 }
 
 impl Library {
-    pub fn setup(&self, client: Rc<MpdWrapper>, player: Player) {
+    pub fn setup(&self, client: Rc<MpdWrapper>, player: Player, cache: Rc<Cache>) {
         let _ = self.imp().client.set(client);
         let _ = self.imp().player.set(player);
+
+        let state = cache.get_cache_state();
+        let _ = self.imp().playlist_cover_ids.replace(Some((
+            state.connect_closure(
+                "playlist-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, _: String, _: gdk::Texture, _: gdk::Texture| {
+                        glib::spawn_future_local(async move {
+                            this.init_playlists(true).await;
+                        });
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "playlist-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, _: String| {
+                        glib::spawn_future_local(async move {
+                            this.init_playlists(true).await;
+                        });
+                    }
+                ),
+            ),
+        )));
+        let _ = self.imp().dyn_playlist_cover_ids.replace(Some((
+            state.connect_closure(
+                "dynamic-playlist-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, _: String, _: gdk::Texture, _: gdk::Texture| {
+                        glib::spawn_future_local(async move {
+                            this.init_dyn_playlists(true).await;
+                        });
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "dynamic-playlist-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, _: String| {
+                        glib::spawn_future_local(async move {
+                            this.init_dyn_playlists(true).await;
+                        });
+                    }
+                ),
+            ),
+        )));
+        let _ = self.imp().cache_state.set(Some(&state));
     }
 
     pub fn clear(&self) {

--- a/src/library/dynamic_playlist_content_view.rs
+++ b/src/library/dynamic_playlist_content_view.rs
@@ -1,6 +1,6 @@
 use super::{DynamicPlaylistView, Library};
 use crate::{
-    cache::{Cache, sqlite},
+    cache::{Cache, CacheState, sqlite},
     common::{
         ContentStack, ContentView, DynamicPlaylist, INodeType, ImageStack, Song, SongRow,
         dynamic_playlist::AutoRefresh, inode::INodeInfo,
@@ -15,7 +15,7 @@ use derivative::Derivative;
 use gio::{ActionEntry, SimpleActionGroup};
 use glib::WeakRef;
 use glib::{clone, closure_local};
-use gtk::{CompositeTemplate, ListItem, SignalListItemFactory, gio, glib};
+use gtk::{CompositeTemplate, ListItem, SignalListItemFactory, gdk, gio, glib};
 use std::{
     cell::{OnceCell, RefCell},
     rc::Rc,
@@ -73,6 +73,7 @@ mod imp {
         pub outer: WeakRef<DynamicPlaylistView>,
         pub window: WeakRef<EuphonicaWindow>,
         pub cache: OnceCell<Rc<Cache>>,
+        pub cover_signal_ids: RefCell<Option<(glib::SignalHandlerId, glib::SignalHandlerId)>>,
     }
 
     #[glib::object_subclass]
@@ -548,6 +549,37 @@ impl DynamicPlaylistContentView {
     }
 
     pub async fn bind_by_name(&self, name: String) {
+        // Wire dynamic-playlist-cover signals for live updates.
+        let cache = self.imp().cache.get().unwrap().clone();
+        let state = cache.get_cache_state();
+        let _ = self.imp().cover_signal_ids.replace(Some((
+            state.connect_closure(
+                "dynamic-playlist-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String, tex: gdk::Texture, _: gdk::Texture| {
+                        if this.imp().dp.borrow().as_ref().is_some_and(|dp| dp.name == name) {
+                            this.imp().cover.show(&tex);
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "dynamic-playlist-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String| {
+                        if this.imp().dp.borrow().as_ref().is_some_and(|dp| dp.name == name) {
+                            this.imp().cover.clear();
+                        }
+                    }
+                ),
+            ),
+        )));
         self.update_cover(name.clone()).await;
         match gio::spawn_blocking(move || sqlite::get_dynamic_playlist_info(&name))
             .await
@@ -595,6 +627,13 @@ impl DynamicPlaylistContentView {
     }
 
     pub fn unbind(&self) {
+        if let Some((set_id, cleared_id)) = self.imp().cover_signal_ids.take()
+            && let Some(cache) = self.imp().cache.get()
+        {
+            let state = cache.get_cache_state();
+            state.disconnect(set_id);
+            state.disconnect(cleared_id);
+        }
         self.imp().song_list.remove_all();
         self.imp().title.set_label("");
         self.imp().dp.take();

--- a/src/library/playlist_content_view.rs
+++ b/src/library/playlist_content_view.rs
@@ -15,7 +15,7 @@ use std::{
 
 use super::Library;
 use crate::{
-    cache::Cache,
+    cache::{Cache, CacheState},
     client::Error as ClientError,
     common::{ContentStack, INode, ImageStack, RowAddButtons, RowEditButtons, Song, SongRow},
     utils::{format_secs_as_duration, tokio_runtime},
@@ -194,7 +194,7 @@ mod imp {
 
         pub playlist: RefCell<Option<INode>>,
         pub bindings: RefCell<Vec<Binding>>,
-        pub cover_signal_id: RefCell<Option<SignalHandlerId>>,
+        pub cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
         pub cache: OnceCell<Rc<Cache>>,
         #[derivative(Default(value = "Cell::new(true)"))]
         pub selecting_all: Cell<bool>, // Enables queuing the entire playlist efficiently
@@ -1041,6 +1041,38 @@ impl PlaylistContentView {
         // Save binding
         bindings.push(last_mod_binding);
 
+        // Playlist cover updates (necessary?)
+        let cache = self.imp().cache.get().unwrap().clone();
+        let state = cache.get_cache_state();
+        let _ = self.imp().cover_signal_ids.replace(Some((
+            state.connect_closure(
+                "playlist-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String, tex: gdk::Texture, _: gdk::Texture| {
+                        if this.imp().playlist.borrow().as_ref().map_or(false, |p| p.get_uri() == name) {
+                            this.update_cover(&tex);
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "playlist-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String| {
+                        if this.imp().playlist.borrow().as_ref().map_or(false, |p| p.get_uri() == name) {
+                            this.clear_cover();
+                        }
+                    }
+                ),
+            ),
+        )));
+
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -1109,10 +1141,12 @@ impl PlaylistContentView {
         for binding in self.imp().bindings.borrow_mut().drain(..) {
             binding.unbind();
         }
-        if let Some(id) = self.imp().cover_signal_id.take()
+        if let Some((set_id, cleared_id)) = self.imp().cover_signal_ids.take()
             && let Some(cache) = self.imp().cache.get()
         {
-            cache.get_cache_state().disconnect(id);
+            let state = cache.get_cache_state();
+            state.disconnect(set_id);
+            state.disconnect(cleared_id);
         }
         if clear_contents {
             self.imp().song_list.remove_all();

--- a/src/library/playlist_row.rs
+++ b/src/library/playlist_row.rs
@@ -1,5 +1,5 @@
 use glib::{Object, ParamSpec, ParamSpecString, clone};
-use gtk::{CompositeTemplate, gdk, glib, prelude::*, subclass::prelude::*};
+use gtk::{CompositeTemplate, glib, prelude::*, subclass::prelude::*};
 use once_cell::sync::Lazy;
 use std::{
     cell::{Cell, OnceCell, RefCell},

--- a/src/library/playlist_row.rs
+++ b/src/library/playlist_row.rs
@@ -1,5 +1,5 @@
-use glib::{Object, ParamSpec, ParamSpecString, clone};
-use gtk::{CompositeTemplate, glib, prelude::*, subclass::prelude::*};
+use glib::{Object, ParamSpec, ParamSpecString, clone, closure_local};
+use gtk::{CompositeTemplate, gdk, glib, prelude::*, subclass::prelude::*};
 use once_cell::sync::Lazy;
 use std::{
     cell::{Cell, OnceCell, RefCell},
@@ -7,14 +7,16 @@ use std::{
 };
 
 use crate::{
-    cache::{Cache, placeholders::ALBUMART_THUMBNAIL_PLACEHOLDER},
+    cache::{Cache, CacheState, placeholders::ALBUMART_THUMBNAIL_PLACEHOLDER},
     common::INode,
 };
 
 use super::Library;
 
 mod imp {
-    use super::*;
+    use gtk::glib::WeakRef;
+
+use super::*;
 
     #[derive(Default, CompositeTemplate)]
     #[template(resource = "/io/github/htkhiem/Euphonica/gtk/library/playlist-row.ui")]
@@ -37,6 +39,8 @@ mod imp {
         pub playlist: RefCell<Option<INode>>,
         pub is_dynamic: Cell<bool>,
         pub cache: OnceCell<Rc<Cache>>,
+        pub cover_signal_ids: RefCell<Option<(glib::SignalHandlerId, glib::SignalHandlerId)>>,
+        pub cache_state: WeakRef<CacheState>,
     }
 
     // The central trait for subclassing a GObject
@@ -196,6 +200,41 @@ impl PlaylistRow {
         // Bind album art listener. Set once first (like sync_create)
         self.imp().playlist.replace(Some(playlist.clone()));
         self.clear_thumbnail();
+        // Wire playlist-cover signals for live thumbnail updates.
+        let is_dynamic = self.imp().is_dynamic.get();
+        let set_signal = if is_dynamic { "dynamic-playlist-cover-set" } else { "playlist-cover-set" };
+        let cleared_signal = if is_dynamic { "dynamic-playlist-cover-cleared" } else { "playlist-cover-cleared" };
+        let cache = self.imp().cache.get().unwrap().clone();
+        let state = cache.get_cache_state();
+        let _ = self.imp().cache_state.set(Some(&state));
+        let _ = self.imp().cover_signal_ids.replace(Some((
+            state.connect_closure(
+                set_signal,
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String, tex: gdk::Texture, _: gdk::Texture| {
+                        if this.uri().is_some_and(|u| u == name) {
+                            this.imp().thumbnail.set_paintable(Some(&tex));
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                cleared_signal,
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, name: String| {
+                        if this.uri().is_some_and(|u| u == name) {
+                            this.clear_thumbnail();
+                        }
+                    }
+                ),
+            ),
+        )));
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -233,6 +272,12 @@ impl PlaylistRow {
     }
 
     pub fn unbind(&self) {
+        if let Some((set_id, cleared_id)) = self.imp().cover_signal_ids.take()
+            && let Some(state) = self.imp().cache_state.upgrade()
+        {
+            state.disconnect(set_id);
+            state.disconnect(cleared_id);
+        }
         if let Some(_) = self.imp().playlist.take() {
             self.clear_thumbnail();
         }

--- a/src/library/playlist_row.rs
+++ b/src/library/playlist_row.rs
@@ -1,4 +1,4 @@
-use glib::{Object, ParamSpec, ParamSpecString, clone, closure_local};
+use glib::{Object, ParamSpec, ParamSpecString, clone};
 use gtk::{CompositeTemplate, gdk, glib, prelude::*, subclass::prelude::*};
 use once_cell::sync::Lazy;
 use std::{
@@ -7,16 +7,14 @@ use std::{
 };
 
 use crate::{
-    cache::{Cache, CacheState, placeholders::ALBUMART_THUMBNAIL_PLACEHOLDER},
+    cache::{Cache, placeholders::ALBUMART_THUMBNAIL_PLACEHOLDER},
     common::INode,
 };
 
 use super::Library;
 
 mod imp {
-    use gtk::glib::WeakRef;
-
-use super::*;
+    use super::*;
 
     #[derive(Default, CompositeTemplate)]
     #[template(resource = "/io/github/htkhiem/Euphonica/gtk/library/playlist-row.ui")]
@@ -38,9 +36,7 @@ use super::*;
         pub library: OnceCell<Library>,
         pub playlist: RefCell<Option<INode>>,
         pub is_dynamic: Cell<bool>,
-        pub cache: OnceCell<Rc<Cache>>,
-        pub cover_signal_ids: RefCell<Option<(glib::SignalHandlerId, glib::SignalHandlerId)>>,
-        pub cache_state: WeakRef<CacheState>,
+        pub cache: OnceCell<Rc<Cache>>
     }
 
     // The central trait for subclassing a GObject
@@ -200,41 +196,6 @@ impl PlaylistRow {
         // Bind album art listener. Set once first (like sync_create)
         self.imp().playlist.replace(Some(playlist.clone()));
         self.clear_thumbnail();
-        // Wire playlist-cover signals for live thumbnail updates.
-        let is_dynamic = self.imp().is_dynamic.get();
-        let set_signal = if is_dynamic { "dynamic-playlist-cover-set" } else { "playlist-cover-set" };
-        let cleared_signal = if is_dynamic { "dynamic-playlist-cover-cleared" } else { "playlist-cover-cleared" };
-        let cache = self.imp().cache.get().unwrap().clone();
-        let state = cache.get_cache_state();
-        let _ = self.imp().cache_state.set(Some(&state));
-        let _ = self.imp().cover_signal_ids.replace(Some((
-            state.connect_closure(
-                set_signal,
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |_: CacheState, name: String, tex: gdk::Texture, _: gdk::Texture| {
-                        if this.uri().is_some_and(|u| u == name) {
-                            this.imp().thumbnail.set_paintable(Some(&tex));
-                        }
-                    }
-                ),
-            ),
-            state.connect_closure(
-                cleared_signal,
-                false,
-                closure_local!(
-                    #[weak(rename_to = this)]
-                    self,
-                    move |_: CacheState, name: String| {
-                        if this.uri().is_some_and(|u| u == name) {
-                            this.clear_thumbnail();
-                        }
-                    }
-                ),
-            ),
-        )));
         glib::spawn_future_local(clone!(
             #[weak(rename_to = this)]
             self,
@@ -272,12 +233,6 @@ impl PlaylistRow {
     }
 
     pub fn unbind(&self) {
-        if let Some((set_id, cleared_id)) = self.imp().cover_signal_ids.take()
-            && let Some(state) = self.imp().cache_state.upgrade()
-        {
-            state.disconnect(set_id);
-            state.disconnect(cleared_id);
-        }
         if let Some(_) = self.imp().playlist.take() {
             self.clear_thumbnail();
         }

--- a/src/onboarding/window.rs
+++ b/src/onboarding/window.rs
@@ -20,37 +20,17 @@
 
 use crate::{
     application::EuphonicaApplication,
-    client::{ClientState, ConnectionState, Result as ClientResult},
-    common::{Album, Artist, INode, ThemeSelector, View, paintables::FadePaintable},
-    library::{
-        AlbumView, ArtistContentView, ArtistView, DynamicPlaylistEditorView, DynamicPlaylistView,
-        FolderView, PlaylistView, RecentView,
-    },
-    player::{Player, PlayerBar, QueueView},
-    sidebar::Sidebar,
-    utils::{self, LazyInit, SearchableView, settings_manager},
+    utils::settings_manager,
 };
-use adw::{ColorScheme, StyleManager, prelude::*, subclass::prelude::*};
-use auto_palette::{ImageData, Palette, color::RGB};
+use adw::{prelude::*, subclass::prelude::*};
 use glib::WeakRef;
 use gtk::{
-    CssProvider, cairo, gdk,
-    gio::{self, SimpleActionGroup},
-    glib::{self, BoxedAnyObject, SignalHandlerId, clone, closure_local},
-    graphene, gsk,
+    gio::{self},
+    glib::{self, clone},
 };
-use image::{DynamicImage, imageops::FilterType};
-use libblur::{FastBlurChannels, ThreadingPolicy, stack_blur};
-use mpd::Subsystem;
-use std::{cell::RefCell, ops::Deref, path::PathBuf, thread, time::Duration};
-use std::{
-    cell::{Cell, OnceCell},
-    sync::{Arc, Mutex},
-};
+use std::cell::Cell;
 
-use async_channel::Sender;
 use glib::Properties;
-use image::ImageReader as Reader;
 
 mod imp {
     use super::*;

--- a/src/player/bar.rs
+++ b/src/player/bar.rs
@@ -1,17 +1,18 @@
 use glib::{SignalHandlerId, WeakRef, clone, closure_local};
 use gtk::{
-    CompositeTemplate,
+    CompositeTemplate, gdk,
     glib::{self, Properties, subclass::Signal},
     prelude::*,
     subclass::prelude::*,
 };
+use rusqlite::fallible_streaming_iterator::FallibleStreamingIterator;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::OnceLock;
 
 use crate::{
     cache::{
-        Cache,
+        Cache, CacheState,
         placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
     },
     common::{ImageStack, Marquee, Song},
@@ -65,6 +66,8 @@ mod imp {
 
         pub player: WeakRef<Player>,
         pub cover_changed_id: RefCell<Option<SignalHandlerId>>,
+        pub album_cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
+        pub cache_state: WeakRef<CacheState>,
         #[property(get, set)]
         pub layout: Cell<u32>, // 0: micro, 1: mini, 2: full. TODO: turn into enum.
     }
@@ -128,7 +131,7 @@ mod imp {
                     Some(
                         match layout {
                             0 => 12,
-                            _ => 0
+                            _ => 0,
                         }
                         .to_value(),
                     )
@@ -168,9 +171,16 @@ mod imp {
 
         fn dispose(&self) {
             if let Some(player) = self.player.upgrade()
-                && let Some(id) = self.cover_changed_id.take() {
-                    player.disconnect(id);
-                }
+                && let Some(id) = self.cover_changed_id.take()
+            {
+                player.disconnect(id);
+            }
+            if let Some((set_id, cleared_id)) = self.album_cover_signal_ids.take()
+                && let Some(state) = self.cache_state.upgrade()
+            {
+                state.disconnect(set_id);
+                state.disconnect(cleared_id);
+            }
         }
     }
 
@@ -274,6 +284,54 @@ impl PlayerBar {
                     }
                 ),
             )));
+
+        // Update album art live when the current song's cover is set/cleared.
+        let state = cache.get_cache_state();
+        let (set_id, cleared_id) = (
+            state.connect_closure(
+                "album-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, uri: String, _: gdk::Texture, thumb: gdk::Texture| {
+                        if this
+                            .imp()
+                            .player
+                            .upgrade()
+                            .and_then(|p| p.current_song())
+                            .map_or(false, |s| s.get_uri() == &uri || s.get_folder_uri() == &uri)
+                        {
+                            this.imp().albumart.show(&thumb);
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "album-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, uri: String| {
+                        if this
+                            .imp()
+                            .player
+                            .upgrade()
+                            .and_then(|p| p.current_song())
+                            .map_or(false, |s| s.get_uri() == &uri || s.get_folder_uri() == &uri)
+                        {
+                            this.imp().albumart.clear();
+                        }
+                    }
+                ),
+            ),
+        );
+        let _ = self.imp().cache_state.set(Some(&state));
+        let _ = self
+            .imp()
+            .album_cover_signal_ids
+            .replace(Some((set_id, cleared_id)));
     }
 
     fn update_album_art(&self, song: Option<Song>, cache: Rc<Cache>) {

--- a/src/player/pane.rs
+++ b/src/player/pane.rs
@@ -2,7 +2,7 @@ use adw::prelude::*;
 use ashpd::desktop::file_chooser::{FileFilter, SelectedFiles};
 use glib::{SignalHandlerId, WeakRef, clone, closure_local};
 use gtk::{
-    CompositeTemplate,
+    CompositeTemplate, gdk,
     glib::{self, Variant},
     subclass::prelude::*,
 };
@@ -15,12 +15,14 @@ use std::{
 
 use crate::{
     cache::{
-        Cache, placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING}
+        Cache, CacheState,
+        placeholders::{EMPTY_ALBUM_STRING, EMPTY_ARTIST_STRING},
     },
     client::{ClientState, state::StickersSupportLevel},
     common::{PictureStack, Rating, Song, paintables::RotatingPaintable},
     player::seekbar2::Seekbar,
-    utils::{self, settings_manager, sync_animation}, window::EuphonicaWindow,
+    utils::{self, settings_manager, sync_animation},
+    window::EuphonicaWindow,
 };
 
 use super::{MpdOutput, OutputControls, PlaybackControls, PlaybackState, Player, VolumeKnob};
@@ -102,6 +104,8 @@ mod imp {
         pub song_changed_id: RefCell<Option<SignalHandlerId>>,
         pub playback_state_id: RefCell<Option<SignalHandlerId>>,
         pub seeked_id: RefCell<Option<SignalHandlerId>>,
+        pub album_cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
+        pub cache_state: RefCell<Option<CacheState>>,
     }
 
     // The central trait for subclassing a GObject
@@ -248,6 +252,12 @@ mod imp {
                     player.disconnect(id);
                 }
             }
+            if let Some((set_id, cleared_id)) = self.album_cover_signal_ids.take()
+                && let Some(state) = self.cache_state.borrow().clone()
+            {
+                state.disconnect(set_id);
+                state.disconnect(cleared_id);
+            }
             self.albumart_animation.get().unwrap().reset();
         }
     }
@@ -330,7 +340,13 @@ impl PlayerPane {
         }
     }
 
-    pub fn setup(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState, win: &EuphonicaWindow) {
+    pub fn setup(
+        &self,
+        player: &Player,
+        cache: Rc<Cache>,
+        client_state: &ClientState,
+        win: &EuphonicaWindow,
+    ) {
         self.imp().player.set(Some(player));
         self.imp()
             .song_changed_id
@@ -387,7 +403,13 @@ impl PlayerPane {
         self.imp().seekbar.setup(player);
     }
 
-    fn bind_state(&self, player: &Player, cache: Rc<Cache>, client_state: &ClientState, win: &EuphonicaWindow) {
+    fn bind_state(
+        &self,
+        player: &Player,
+        cache: Rc<Cache>,
+        client_state: &ClientState,
+        win: &EuphonicaWindow,
+    ) {
         let imp = self.imp();
         self.imp().vol_knob.setup(player);
         let rg_btn = self.imp().rg_btn.get();
@@ -629,6 +651,54 @@ impl PlayerPane {
                 ),
             )));
 
+        // Update album art live when the current song's cover is set/cleared.
+        let state = cache.get_cache_state();
+        let (set_id, cleared_id) = (
+            state.connect_closure(
+                "album-cover-set",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, uri: String, hires: gdk::Texture, _: gdk::Texture| {
+                        if this
+                            .imp()
+                            .player
+                            .upgrade()
+                            .and_then(|p| p.current_song())
+                            .map_or(false, |s| s.get_uri() == &uri || s.get_folder_uri() == &uri)
+                        {
+                            this.imp().albumart.show(&hires);
+                        }
+                    }
+                ),
+            ),
+            state.connect_closure(
+                "album-cover-cleared",
+                false,
+                closure_local!(
+                    #[weak(rename_to = this)]
+                    self,
+                    move |_: CacheState, uri: String| {
+                        if this
+                            .imp()
+                            .player
+                            .upgrade()
+                            .and_then(|p| p.current_song())
+                            .map_or(false, |s| s.get_uri() == &uri || s.get_folder_uri() == &uri)
+                        {
+                            this.imp().albumart.clear();
+                        }
+                    }
+                ),
+            ),
+        );
+        let _ = self.imp().cache_state.replace(Some(state));
+        let _ = self
+            .imp()
+            .album_cover_signal_ids
+            .replace(Some((set_id, cleared_id)));
+
         imp.show_lyrics.connect_notify_local(
             Some("active"),
             clone!(
@@ -667,7 +737,9 @@ impl PlayerPane {
                 glib::spawn_future_local(async move {
                     if let Some(song) = player.current_song() {
                         btn.set_visible(false);
-                        let res = cache.get_lyrics(song.get_info(), true, true, Some(&win)).await;
+                        let res = cache
+                            .get_lyrics(song.get_info(), true, true, Some(&win))
+                            .await;
                         btn.set_visible(true);
                         match res {
                             Ok(Some(lyrics)) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -334,10 +334,19 @@ pub fn save_and_register_image(
     dyn_img: DynamicImage,
     key: &str,
     prefix: Option<&'static str>,
+    additional_keys: Option<Vec<String>>,
 ) -> RegisteredImageBundle {
     let (hires_img, thumb_img) = resize_convert_image(dyn_img);
     let hires_k = save_and_register_single_image(&hires_img, key, prefix, false);
     let thumb_k = save_and_register_single_image(&thumb_img, key, prefix, true);
+    if let Some(keys) = additional_keys {
+        for key in keys.iter() {
+            // Reuse the same two files as created above for other keys (for setting cover art at the track
+            // level for all tracks in the same release).
+            sqlite::register_image_key(key, prefix, Some(&hires_k), false).expect("Sqlite error");
+            sqlite::register_image_key(key, prefix, Some(&thumb_k), true).expect("Sqlite error");
+        }
+    }
 
     RegisteredImageBundle {
         hires: RegisteredImage {

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,6 +20,7 @@
 
 use crate::{
     application::EuphonicaApplication,
+    cache::CacheState,
     client::{ClientState, ConnectionState, Result as ClientResult},
     common::{Album, Artist, INode, ThemeSelector, View, paintables::FadePaintable},
     library::{
@@ -274,6 +275,8 @@ mod imp {
         pub client_state_idle_id: RefCell<Option<SignalHandlerId>>,
         pub client_state_conn_state_id: RefCell<Option<SignalHandlerId>>,
         pub player_cover_changed_id: RefCell<Option<SignalHandlerId>>,
+        pub cover_signal_ids: RefCell<Option<(SignalHandlerId, SignalHandlerId)>>,
+        pub cache_state: WeakRef<CacheState>,
         pub player_title_changed_id: RefCell<Option<SignalHandlerId>>,
         pub client_state_pct_fg_id: RefCell<Option<SignalHandlerId>>,
         pub client_state_pct_bg_id: RefCell<Option<SignalHandlerId>>,
@@ -333,6 +336,12 @@ mod imp {
                 && let Some(player) = self.player.upgrade()
             {
                 player.disconnect(id);
+            }
+            if let Some((set_id, cleared_id)) = self.cover_signal_ids.take()
+                && let Some(state) = self.cache_state.upgrade()
+            {
+                state.disconnect(set_id);
+                state.disconnect(cleared_id);
             }
             if let Some(id) = self.player_title_changed_id.take()
                 && let Some(player) = self.player.upgrade()
@@ -1279,6 +1288,61 @@ impl EuphonicaWindow {
             .player_bar
             .setup(app.get_player(), app.get_cache());
 
+        // Update blurred background live when the current song's album cover is set/cleared.
+        {
+            let cache = app.get_cache();
+            let state = cache.get_cache_state();
+            let (set_id, cleared_id) = (
+                state.connect_closure(
+                    "album-cover-set",
+                    false,
+                    closure_local!(
+                        #[weak(rename_to = this)]
+                        win,
+                        move |_: CacheState, uri: String, _: gdk::Texture, _: gdk::Texture| {
+                            if this
+                                .imp()
+                                .player
+                                .upgrade()
+                                .and_then(|p| p.current_song())
+                                .map_or(false, |song| {
+                                    song.get_uri() == uri || song.get_folder_uri() == uri
+                                })
+                            {
+                                this.queue_new_background();
+                            }
+                        }
+                    ),
+                ),
+                state.connect_closure(
+                    "album-cover-cleared",
+                    false,
+                    closure_local!(
+                        #[weak(rename_to = this)]
+                        win,
+                        move |_: CacheState, uri: String| {
+                            if this
+                                .imp()
+                                .player
+                                .upgrade()
+                                .and_then(|p| p.current_song())
+                                .map_or(false, |song| {
+                                    song.get_uri() == uri || song.get_folder_uri() == uri
+                                })
+                            {
+                                this.queue_new_background();
+                            }
+                        }
+                    ),
+                ),
+            );
+            let _ = win.imp().cache_state.set(Some(&state));
+            let _ = win
+                .imp()
+                .cover_signal_ids
+                .replace(Some((set_id, cleared_id)));
+        }
+
         // Now that all the components are ready, we can start handling backend state changes
         win.imp()
             .fft_data
@@ -2083,7 +2147,12 @@ impl EuphonicaWindow {
             .set_int("last-window-height", height)
             .expect("Unable to stop last-window-height");
         if let Some(visible_child_name) = self.imp().stack.visible_child_name() {
-            let _ = state.set_enum("last-view", View::try_from(visible_child_name.as_str()).unwrap().as_idx() as i32);
+            let _ = state.set_enum(
+                "last-view",
+                View::try_from(visible_child_name.as_str())
+                    .unwrap()
+                    .as_idx() as i32,
+            );
         }
     }
 


### PR DESCRIPTION
# Sequence

This is like, what, the 6th iteration of our album art loading algorithm? Hopefully the last.

1. Check by folder_key in in-mem cache.
2. If not available, check by embedded_key too.
3. Check by folder_key on disk. If hits, cache by folder_key.
4. Check by embedded_key on disk too. If hits, cache by embedded_key.
5. Try fetching cover file from MPD. If hits, cache by folder key.
6. Try fetching embedded art from MPD too. If hits, cache by folder key **if embedded art optimisation is enabled**, else by **every single URI in the album**.
7. Try fetching from external sources. If hits, cache by folder key **if embedded art optimisation is enabled**, else by **every single URI in the album**.
8. If we still can't find anything then write a placeholder entry into SQLite & return None.

When embedded-art optimisation is on, this matches the v0.99.6 behaviour of fetching just one image per folder, be it a `cover` file or a random track's embedded art. With that turned off, we STILL prefer the `cover` file, but now if one does not exist, we fetch every track's embedded art individually.

Custom album arts are keyed at the track URI level if said optimisation is disabled (just like external sources or embedded art from MPD). Assuming the library remains constant and MPD doesn't change its behaviour, then the representative track for each album (fetched with window size 1) should always be the first track, and by using its URI as the embedded key of that album, the custom arts should be persisted across boots. This allows customising album arts even in libraries that don't follow the one-release-per-folder rule.

# General guidelines

- Try to keep your last-level folders to a single "release" (album). With this, the above optimisation can be turned on without issue. This does not even require a `cover.{png,webp,jpg}` file as Euphonica will just read the embedded art of one track and use it for all other tracks too.
- In case you have some "mixed" folders, in which there are tracks from different albums, do these: 
    - Disable the above optimisation (either choose "Mixed" at the onboarding wizard's Library organisation page or go to Preferences -> Library -> disable `Optimise embedded cover loading`), and
    - DO NOT place a `cover.{png,webp,jpg}` file in those folders. Even with the optimisation disabled, Euphonica will _still_ try to opportunistically use said file (steps 1, 3 and 5 are always active in the above sequence).
    - If your library still has some single-release folders, PLACE `cover.{png,webp,jpg}` FILES IN THEM. Without the optimisation, these files are required to prevent Euphonica from downloading the same embedded art again and again for every track in the same release.

# Rationale

In case the above still sounds so stupid, pls hear me out:

- The blanket "always pick just one image per folder" trick caters to libraries that are organised into single-release folders but do NOT have separate `cover` files. Without the optimisation, every embedded art from every track would be downloaded, blowing up the cache size and RAM usage.
- Steps 1, 3 and 5 being always-on is to allow libraries that are "almost there" in terms of folder organisation to benefit from the same optimisation without forcing it on by manually providing separate `cover.{png,webp,jpg}` files for folders that are single-release, and fall back to per-track embedded art for folders that aren't. I suppose the majority of people will have libraries that fall into this category (a few "unorganised" folders). 
- For libraries that are wholly NOT organised into single-release folders and do NOT have any `cover.{png,webp,jpg}` files, steps 1, 3 and 5 do nothing on their own and disabling the optimisation enables step 6 to write at track-URI level, correctly resolving one album art for every track.
    - Downside: if tracks of an album are scattered or duplicated over multiple folders, their album arts will be downloaded once for each folder the tracks are in, thereby still resulting in duplicate downloads.

# Other changes

- Fixed a bunch of issues with DP cover saving across renames.
- Filled in a lot of missing image-changed signals and listeners, so now changing one image (cover/avatar) will correctly propagate across the app and even to the blurred background.