### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788372231,
+        "narHash": "sha256-7aqErvrAEz/5OcPA5p3M+tVOqeYc4oJXkNIPXfCqxAw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9387b3fcc0c23c86661636da63faabad4235a0a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Euphonica";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      eachLinuxSystem = nixpkgs.lib.genAttrs [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      eachDarwinSystem = nixpkgs.lib.genAttrs [ "aarch64-darwin" ];
+    in
+    {
+      packages = eachLinuxSystem (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          euphonica = pkgs.euphonica.overrideAttrs (_: {
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+            src = self;
+            cargoDeps = pkgs.rustPlatform.importCargoLock {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+          });
+        in
+        {
+          inherit euphonica;
+          default = euphonica;
+        }
+      );
+
+      devShells =
+
+        eachLinuxSystem (
+          system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+          in
+          {
+            default = pkgs.mkShell {
+              inputsFrom = [ self.packages.${system}.default ];
+            };
+          }
+        )
+        // eachDarwinSystem (
+          system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+          in
+          {
+            default = pkgs.mkShell {
+              packages = with pkgs; [
+                cargo
+                meson
+                pkg-config
+                rustc
+              ];
+            };
+          }
+        );
+    };
+}


### PR DESCRIPTION
This adds optional Nix flake support for building and developing Euphonica on Linux. Useful for anyone who uses nix (on any Linux distro)

Nix users can:
- Run `nix run github:htkhiem/euphonica` to reproducibly build and launch Euphonica from the tip of main on Linux, or use `nix run .` from a local checkout.
- `nix develop` to drop into a shell with all native and Rust build dependencies on Linux/MacOS (MacOS won't be able to compile Euphonica obviously, yet)

For incremental development on Linux:

```sh 
nix develop
meson setup build --prefix="$PWD/build/install" -Dprofile=dev
meson compile -C build
meson install -C build
build/install/bin/euphonica
```

After the initial setup, only the final three commands are needed.